### PR TITLE
Fix/empty dimensions

### DIFF
--- a/packages/app/src/__tests__/current.spec.js
+++ b/packages/app/src/__tests__/current.spec.js
@@ -32,25 +32,27 @@ const ou = {
     items: [{ id: ouItem1Id }],
 };
 
+const emptyId = 'empty';
+
 const ui = {
     layout: {
-        [COLUMNS]: [dx.dimension, other.dimension],
-        [ROWS]: [pe.dimension],
-        [FILTERS]: [ou.dimension],
+        [COLUMNS]: [dxId, otherId],
+        [ROWS]: [peId, emptyId],
+        [FILTERS]: [ouId],
     },
     itemsByDimension: {
-        [dx.dimension]: dx.items.map(i => i.id),
-        [other.dimension]: other.items.map(i => i.id),
-        [ou.dimension]: ou.items.map(i => i.id),
-        [pe.dimension]: pe.items.map(i => i.id),
+        [dxId]: dx.items.map(i => i.id),
+        [otherId]: other.items.map(i => i.id),
+        [peId]: pe.items.map(i => i.id),
+        [ouId]: ou.items.map(i => i.id),
     },
 };
 
 describe('getAxesFromUi', () => {
-    it('should return an object with rows, columns, filters keys with dimension and list of item objects as value', () => {
+    it('should return a layout object (columns, rows, filters) with dimensions (id and item objects) that are not empty', () => {
         const expectedState = {
-            rows: [pe],
             columns: [dx, other],
+            rows: [pe],
             filters: [ou],
         };
         const actualState = getAxesFromUi(ui);

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import FileMenu from '@dhis2/d2-ui-file-menu';
 
-import Update from './Update';
+import UpdateButton from './UpdateButton';
 import VisualizationOptionsManager from '../VisualizationOptions/VisualizationOptionsManager';
 import * as fromActions from '../../actions';
 import './MenuBar.css';
@@ -13,7 +13,7 @@ const getOnOpen = props => id => props.onLoadVisualizaton(id);
 export const MenuBar = (props, context) => (
     <div className="menubar">
         <div>
-            <Update />
+            <UpdateButton />
         </div>
         <div>
             <FileMenu

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -2,37 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import FileMenu from '@dhis2/d2-ui-file-menu';
-import Button from '@material-ui/core/Button';
 
-import { colors } from '../../colors';
+import Update from './Update';
 import VisualizationOptionsManager from '../VisualizationOptions/VisualizationOptionsManager';
 import * as fromActions from '../../actions';
 import './MenuBar.css';
-import { sGetCurrent } from '../../reducers/current';
-import { sGetVisualization } from '../../reducers/visualization';
-import { sGetUi } from '../../reducers/ui';
 
-const getOnOpen = props => {
-    // TODO get type somehow!
-    // from props, when choosing visualization type set type in the store?
-    return id => props.onLoadVisualizaton(id);
-};
+const getOnOpen = props => id => props.onLoadVisualizaton(id);
 
 export const MenuBar = (props, context) => (
     <div className="menubar">
         <div>
-            <Button
-                onClick={() => props.onUpdate(props.ui)}
-                style={{
-                    backgroundColor: colors.accentPrimaryDark,
-                    color: colors.white,
-                    fontSize: 13,
-                }}
-                disableRipple={true}
-                disableFocusRipple={true}
-            >
-                Update
-            </Button>
+            <Update />
         </div>
         <div>
             <FileMenu
@@ -57,19 +38,12 @@ MenuBar.contextTypes = {
     d2: PropTypes.object,
 };
 
-const mapStateToProps = state => ({
-    visualization: sGetVisualization(state),
-    current: sGetCurrent(state),
-    ui: sGetUi(state),
-});
-
 const mapDispatchToProps = (dispatch, ownProps) => ({
     onLoadVisualizaton: id =>
         dispatch(fromActions.tDoLoadVisualization(ownProps.apiObjectName, id)),
-    onUpdate: ui => dispatch(fromActions.fromCurrent.acSetCurrentFromUi(ui)),
 });
 
 export default connect(
-    mapStateToProps,
+    null,
     mapDispatchToProps
 )(MenuBar);

--- a/packages/app/src/components/MenuBar/Update.js
+++ b/packages/app/src/components/MenuBar/Update.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import Button from '@material-ui/core/Button';
+
+import { sGetUi } from '../../reducers/ui';
+import { colors } from '../../colors';
+import * as fromActions from '../../actions';
+
+const Update = props => (
+    <Button
+        onClick={() => props.onUpdate(props.ui)}
+        style={{
+            backgroundColor: colors.accentPrimaryDark,
+            color: colors.white,
+            fontSize: 13,
+        }}
+        disableRipple={true}
+        disableFocusRipple={true}
+    >
+        Update
+    </Button>
+);
+
+const mapStateToProps = state => ({
+    ui: sGetUi(state),
+});
+
+const mapDispatchToProps = dispatch => ({
+    onUpdate: ui => dispatch(fromActions.fromCurrent.acSetCurrentFromUi(ui)),
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Update);

--- a/packages/app/src/components/MenuBar/UpdateButton.js
+++ b/packages/app/src/components/MenuBar/UpdateButton.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Button from '@material-ui/core/Button';
+import i18n from '@dhis2/d2-i18n';
 
 import { sGetUi } from '../../reducers/ui';
 import { colors } from '../../colors';
 import * as fromActions from '../../actions';
 
-const Update = props => (
+const UpdateButton = props => (
     <Button
         onClick={() => props.onUpdate(props.ui)}
         style={{
@@ -17,7 +18,7 @@ const Update = props => (
         disableRipple={true}
         disableFocusRipple={true}
     >
-        Update
+        {i18n.t('Update')}
     </Button>
 );
 
@@ -32,4 +33,4 @@ const mapDispatchToProps = dispatch => ({
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(Update);
+)(UpdateButton);

--- a/packages/app/src/current.js
+++ b/packages/app/src/current.js
@@ -1,26 +1,27 @@
-import { getPropsByKeys } from './util';
-import { AXIS_NAMES } from './layout';
+import arrayClean from 'd2-utilizr/lib/arrayClean';
 
-export const getAxesFromUi = ui => {
-    const axes = getPropsByKeys(ui.layout, AXIS_NAMES);
-    const itemsByDimension = Object.entries(ui.itemsByDimension).reduce(
-        (acc, [key, value]) => ({
-            ...acc,
-            [key]: value.map(item => ({ id: item })),
+const getModelAxis = (dimensionId, itemIds) => ({
+    dimension: dimensionId,
+    items: itemIds.map(id => ({
+        id,
+    })),
+});
+
+const hasItems = (object, id) =>
+    object.hasOwnProperty(id) && Array.isArray(object[id]) && object[id].length;
+
+export const getAxesFromUi = ui =>
+    Object.entries(ui.layout).reduce(
+        (layout, [axisName, ids]) => ({
+            ...layout,
+            [axisName]: arrayClean(
+                ids.map(
+                    id =>
+                        hasItems(ui.itemsByDimension, id)
+                            ? getModelAxis(id, ui.itemsByDimension[id])
+                            : null
+                )
+            ),
         }),
         {}
     );
-
-    const axesWithIds = Object.keys(axes).reduce(
-        (acc, axis) => ({
-            ...acc,
-            [axis]: axes[axis].map(dimension => ({
-                dimension,
-                items: itemsByDimension[dimension],
-            })),
-        }),
-        {}
-    );
-
-    return axesWithIds;
-};

--- a/packages/app/src/current.js
+++ b/packages/app/src/current.js
@@ -1,5 +1,3 @@
-import arrayClean from 'd2-utilizr/lib/arrayClean';
-
 const getModelAxis = (dimensionId, itemIds) => ({
     dimension: dimensionId,
     items: itemIds.map(id => ({
@@ -14,14 +12,14 @@ export const getAxesFromUi = ui =>
     Object.entries(ui.layout).reduce(
         (layout, [axisName, ids]) => ({
             ...layout,
-            [axisName]: arrayClean(
-                ids.map(
+            [axisName]: ids
+                .map(
                     id =>
                         hasItems(ui.itemsByDimension, id)
                             ? getModelAxis(id, ui.itemsByDimension[id])
                             : null
                 )
-            ),
+                .filter(dim => dim !== null),
         }),
         {}
     );

--- a/packages/app/src/reducers/current.js
+++ b/packages/app/src/reducers/current.js
@@ -11,24 +11,23 @@ export const DEFAULT_CURRENT = {};
 
 export default (state = DEFAULT_CURRENT, action) => {
     switch (action.type) {
-        case actionTypes.SET_CURRENT:
+        case actionTypes.SET_CURRENT: {
             return action.value;
-        case actionTypes.SET_CURRENT_FROM_UI:
-            console.log('action.value', action.value);
+        }
+        case actionTypes.SET_CURRENT_FROM_UI: {
             const axesFromUi = getAxesFromUi(action.value);
-            console.log('axesFromUi', axesFromUi);
             const optionsFromUi = getPropsByKeys(
                 action.value.options,
                 Object.keys(options)
             );
-            console.log('optionsFromUi', optionsFromUi);
 
             return {
                 ...state,
-                ...axesFromUi, // rows, columns, filters
+                ...axesFromUi,
                 ...optionsFromUi,
                 type: action.value.type,
             };
+        }
         default:
             return state;
     }

--- a/packages/app/src/reducers/current.js
+++ b/packages/app/src/reducers/current.js
@@ -14,11 +14,14 @@ export default (state = DEFAULT_CURRENT, action) => {
         case actionTypes.SET_CURRENT:
             return action.value;
         case actionTypes.SET_CURRENT_FROM_UI:
+            console.log('action.value', action.value);
             const axesFromUi = getAxesFromUi(action.value);
+            console.log('axesFromUi', axesFromUi);
             const optionsFromUi = getPropsByKeys(
                 action.value.options,
                 Object.keys(options)
             );
+            console.log('optionsFromUi', optionsFromUi);
 
             return {
                 ...state,


### PR DESCRIPTION
- Ignore empty dimensions when updating "current" based on "ui"
- Extract Update button component to push the store listener further down the ui tree (avoiding re-render of the menu bar)