### PR TITLE
Add InterpretationsButton component

### DIFF
--- a/packages/app/src/actions/ui.js
+++ b/packages/app/src/actions/ui.js
@@ -15,6 +15,7 @@ import {
     SET_UI_ACTIVE_MODAL_DIALOG,
     SET_UI_YEAR_ON_YEAR_SERIES,
     SET_UI_YEAR_ON_YEAR_CATEGORY,
+    TOGGLE_UI_RIGHT_SIDEBAR_OPEN,
 } from '../reducers/ui';
 
 export const acSetUi = value => ({
@@ -95,4 +96,8 @@ export const acSetParentGraphMap = value => ({
 export const acSetUiActiveModalDialog = value => ({
     type: SET_UI_ACTIVE_MODAL_DIALOG,
     value,
+});
+
+export const acToggleUiRightSidebarOpen = () => ({
+    type: TOGGLE_UI_RIGHT_SIDEBAR_OPEN,
 });

--- a/packages/app/src/components/App.css
+++ b/packages/app/src/components/App.css
@@ -24,7 +24,6 @@ body {
 }
 .interpretations {
     grid-area: interpretations;
-    padding: 20px;
 }
 .canvas {
     grid-area: canvas;
@@ -37,7 +36,7 @@ body {
 .app {
     display: grid;
     grid-gap: 1px;
-    grid-template-columns: 262px auto 160px;
+    grid-template-columns: 262px 1fr min-content;
     grid-template-rows: 0 40px 94px auto;
     grid-template-areas:
         'headerbar headerbar headerbar'

--- a/packages/app/src/components/App.css
+++ b/packages/app/src/components/App.css
@@ -27,6 +27,7 @@ body {
 }
 .canvas {
     grid-area: canvas;
+    position: relative;
 }
 
 .app * {

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -108,24 +108,26 @@ export class App extends Component {
             <UI>
                 <HeaderBar appName={i18n.t('Data Visualizer')} />
                 <div className="app">
-                    <div className="item2 visualization-type-selector">
+                    <div className="visualization-type-selector">
                         <VisualizationTypeSelector />
                     </div>
-                    <div className="item3 menu-bar">
+                    <div className="menu-bar">
                         <MenuBar apiObjectName={this.props.apiObjectName} />
                     </div>
-                    <div className="item4 dimensions">
+                    <div className="dimensions">
                         <Dimensions />
                     </div>
-                    <div className="item5 chart-layout">
+                    <div className="chart-layout">
                         <Layout />
                     </div>
-                    <div className="item6 interpretations">
-                        Interpretations panel
-                    </div>
-                    <div className="item8 canvas">
+                    <div className="canvas">
                         <TitleBar />
                         {hasCurrent ? <Visualization /> : <BlankCanvas />}
+                    </div>
+                    <div className="interpretations">
+                        {this.props.ui.rightSidebarOpen
+                            ? 'Interpretations panel'
+                            : null}
                     </div>
                 </div>
                 {this.renderSnackbar()}

--- a/packages/app/src/components/Interpretations/InterpretationsButton.js
+++ b/packages/app/src/components/Interpretations/InterpretationsButton.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Button from '@material-ui/core/Button';
+import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
+import i18n from '@dhis2/d2-i18n';
+
+import { sGetUiRightSidebarOpen } from '../../reducers/ui';
+import { sGetCurrent } from '../../reducers/current';
+import { acToggleUiRightSidebarOpen } from '../../actions/ui';
+import styles from './styles/InterpretationsButton.style';
+
+export const InterpretationsButton = props => (
+    <Button
+        size="small"
+        disabled={!Boolean(props.id)}
+        disableRipple={true}
+        disableFocusRipple={true}
+        style={{ ...styles, ...props.labelStyle }}
+        onClick={props.onClick}
+    >
+        {props.rightSidebarOpen ? (
+            <KeyboardArrowRightIcon />
+        ) : (
+            <KeyboardArrowLeftIcon />
+        )}
+        {i18n.t('Interpretations')}
+    </Button>
+);
+
+InterpretationsButton.propTypes = {
+    rightSiderbarOpen: PropTypes.bool,
+    onClick: PropTypes.func,
+    labelStyle: PropTypes.object,
+};
+
+const mapStateToProps = state => ({
+    rightSidebarOpen: sGetUiRightSidebarOpen(state),
+    id: sGetCurrent(state).id,
+});
+
+const mapDispatchToProps = dispatch => ({
+    onClick: () => dispatch(acToggleUiRightSidebarOpen()),
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(InterpretationsButton);

--- a/packages/app/src/components/Interpretations/__tests__/IterpretationsButton.spec.js
+++ b/packages/app/src/components/Interpretations/__tests__/IterpretationsButton.spec.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { InterpretationsButton } from '../InterpretationsButton';
+import Button from '@material-ui/core/Button';
+import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
+
+describe('InterpretationsButton component', () => {
+    let props;
+    let shallowInterpretationsButton;
+
+    const interpretationsButton = () => {
+        if (!shallowInterpretationsButton) {
+            shallowInterpretationsButton = shallow(
+                <InterpretationsButton {...props} />
+            );
+        }
+        return shallowInterpretationsButton;
+    };
+
+    const onClick = jest.fn();
+
+    beforeEach(() => {
+        props = {
+            id: 'test',
+            rightSidebarOpen: false,
+            onClick,
+        };
+
+        shallowInterpretationsButton = undefined;
+    });
+
+    it('renders a <Button>', () => {
+        expect(
+            interpretationsButton()
+                .find(Button)
+                .first().length
+        ).toEqual(1);
+    });
+
+    it('renders a disabled <Button> if no id is passed', () => {
+        props.id = null;
+
+        expect(
+            interpretationsButton()
+                .find(Button)
+                .prop('disabled')
+        ).toEqual(true);
+    });
+
+    it('it triggers onClick when the button is clicked', () => {
+        interpretationsButton()
+            .find(Button)
+            .simulate('click');
+
+        expect(onClick).toHaveBeenCalled();
+    });
+
+    it('uses the correct arrow icon based on props', () => {
+        expect(
+            interpretationsButton()
+                .find(KeyboardArrowLeftIcon)
+                .first().length
+        ).toEqual(1);
+    });
+
+    it('uses the correct arrow icon when the panel is open', () => {
+        props.rightSidebarOpen = true;
+
+        expect(
+            interpretationsButton()
+                .find(KeyboardArrowRightIcon)
+                .first().length
+        ).toEqual(1);
+    });
+});

--- a/packages/app/src/components/Interpretations/styles/InterpretationsButton.style.js
+++ b/packages/app/src/components/Interpretations/styles/InterpretationsButton.style.js
@@ -1,0 +1,3 @@
+export default {
+    marginLeft: 'auto',
+};

--- a/packages/app/src/components/MenuBar/MenuBar.css
+++ b/packages/app/src/components/MenuBar/MenuBar.css
@@ -1,7 +1,0 @@
-.menubar > div {
-    padding: 8px 16px;
-}
-
-.menubar > .spacefiller {
-    flex: 1;
-}

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -5,10 +5,10 @@ import FileMenu from '@dhis2/d2-ui-file-menu';
 
 import UpdateButton from '../UpdateButton/UpdateButton';
 import DownloadMenu from '../DownloadMenu/DownloadMenu';
+import InterpretationsButton from '../Interpretations/InterpretationsButton';
 import VisualizationOptionsManager from '../VisualizationOptions/VisualizationOptionsManager';
 import * as fromActions from '../../actions';
 import { sGetCurrent } from '../../reducers/current';
-import './MenuBar.css';
 import history from '../../modules/history';
 import styles from './styles/MenuBar.style';
 
@@ -39,8 +39,7 @@ export const MenuBar = (props, context) => (
         />
         <VisualizationOptionsManager labelStyle={styles.label} />
         <DownloadMenu labelStyle={styles.label} />
-        <div className="spacefiller" />
-        <div style={styles.label}>Interpretations</div>
+        <InterpretationsButton labelStyle={styles.label} />
     </div>
 );
 

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -6,6 +6,7 @@ import { sGetCurrent } from '../../reducers/current';
 import BlankCanvas, { visContainerId } from './BlankCanvas';
 import { getOptionsForRequest } from '../../modules/options';
 import { acAddMetadata } from '../../actions/metadata';
+import { sGetUiRightSidebarOpen } from '../../reducers/ui';
 import {
     acSetLoadError,
     acSetLoading,
@@ -22,6 +23,12 @@ import {
 } from '../../modules/chartTypes';
 
 export class Visualization extends Component {
+    constructor(props) {
+        super(props);
+
+        this.chart = undefined;
+    }
+
     componentDidMount() {
         if (this.props.current) {
             this.renderVisualization();
@@ -31,6 +38,12 @@ export class Visualization extends Component {
     componentDidUpdate(prevProps) {
         if (this.props.current !== prevProps.current) {
             this.renderVisualization();
+        }
+
+        if (this.props.rightSidebarOpen !== prevProps.rightSidebarOpen) {
+            if (this.chart) {
+                this.chart.reflow();
+            }
         }
     }
 
@@ -87,6 +100,8 @@ export class Visualization extends Component {
                 extraOptions
             );
 
+            this.chart = chartConfig.chart;
+
             this.props.acSetChart(
                 chartConfig.chart.getSVGForExport({
                     sourceHeight: 768,
@@ -108,6 +123,7 @@ export class Visualization extends Component {
 
 const mapStateToProps = state => ({
     current: sGetCurrent(state),
+    rightSidebarOpen: sGetUiRightSidebarOpen(state),
 });
 
 export default connect(

--- a/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
+++ b/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
@@ -59,6 +59,7 @@ describe('Visualization', () => {
     beforeEach(() => {
         props = {
             current: {},
+            rightSidebarOpen: false,
             acAddMetadata: jest.fn(),
             acSetChart: jest.fn(),
             acSetLoading: jest.fn(),
@@ -208,6 +209,26 @@ describe('Visualization', () => {
                 expect(props.acSetLoadError).toHaveBeenCalled();
                 done();
             });
+        });
+    });
+
+    describe('chart reflow', () => {
+        const reflowFn = jest.fn();
+
+        const vis = canvas();
+
+        vis.instance().chart = {
+            reflow: reflowFn,
+        };
+
+        it('triggers a reflow when rightSidebarOpen prop changes', () => {
+            vis.setProps({ rightSidebarOpen: true });
+
+            expect(reflowFn).toHaveBeenCalled();
+
+            vis.setProps({ rightSidebarOpen: false });
+
+            expect(reflowFn).toHaveBeenCalled();
         });
     });
 });

--- a/packages/app/src/components/Visualization/styles/BlankCanvas.style.js
+++ b/packages/app/src/components/Visualization/styles/BlankCanvas.style.js
@@ -5,6 +5,8 @@ export default {
         display: 'flex',
         justifyContent: 'center',
         height: '100%',
+        width: '100%',
+        position: 'absolute',
     },
     inner: {
         maxWidth: 200,

--- a/packages/app/src/components/__tests__/App.spec.js
+++ b/packages/app/src/components/__tests__/App.spec.js
@@ -34,6 +34,7 @@ describe('App', () => {
             snackbarOpen: false,
             snackbarMessage: '',
             current: {},
+            ui: { rightSidebarOpen: false },
             location: { pathname: '/' },
             settings: {
                 rootOrganisationUnit: {

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -16,6 +16,7 @@ import reducer, {
     CLEAR_UI,
     SET_UI_YEAR_ON_YEAR_SERIES,
     SET_UI_YEAR_ON_YEAR_CATEGORY,
+    TOGGLE_UI_RIGHT_SIDEBAR_OPEN,
 } from '../ui';
 import { AXIS_NAMES } from '../../modules/layout';
 import { BAR } from '../../modules/chartTypes';
@@ -414,5 +415,19 @@ describe('reducer: ui', () => {
         });
 
         expect(actualState.activeModalDialog).toEqual(dialog);
+    });
+
+    it(`${TOGGLE_UI_RIGHT_SIDEBAR_OPEN}: should toggle the state of the right sidebar`, () => {
+        let actualState = reducer(DEFAULT_UI, {
+            type: TOGGLE_UI_RIGHT_SIDEBAR_OPEN,
+        });
+
+        expect(actualState.rightSidebarOpen).toEqual(true);
+
+        actualState = reducer(actualState, {
+            type: TOGGLE_UI_RIGHT_SIDEBAR_OPEN,
+        });
+
+        expect(actualState.rightSidebarOpen).toEqual(false);
     });
 });

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -26,6 +26,7 @@ export const SET_UI_ACTIVE_MODAL_DIALOG = 'SET_UI_ACTIVE_MODAL_DIALOG';
 export const SET_UI_YEAR_ON_YEAR_SERIES = 'SET_UI_YEAR_ON_YEAR_SERIES';
 export const SET_UI_YEAR_ON_YEAR_CATEGORY = 'SET_UI_YEAR_ON_YEAR_CATEGORY';
 export const CLEAR_UI = 'CLEAR_UI';
+export const TOGGLE_UI_RIGHT_SIDEBAR_OPEN = 'TOGGLE_UI_RIGHT_SIDEBAR_OPEN';
 
 const dxId = FIXED_DIMENSIONS.dx.id;
 const peId = FIXED_DIMENSIONS.pe.id;
@@ -44,6 +45,7 @@ export const DEFAULT_UI = {
     yearOnYearCategory: ['MONTHS_THIS_YEAR'],
     parentGraphMap: {},
     activeModalDialog: null,
+    rightSidebarOpen: false,
 };
 
 export default (state = DEFAULT_UI, action) => {
@@ -203,6 +205,11 @@ export default (state = DEFAULT_UI, action) => {
                     [rootOrganisationUnit.id]: `/${rootOrganisationUnit.id}`,
                 },
             };
+        case TOGGLE_UI_RIGHT_SIDEBAR_OPEN:
+            return {
+                ...state,
+                rightSidebarOpen: !state.rightSidebarOpen,
+            };
         default:
             return state;
     }
@@ -221,6 +228,7 @@ export const sGetUiYearOnYearCategory = state =>
     sGetUi(state).yearOnYearCategory;
 export const sGetUiParentGraphMap = state => sGetUi(state).parentGraphMap;
 export const sGetUiActiveModalDialog = state => sGetUi(state).activeModalDialog;
+export const sGetUiRightSidebarOpen = state => sGetUi(state).rightSidebarOpen;
 
 export const sGetDimensionIdsFromLayout = state =>
     Object.values(sGetUiLayout(state)).reduce(


### PR DESCRIPTION
I found a way to do the show/hide of the interpretations panel while expanding the grid, see the change in App.css.
It works well when no AO is loaded, but it extends the panel on the right end side of the screen when there is a chart.

I suspect the problem is due to some `width` in one of the elements inside the chart div...