### PR TITLE
Output bundle analyzer report to docs folder 

### DIFF
--- a/packages/app/config/webpack.config.prod.js
+++ b/packages/app/config/webpack.config.prod.js
@@ -373,7 +373,7 @@ module.exports = {
         new BundleAnalyzerPlugin({
             analyzerMode: 'static',
             openAnalyzer: false,
-            reportFilename: 'bundleAnalyzerReport.html',
+            reportFilename: 'docs/bundleAnalyzerReport.html',
         }),
     ],
     // Some libraries import Node modules but don't use them in the browser.


### PR DESCRIPTION
When it is output to the docs folder, then it will automatically be depoloyed to github pages for d2-builds and rendered properly