### PR TITLE
Add support for Year over Year column chart type

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-10-31T09:12:27.495Z\n"
-"PO-Revision-Date: 2018-10-31T09:12:27.496Z\n"
+"POT-Creation-Date: 2018-11-02T10:47:13.180Z\n"
+"PO-Revision-Date: 2018-11-02T10:47:13.180Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -111,6 +111,9 @@ msgid "Data value set"
 msgstr ""
 
 msgid "Other formats"
+msgstr ""
+
+msgid "Interpretations"
 msgstr ""
 
 msgid "selected"
@@ -317,7 +320,10 @@ msgstr ""
 msgid "Gauge"
 msgstr ""
 
-msgid "Year on year"
+msgid "Year over year (line)"
+msgstr ""
+
+msgid "Year over year (column)"
 msgstr ""
 
 msgid "Indicators"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -39,7 +39,7 @@
         "chalk": "2.4.1",
         "css-loader": "0.28.7",
         "d2": "31.2.1",
-        "d2-charts-api": "31.0.2",
+        "d2-charts-api": "31.0.3",
         "d2-manifest": "^1.0.0",
         "dotenv": "6.0.0",
         "dotenv-expand": "4.2.0",

--- a/packages/app/src/assets/YearOverYearColumnIcon.js
+++ b/packages/app/src/assets/YearOverYearColumnIcon.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+const YearOverYearColumnIcon = ({
+    style = { paddingRight: '8px', width: 24, height: 24 },
+}) => (
+    <SvgIcon viewBox="0,0,48,48" style={style}>
+        <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+            <g>
+                <mask id="mask-2" fill="white">
+                    <rect x="0" y="0" width="48" height="48" />
+                </mask>
+                <polygon
+                    stroke="#1976D2"
+                    strokeWidth="2"
+                    mask="url(#mask-2)"
+                    points="1 28 10 35 18 16 34 35 50 36 50 51 -3 51 -3 28"
+                />
+                <polygon
+                    stroke="#004BA0"
+                    strokeWidth="2"
+                    mask="url(#mask-2)"
+                    points="1 20 8 20 19 29 36 17 50 28 50 51 -3 51 -3 20"
+                />
+                <polygon
+                    stroke="#63A4FF"
+                    strokeWidth="2"
+                    mask="url(#mask-2)"
+                    points="1 35 19 39 28 31 38 28 50 43 50 66 -3 66 -3 35"
+                />
+                <rect fill="#9E9E9E" x="0" y="0" width="2" height="48" />
+                <rect fill="#9E9E9E" x="0" y="46" width="48" height="2" />
+            </g>
+        </g>
+    </SvgIcon>
+);
+
+export default YearOverYearColumnIcon;

--- a/packages/app/src/components/Layout/Layout.js
+++ b/packages/app/src/components/Layout/Layout.js
@@ -14,6 +14,7 @@ import {
     RADAR,
     GAUGE,
     YEAR_OVER_YEAR_LINE,
+    YEAR_OVER_YEAR_COLUMN,
 } from '../../modules/chartTypes';
 import { sGetUiType } from '../../reducers/ui';
 
@@ -28,6 +29,7 @@ const layoutMap = {
     [RADAR]: DefaultLayout,
     [GAUGE]: DefaultLayout,
     [YEAR_OVER_YEAR_LINE]: YearOnYearLayout,
+    [YEAR_OVER_YEAR_COLUMN]: YearOnYearLayout,
 };
 
 const getLayoutByType = (type, props) => {

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -16,7 +16,7 @@ import {
     apiFetchAnalytics,
     apiFetchAnalyticsForYearOnYear,
 } from '../../api/analytics';
-import { YEAR_OVER_YEAR_LINE } from '../../modules/chartTypes';
+import { YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN } from '../../modules/chartTypes';
 
 export class Visualization extends Component {
     componentDidMount() {
@@ -53,7 +53,7 @@ export class Visualization extends Component {
             const extraOptions = {};
             let responses = [];
 
-            if (current.type === YEAR_OVER_YEAR_LINE) {
+            if ([YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN].includes(current.type)) {
                 let yearlySeriesLabels = [];
 
                 ({

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -16,7 +16,10 @@ import {
     apiFetchAnalytics,
     apiFetchAnalyticsForYearOnYear,
 } from '../../api/analytics';
-import { YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN } from '../../modules/chartTypes';
+import {
+    YEAR_OVER_YEAR_LINE,
+    YEAR_OVER_YEAR_COLUMN,
+} from '../../modules/chartTypes';
 
 export class Visualization extends Component {
     componentDidMount() {
@@ -53,7 +56,11 @@ export class Visualization extends Component {
             const extraOptions = {};
             let responses = [];
 
-            if ([YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN].includes(current.type)) {
+            if (
+                [YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN].includes(
+                    current.type
+                )
+            ) {
                 let yearlySeriesLabels = [];
 
                 ({

--- a/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeIcon.js
+++ b/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeIcon.js
@@ -11,6 +11,7 @@ import LineIcon from '../../assets/LineIcon';
 import AreaIcon from '../../assets/AreaIcon';
 import RadarIcon from '../../assets/RadarIcon';
 import YearOverYearLineIcon from '../../assets/YearOverYearLineIcon';
+import YearOverYearColumnIcon from '../../assets/YearOverYearColumnIcon';
 import {
     COLUMN,
     STACKED_COLUMN,
@@ -22,6 +23,7 @@ import {
     RADAR,
     GAUGE,
     YEAR_OVER_YEAR_LINE,
+    YEAR_OVER_YEAR_COLUMN,
     chartTypeDisplayNames,
 } from '../../modules/chartTypes';
 
@@ -45,6 +47,8 @@ const VisualizationTypeIcon = ({ type = COLUMN, style }) => {
             return <RadarIcon style={style} />;
         case YEAR_OVER_YEAR_LINE:
             return <YearOverYearLineIcon style={style} />;
+        case YEAR_OVER_YEAR_COLUMN:
+            return <YearOverYearColumnIcon style={style} />;
         case COLUMN:
         default:
             return <ColumnIcon style={style} />;

--- a/packages/app/src/modules/chartTypes.js
+++ b/packages/app/src/modules/chartTypes.js
@@ -11,6 +11,7 @@ export const RADAR = 'RADAR';
 export const GAUGE = 'GAUGE';
 export const BUBBLE = 'BUBBLE';
 export const YEAR_OVER_YEAR_LINE = 'YEAR_OVER_YEAR_LINE';
+export const YEAR_OVER_YEAR_COLUMN = 'YEAR_OVER_YEAR_COLUMN';
 
 export const chartTypeDisplayNames = {
     [COLUMN]: i18n.t('Column'),
@@ -22,5 +23,6 @@ export const chartTypeDisplayNames = {
     [PIE]: i18n.t('Pie'),
     [RADAR]: i18n.t('Radar'),
     [GAUGE]: i18n.t('Gauge'),
-    [YEAR_OVER_YEAR_LINE]: i18n.t('Year on year'),
+    [YEAR_OVER_YEAR_LINE]: i18n.t('Year over year (line)'),
+    [YEAR_OVER_YEAR_COLUMN]: i18n.t('Year over year (column)'),
 };

--- a/packages/app/src/modules/ui.js
+++ b/packages/app/src/modules/ui.js
@@ -1,4 +1,4 @@
-import { YEAR_OVER_YEAR_LINE } from './chartTypes';
+import { YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN } from './chartTypes';
 import {
     AXIS_NAME_COLUMNS,
     AXIS_NAME_ROWS,
@@ -53,7 +53,8 @@ const yearOnYearUiAdapter = ui => {
 
 export const getAdaptedUiByType = ui => {
     switch (ui.type) {
-        case YEAR_OVER_YEAR_LINE: {
+        case YEAR_OVER_YEAR_LINE:
+        case YEAR_OVER_YEAR_COLUMN: {
             return yearOnYearUiAdapter(ui);
         }
         default:

--- a/packages/app/src/modules/yearOnYear.js
+++ b/packages/app/src/modules/yearOnYear.js
@@ -38,4 +38,5 @@ export const categoryOptions = [
 ];
 
 // Check if a type is a year on year type
-export const isYearOnYear = type => [YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN].includes(type);
+export const isYearOnYear = type =>
+    [YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN].includes(type);

--- a/packages/app/src/modules/yearOnYear.js
+++ b/packages/app/src/modules/yearOnYear.js
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n';
-import { YEAR_OVER_YEAR_LINE } from './chartTypes';
+import { YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN } from './chartTypes';
 
 // Fixed years generator
 const getFixedYears = len => {
@@ -38,4 +38,4 @@ export const categoryOptions = [
 ];
 
 // Check if a type is a year on year type
-export const isYearOnYear = type => [YEAR_OVER_YEAR_LINE].includes(type);
+export const isYearOnYear = type => [YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN].includes(type);

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -18,7 +18,7 @@ import reducer, {
     SET_UI_YEAR_ON_YEAR_CATEGORY,
 } from '../ui';
 import { AXIS_NAMES } from '../../modules/layout';
-import { BAR, YEAR_OVER_YEAR_LINE } from '../../modules/chartTypes';
+import { BAR } from '../../modules/chartTypes';
 import { FIXED_DIMENSIONS } from '../../modules/fixedDimensions';
 
 const [COLUMNS, ROWS, FILTERS] = AXIS_NAMES;

--- a/packages/app/src/reducers/current.js
+++ b/packages/app/src/reducers/current.js
@@ -1,6 +1,9 @@
 import { getAxesFromUi, getOptionsFromUi } from '../modules/current';
 import { createDimension } from '../modules/layout';
-import { YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN } from '../modules/chartTypes';
+import {
+    YEAR_OVER_YEAR_LINE,
+    YEAR_OVER_YEAR_COLUMN,
+} from '../modules/chartTypes';
 import { FIXED_DIMENSIONS } from '../modules/fixedDimensions';
 
 export const SET_CURRENT = 'SET_CURRENT';

--- a/packages/app/src/reducers/current.js
+++ b/packages/app/src/reducers/current.js
@@ -1,6 +1,6 @@
 import { getAxesFromUi, getOptionsFromUi } from '../modules/current';
 import { createDimension } from '../modules/layout';
-import { YEAR_OVER_YEAR_LINE } from '../modules/chartTypes';
+import { YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN } from '../modules/chartTypes';
 import { FIXED_DIMENSIONS } from '../modules/fixedDimensions';
 
 export const SET_CURRENT = 'SET_CURRENT';
@@ -40,6 +40,7 @@ export default (state = DEFAULT_CURRENT, action) => {
         case SET_CURRENT_FROM_UI: {
             switch (action.value.type) {
                 case YEAR_OVER_YEAR_LINE:
+                case YEAR_OVER_YEAR_COLUMN:
                     return getYearOnYearCurrentFromUi(state, action);
                 default: {
                     const axesFromUi = getAxesFromUi(action.value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3311,9 +3311,10 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
-d2-charts-api@31.0.2:
-  version "31.0.2"
-  resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-31.0.2.tgz#1cc1eeb957273f7c169861d94eb93357f2f066fc"
+d2-charts-api@31.0.3:
+  version "31.0.3"
+  resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-31.0.3.tgz#dc72b38425aa62682d8792e1e65f3b6abfde114a"
+  integrity sha512-ZffvkBJ5njXUc6I9uf6DqCTlJ40wFkjvahsXzGx4qTaBCdA9mWXBQCyDrTcBKC1Xi98C9Oh3mJ/VxkZ8/LdZIw==
   dependencies:
     d2-utilizr "0.2.13"
     d3-color "1.0.1"


### PR DESCRIPTION
Requires updated d2-charts-api before merging to master.

A new icon is needed, for now it's the same as the year over year line one.