### PR TITLE
task/Add localize step to build script

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -82,7 +82,7 @@
         "prestart": "npm run localize && d2-manifest package.json ./public/manifest.webapp",
         "start": "node scripts/start.js",
         "prebuild": "npm run lint && npm run prettier-ci && npm run coverage && rimraf build && mkdirp build && npm run manifest",
-        "build": "node scripts/build.js",
+        "build": "npm run localize && node scripts/build.js",
         "postbuild": "cp -r public/i18n build && cp package.json build",
         "lint": "eslint --config=../../.eslintrc.json src",
         "prettier-ci": "prettier \"./src/{**/*,*}.js\" --list-different",


### PR DESCRIPTION
Creating the translation files is part of the build process. It was included in the start script, but for some reason wasn't in the build script.