### PR TITLE
Rename YEAR_ON_YEAR to YEAR_OVER_YEAR_LINE chart type

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -39,7 +39,7 @@
         "chalk": "2.4.1",
         "css-loader": "0.28.7",
         "d2": "31.1.1",
-        "d2-charts-api": "31.0.0",
+        "d2-charts-api": "31.0.1",
         "d2-manifest": "^1.0.0",
         "dotenv": "6.0.0",
         "dotenv-expand": "4.2.0",

--- a/packages/app/src/assets/YearOverYearLineIcon.js
+++ b/packages/app/src/assets/YearOverYearLineIcon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import SvgIcon from '@material-ui/core/SvgIcon';
 
-const YearOnYearIcon = ({
+const YearOverYearLineIcon = ({
     style = { paddingRight: '8px', width: 24, height: 24 },
 }) => (
     <SvgIcon viewBox="0,0,48,48" style={style}>
@@ -35,4 +35,4 @@ const YearOnYearIcon = ({
     </SvgIcon>
 );
 
-export default YearOnYearIcon;
+export default YearOverYearLineIcon;

--- a/packages/app/src/components/Layout/Layout.js
+++ b/packages/app/src/components/Layout/Layout.js
@@ -13,7 +13,7 @@ import {
     PIE,
     RADAR,
     GAUGE,
-    YEAR_ON_YEAR,
+    YEAR_OVER_YEAR_LINE,
 } from '../../modules/chartTypes';
 import { sGetUiType } from '../../reducers/ui';
 
@@ -27,7 +27,7 @@ const layoutMap = {
     [PIE]: DefaultLayout,
     [RADAR]: DefaultLayout,
     [GAUGE]: DefaultLayout,
-    [YEAR_ON_YEAR]: YearOnYearLayout,
+    [YEAR_OVER_YEAR_LINE]: YearOnYearLayout,
 };
 
 const getLayoutByType = (type, props) => {

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -16,7 +16,7 @@ import {
     apiFetchAnalytics,
     apiFetchAnalyticsForYearOnYear,
 } from '../../api/analytics';
-import { YEAR_ON_YEAR } from '../../modules/chartTypes';
+import { YEAR_OVER_YEAR_LINE } from '../../modules/chartTypes';
 
 export class Visualization extends Component {
     componentDidMount() {
@@ -53,7 +53,7 @@ export class Visualization extends Component {
             const extraOptions = {};
             let responses = [];
 
-            if (current.type === YEAR_ON_YEAR) {
+            if (current.type === YEAR_OVER_YEAR_LINE) {
                 let yearlySeriesLabels = [];
 
                 ({

--- a/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
+++ b/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
@@ -5,7 +5,7 @@ import * as api from '../../../api/analytics';
 import { Visualization } from '../Visualization';
 import BlankCanvas from '../BlankCanvas';
 import * as options from '../../../modules/options';
-import { YEAR_ON_YEAR } from '../../../modules/chartTypes';
+import { YEAR_OVER_YEAR_LINE } from '../../../modules/chartTypes';
 
 jest.mock('d2-charts-api');
 
@@ -148,7 +148,7 @@ describe('Visualization', () => {
         describe('Year-on-year chart', () => {
             beforeEach(() => {
                 props.current = {
-                    type: YEAR_ON_YEAR,
+                    type: YEAR_OVER_YEAR_LINE,
                     option1: 'def',
                 };
 

--- a/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeIcon.js
+++ b/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeIcon.js
@@ -10,7 +10,7 @@ import GaugeIcon from '../../assets/GaugeIcon';
 import LineIcon from '../../assets/LineIcon';
 import AreaIcon from '../../assets/AreaIcon';
 import RadarIcon from '../../assets/RadarIcon';
-import YearOnYearIcon from '../../assets/YearOnYearIcon';
+import YearOverYearLineIcon from '../../assets/YearOverYearLineIcon';
 import {
     COLUMN,
     STACKED_COLUMN,
@@ -21,7 +21,7 @@ import {
     PIE,
     RADAR,
     GAUGE,
-    YEAR_ON_YEAR,
+    YEAR_OVER_YEAR_LINE,
     chartTypeDisplayNames,
 } from '../../modules/chartTypes';
 
@@ -43,8 +43,8 @@ const VisualizationTypeIcon = ({ type = COLUMN, style }) => {
             return <AreaIcon style={style} />;
         case RADAR:
             return <RadarIcon style={style} />;
-        case YEAR_ON_YEAR:
-            return <YearOnYearIcon style={style} />;
+        case YEAR_OVER_YEAR_LINE:
+            return <YearOverYearLineIcon style={style} />;
         case COLUMN:
         default:
             return <ColumnIcon style={style} />;

--- a/packages/app/src/modules/chartTypes.js
+++ b/packages/app/src/modules/chartTypes.js
@@ -10,7 +10,7 @@ export const PIE = 'PIE';
 export const RADAR = 'RADAR';
 export const GAUGE = 'GAUGE';
 export const BUBBLE = 'BUBBLE';
-export const YEAR_ON_YEAR = 'YEAR_ON_YEAR';
+export const YEAR_OVER_YEAR_LINE = 'YEAR_OVER_YEAR_LINE';
 
 export const chartTypeDisplayNames = {
     [COLUMN]: i18n.t('Column'),
@@ -22,5 +22,5 @@ export const chartTypeDisplayNames = {
     [PIE]: i18n.t('Pie'),
     [RADAR]: i18n.t('Radar'),
     [GAUGE]: i18n.t('Gauge'),
-    [YEAR_ON_YEAR]: i18n.t('Year on year'),
+    [YEAR_OVER_YEAR_LINE]: i18n.t('Year on year'),
 };

--- a/packages/app/src/reducers/__tests__/current.spec.js
+++ b/packages/app/src/reducers/__tests__/current.spec.js
@@ -5,7 +5,7 @@ import reducer, {
     SET_CURRENT_FROM_UI,
     CLEAR_CURRENT,
 } from '../current';
-import { COLUMN, YEAR_ON_YEAR } from '../../modules/chartTypes';
+import { COLUMN, YEAR_OVER_YEAR_LINE } from '../../modules/chartTypes';
 import { FIXED_DIMENSIONS } from '../../modules/fixedDimensions';
 
 const dxId = FIXED_DIMENSIONS.dx.id;
@@ -83,7 +83,7 @@ describe('reducer: current', () => {
 
     it('SET_CURRENT_FROM_UI: should set current on a year on year format from the ui state section', () => {
         const ui = {
-            type: YEAR_ON_YEAR,
+            type: YEAR_OVER_YEAR_LINE,
             layout: { columns: [], rows: [], filters: [dxId, ouId] },
             itemsByDimension: {
                 [dxId]: ['dxItemId1', 'dxItemId2'],

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -18,7 +18,7 @@ import reducer, {
     SET_UI_YEAR_ON_YEAR_CATEGORY,
 } from '../ui';
 import { AXIS_NAMES } from '../../modules/layout';
-import { BAR, YEAR_ON_YEAR } from '../../modules/chartTypes';
+import { BAR, YEAR_OVER_YEAR_LINE } from '../../modules/chartTypes';
 import { FIXED_DIMENSIONS } from '../../modules/fixedDimensions';
 
 const [COLUMNS, ROWS, FILTERS] = AXIS_NAMES;
@@ -115,7 +115,7 @@ describe('reducer: ui', () => {
     it(`${SET_UI_TYPE}: should set the type, layout and items on the year on year format`, () => {
         const expectedState = {
             ...DEFAULT_UI,
-            type: YEAR_ON_YEAR,
+            type: YEAR_OVER_YEAR_LINE,
             layout: {
                 columns: [],
                 rows: [],
@@ -127,7 +127,7 @@ describe('reducer: ui', () => {
         };
         const actualState = reducer(DEFAULT_UI, {
             type: SET_UI_TYPE,
-            value: YEAR_ON_YEAR,
+            value: YEAR_OVER_YEAR_LINE,
         });
 
         expect(actualState).toEqual(expectedState);

--- a/packages/app/src/reducers/current.js
+++ b/packages/app/src/reducers/current.js
@@ -1,6 +1,6 @@
 import { getAxesFromUi, getOptionsFromUi } from '../modules/current';
 import { createDimension } from '../modules/layout';
-import { YEAR_ON_YEAR } from '../modules/chartTypes';
+import { YEAR_OVER_YEAR_LINE } from '../modules/chartTypes';
 import { FIXED_DIMENSIONS } from '../modules/fixedDimensions';
 
 export const SET_CURRENT = 'SET_CURRENT';
@@ -38,7 +38,7 @@ export default (state = DEFAULT_CURRENT, action) => {
         }
         case SET_CURRENT_FROM_UI: {
             switch (action.value.type) {
-                case YEAR_ON_YEAR:
+                case YEAR_OVER_YEAR_LINE:
                     return getYearOnYearCurrentFromUi(state, action);
                 default: {
                     const axesFromUi = getAxesFromUi(action.value);

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -8,7 +8,7 @@ import {
     getOptionsForUi,
     getOptionsFromVisualization,
 } from '../modules/options';
-import { COLUMN, YEAR_ON_YEAR } from '../modules/chartTypes';
+import { COLUMN, YEAR_OVER_YEAR_LINE } from '../modules/chartTypes';
 import { FIXED_DIMENSIONS } from '../modules/fixedDimensions';
 import { toArray } from '../modules/array';
 
@@ -74,7 +74,7 @@ export default (state = DEFAULT_UI, action) => {
             };
 
             switch (action.value) {
-                case YEAR_ON_YEAR: {
+                case YEAR_OVER_YEAR_LINE: {
                     const items = {
                         ...state.itemsByDimension,
                     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3311,10 +3311,10 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
-d2-charts-api@31.0.0:
-  version "31.0.0"
-  resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-31.0.0.tgz#6ca44f4f13c5d00676ed37f6b4c125ffd1f72e1d"
-  integrity sha512-LydlawUZEiSKI+TKZGPs1e2nFpV0ZowX5w6KDdRAMZ8asCFgyQMSCiOWCk2FqH+t//qdcFevNPD8oV2bCSI0aA==
+d2-charts-api@31.0.1:
+  version "31.0.1"
+  resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-31.0.1.tgz#deb3a9293bec0e1e29ab497b10fae19138590e28"
+  integrity sha512-YNLmFDkeXu+KQ9ykGeLHV+mR7oKXXypCGfc9UzLxuAH8Ms79c7MOoj5GnUt7c07KaP4IoN3OwXMVhmW5pgMbbg==
   dependencies:
     d2-utilizr "0.2.13"
     d3-color "1.0.1"


### PR DESCRIPTION
This is to use the same naming as the backend and allow for new chart
types like YEAR_OVER_YEAR_COLUMN.