### PR TITLE
Fix use of D2UIApp and init d2 in the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     },
     "dependencies": {
         "@dhis2/d2-i18n": "^1.0.3",
+        "@dhis2/d2-ui-app": "^1.0.4",
         "@dhis2/d2-ui-core": "^1.0.3",
         "@dhis2/d2-ui-file-menu": "^1.0.1",
         "autoprefixer": "7.1.6",

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,8 @@ import './App.css';
 
 export class App extends Component {
     componentDidMount() {
-        const { store, d2 } = this.context;
+        const { store } = this.context;
+        const d2 = this.props.d2;
         store.dispatch(fromActions.fromUser.acReceivedUser(d2.currentUser));
         store.dispatch(fromActions.fromDimensions.tSetDimensions());
     }
@@ -25,7 +26,7 @@ export class App extends Component {
         return {
             baseUrl: this.props.baseUrl,
             i18n,
-            d2: this.context.d2,
+            d2: this.props.d2,
         };
     }
 
@@ -63,7 +64,6 @@ const mapStateToProps = state => {
 };
 
 App.contextTypes = {
-    d2: PropTypes.object,
     store: PropTypes.object,
 };
 
@@ -71,6 +71,11 @@ App.childContextTypes = {
     d2: PropTypes.object,
     baseUrl: PropTypes.string,
     i18n: PropTypes.object,
+};
+
+App.propTypes = {
+    d2: PropTypes.object,
+    baseUrl: PropTypes.string,
 };
 
 export default connect(mapStateToProps, {

--- a/src/__tests__/App.spec.js
+++ b/src/__tests__/App.spec.js
@@ -18,6 +18,7 @@ describe('App', () => {
 
     beforeEach(() => {
         props = {
+            d2: {},
             baseUrl: undefined,
             snackbarOpen: false,
             snackbarMessage: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,15 @@
   dependencies:
     i18next "^10.3"
 
+"@dhis2/d2-ui-app@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-app/-/d2-ui-app-1.0.4.tgz#05bba43dfb1ba868f08f9c3010fbba29551f6952"
+  dependencies:
+    "@dhis2/d2-ui-core" "^1.1.4"
+    babel-runtime "^6.26.0"
+    lodash "^4.17.10"
+    material-ui "^0.20.0"
+
 "@dhis2/d2-ui-core@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-1.0.3.tgz#1c797a42f98b5e56a0df54661bf5f2fd5e909173"


### PR DESCRIPTION
- D2UIApp is only needed to set the theme for MUI v0.x required by some
components like translation and sharing dialogs.
- Since D2UIApp is not setting d2 in the context anymore, do that in the
  app instead.