### PR TITLE
task/Remove injectTapEventPlugin that breaks with React 16.4

### DIFF
--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -6,7 +6,6 @@ import { Provider } from 'react-redux';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import history from './history';
 
-import injectTapEventPlugin from 'react-tap-event-plugin';
 import { init as d2Init, config, getUserSettings } from 'd2/lib/d2';
 
 import i18n from './locales';
@@ -51,9 +50,6 @@ const render = (location, baseUrl, d2) => {
 };
 
 const init = async () => {
-    // init material-ui
-    injectTapEventPlugin();
-
     // log app info
     console.info(
         `Data Visualizer app, v${manifest.version}, ${


### PR DESCRIPTION
This plugin is deprecated and actually breaks with React 16.4. According to the author, it is no longer needed anyway.

https://github.com/zilverline/react-tap-event-plugin

