### PR TITLE
Use latest period-selector-dialog for improved treeshaking

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -24,7 +24,7 @@
         "@dhis2/d2-i18n": "^1.0.3",
         "@dhis2/d2-ui-file-menu": "4.0.0",
         "@dhis2/d2-ui-org-unit-dialog": "^1.0.0",
-        "@dhis2/d2-ui-period-selector-dialog": "^2.0.1",
+        "@dhis2/d2-ui-period-selector-dialog": "^2.0.2",
         "@material-ui/core": "^3.1.2",
         "@material-ui/icons": "^3.0.1",
         "autoprefixer": "9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,10 +236,10 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-period-selector-dialog@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-2.0.1.tgz#da23c29f89ca2bd3a47488008f2358e1caaa68fd"
-  integrity sha512-Lkr3yX+Zp+YZyqEFSWXoo+9pywQ5c4PmX5V1xWcF2sIVx0lF8D4WYSIy6TPrblFC80W4IaZm75Mjyt7Kpey1nw==
+"@dhis2/d2-ui-period-selector-dialog@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-2.0.2.tgz#b38c3403d8601319d4bb373663896f4005e7461b"
+  integrity sha512-aGmQ38EY32Qg+seSaRLWHviKLRg5KAl5voR9x8JYvXn+Pc33+xLMdj/Kv+dpaWy03/RJrD4QmThokkvuf5dBzA==
   dependencies:
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"


### PR DESCRIPTION
The previous version of period-selector-dialog use the import syntax that resulted in the entire material-ui/icons being included in the bundle. Which was huge.