### PR TITLE
fix/change fn name for filtering text in Dimensions

### DIFF
--- a/packages/app/src/components/Dimensions/DimensionList.js
+++ b/packages/app/src/components/Dimensions/DimensionList.js
@@ -16,7 +16,7 @@ export class DimensionList extends Component {
     };
 
     filterMatchingDimensions = dimension => {
-        return this.searchTextContains(dimension.name)
+        return this.filterTextContains(dimension.name)
             ? this.renderItem(dimension)
             : null;
     };


### PR DESCRIPTION
fix/change fn name for filtering text in Dimensions

From searchTextContains
To: FilterTextContains