### PR TITLE
CSS grid fixes

### DIFF
--- a/packages/app/src/components/App.css
+++ b/packages/app/src/components/App.css
@@ -11,12 +11,15 @@ body {
 }
 .visualization-type-selector {
     grid-area: charttype;
+    border-right: 1px solid #aaa;
 }
 .menu-bar {
     grid-area: menubar;
+    border-bottom: 1px solid #aaa;
 }
 .dimensions {
     grid-area: dimensions;
+    border-right: 1px solid #aaa;
 }
 .chart-layout {
     grid-area: chartlayout;
@@ -36,15 +39,13 @@ body {
 
 .app {
     display: grid;
-    grid-gap: 1px;
     grid-template-columns: 262px auto 160px;
-    grid-template-rows: 0 40px 94px auto;
+    grid-template-rows: 0 41px 94px auto;
     grid-template-areas:
         'headerbar headerbar headerbar'
         'charttype menubar menubar'
         'dimensions chartlayout interpretations'
         'dimensions canvas interpretations';
-    background-color: #aaa;
 }
 .app > div {
     background-color: #f4f6f8;

--- a/packages/app/src/components/App.css
+++ b/packages/app/src/components/App.css
@@ -12,6 +12,7 @@ body {
 .visualization-type-selector {
     grid-area: charttype;
     border-right: 1px solid #aaa;
+    border-bottom: 1px solid #aaa;
 }
 .menu-bar {
     grid-area: menubar;
@@ -27,10 +28,14 @@ body {
 }
 .interpretations {
     grid-area: interpretations;
+    border-left: 1px solid #aaa;
     padding: 20px;
 }
 .canvas {
     grid-area: canvas;
+}
+.title-bar {
+    grid-area: titlebar;
 }
 
 .app * {
@@ -40,11 +45,12 @@ body {
 .app {
     display: grid;
     grid-template-columns: 262px auto 160px;
-    grid-template-rows: 0 41px 94px auto;
+    grid-template-rows: 0 41px 94px 44px auto;
     grid-template-areas:
         'headerbar headerbar headerbar'
         'charttype menubar menubar'
         'dimensions chartlayout interpretations'
+        'dimensions titlebar interpretations'
         'dimensions canvas interpretations';
 }
 .app > div {

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -123,8 +123,10 @@ export class App extends Component {
                     <div className="item6 interpretations">
                         Interpretations panel
                     </div>
-                    <div className="item8 canvas">
+                    <div className="title-bar">
                         <TitleBar />
+                    </div>
+                    <div className="item8 canvas">
                         {hasCurrent ? <Visualization /> : <BlankCanvas />}
                     </div>
                 </div>

--- a/packages/app/src/components/Dimensions/Dimensions.js
+++ b/packages/app/src/components/Dimensions/Dimensions.js
@@ -15,7 +15,7 @@ export class Dimensions extends Component {
 
     render = () => {
         return (
-            <div className={'dimensions'} style={styles.divContainer}>
+            <div style={styles.divContainer}>
                 <DialogManager />
                 <TextField
                     style={styles.textField}

--- a/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeSelector.js
+++ b/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeSelector.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Button from '@material-ui/core/Button';
@@ -36,7 +36,7 @@ export class VisualizationTypeSelector extends Component {
         const { visualizationType } = this.props;
 
         return (
-            <div className="visualization-type-selector">
+            <Fragment>
                 <Button
                     onClick={this.handleButtonClick}
                     disableRipple
@@ -107,7 +107,7 @@ export class VisualizationTypeSelector extends Component {
                         </MenuItem>
                     ))}
                 </Menu>
-            </div>
+            </Fragment>
         );
     }
 }


### PR DESCRIPTION
To make the CSS grid collapse properly when the interpretations panel is toggled, the container of highchart must be absolute positioned.
This caused a minor overflow problem where the legend of the chart was outside the parents' container boundary. That was due to the container having also the TitleBar component.
To solve the problem I added a new grid cell for the TitleBar.
Then the grid-gap was showing a line below the TitleBar also when there was no title.
By replacing grid-gap with the required border rules for the various cells, the undesired lines are removed.