### PR TITLE
fix/make sure root org unit and relative period are sent to clear_ui reducer

### DIFF
--- a/packages/app/src/actions/__tests__/index.spec.js
+++ b/packages/app/src/actions/__tests__/index.spec.js
@@ -76,8 +76,7 @@ describe('index', () => {
             return store
                 .dispatch(fromActions.tDoLoadVisualization())
                 .then(() => {
-                    const actions = store.getActions();
-                    expect(actions).toEqual(expectedActions);
+                    expect(store.getActions()).toEqual(expectedActions);
                 });
         });
     });

--- a/packages/app/src/actions/__tests__/index.spec.js
+++ b/packages/app/src/actions/__tests__/index.spec.js
@@ -12,9 +12,15 @@ import { SET_CURRENT, CLEAR_CURRENT } from '../../reducers/current';
 import { SET_UI_FROM_VISUALIZATION, CLEAR_UI } from '../../reducers/ui';
 import { SET_LOAD_ERROR, CLEAR_LOAD_ERROR } from '../../reducers/loader';
 import { RECEIVED_SNACKBAR_MESSAGE } from '../../reducers/snackbar';
+import * as selectors from '../../reducers/settings';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
+
+const rootOrganisationUnit = 'abc123';
+const relativePeriod = 'xyzpdq';
+selectors.sGetRootOrgUnit = () => rootOrganisationUnit;
+selectors.sGetRelativePeriod = () => relativePeriod;
 
 describe('index', () => {
     describe('tDoLoadVisualization', () => {
@@ -48,7 +54,7 @@ describe('index', () => {
         });
 
         it('dispatches the correct actions when fetch visualization fails', () => {
-            const error = { code: '718', message: 'I am not a teapot' };
+            const error = 'I am not a teapot';
 
             api.apiFetchVisualization = () => Promise.reject(error);
 
@@ -56,7 +62,13 @@ describe('index', () => {
                 { type: SET_LOAD_ERROR, value: error },
                 { type: CLEAR_VISUALIZATION },
                 { type: CLEAR_CURRENT },
-                { type: CLEAR_UI },
+                {
+                    type: CLEAR_UI,
+                    value: {
+                        rootOrganisationUnit,
+                        relativePeriod,
+                    },
+                },
             ];
 
             const store = mockStore({});
@@ -64,7 +76,8 @@ describe('index', () => {
             return store
                 .dispatch(fromActions.tDoLoadVisualization())
                 .then(() => {
-                    expect(store.getActions()).toEqual(expectedActions);
+                    const actions = store.getActions();
+                    expect(actions).toEqual(expectedActions);
                 });
         });
     });
@@ -75,12 +88,18 @@ describe('index', () => {
                 { type: CLEAR_LOAD_ERROR },
                 { type: CLEAR_VISUALIZATION },
                 { type: CLEAR_CURRENT },
-                { type: CLEAR_UI },
+                {
+                    type: CLEAR_UI,
+                    value: {
+                        rootOrganisationUnit,
+                        relativePeriod,
+                    },
+                },
             ];
 
             const store = mockStore({});
 
-            fromActions.clearVisualization(store.dispatch);
+            fromActions.clearVisualization(store.dispatch, store.getState);
 
             expect(store.getActions()).toEqual(expectedActions);
         });

--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -18,6 +18,7 @@ import * as fromLoader from './loader';
 
 import { sGetCurrent } from '../reducers/current';
 import { sGetVisualization } from '../reducers/visualization';
+import { sGetRootOrgUnit, sGetRelativePeriod } from '../reducers/settings';
 
 import history from '../modules/history';
 
@@ -41,7 +42,7 @@ export const onError = (action, error) => {
 
 // visualization, current, ui
 
-export const tDoLoadVisualization = (type, id, settings) => async (
+export const tDoLoadVisualization = (type, id) => async (
     dispatch,
     getState
 ) => {
@@ -57,20 +58,26 @@ export const tDoLoadVisualization = (type, id, settings) => async (
     try {
         return onSuccess(await apiFetchVisualization(type, id));
     } catch (error) {
-        dispatch(fromLoader.acSetLoadError(error));
-        dispatch(fromVisualization.acClear());
-        dispatch(fromCurrent.acClear());
-        dispatch(fromUi.acClear());
+        clearVisualization(dispatch, getState, error);
 
         return onError('tDoLoadVisualization', error);
     }
 };
 
-export const clearVisualization = (dispatch, settings) => {
-    dispatch(fromLoader.acClearLoadError());
+export const clearVisualization = (dispatch, getState, error = null) => {
+    if (error) {
+        dispatch(fromLoader.acSetLoadError(error));
+    } else {
+        dispatch(fromLoader.acClearLoadError());
+    }
+
     dispatch(fromVisualization.acClear());
     dispatch(fromCurrent.acClear());
-    dispatch(fromUi.acClear(settings));
+
+    const rootOrganisationUnit = sGetRootOrgUnit(getState());
+    const relativePeriod = sGetRelativePeriod(getState());
+
+    dispatch(fromUi.acClear({ rootOrganisationUnit, relativePeriod }));
 };
 
 export const tDoRenameVisualization = (type, { name, description }) => (

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -25,11 +25,11 @@ import { sGetUi } from '../reducers/ui';
 export class App extends Component {
     unlisten = null;
 
-    loadVisualization = location => {
+    loadVisualization = async location => {
         const { store } = this.context;
 
         if (location.pathname.length > 1) {
-            store.dispatch(
+            await store.dispatch(
                 fromActions.tDoLoadVisualization(
                     this.props.apiObjectName,
                     location.pathname.slice(1),
@@ -37,7 +37,7 @@ export class App extends Component {
                 )
             );
         } else {
-            fromActions.clearVisualization(store.dispatch, this.props.settings);
+            fromActions.clearVisualization(store.dispatch, store.getState);
         }
     };
 
@@ -50,6 +50,7 @@ export class App extends Component {
         );
         store.dispatch(fromActions.fromUser.acReceivedUser(d2.currentUser));
         store.dispatch(fromActions.fromDimensions.tSetDimensions());
+
         store.dispatch(
             fromActions.fromMetadata.acAddMetadata({
                 ...defaultMetadata,

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -76,7 +76,7 @@ describe('reducer: ui', () => {
     it('CLEAR_UI should set the default state', () => {
         const settings = {
             rootOrganisationUnit: { id: 'ROOT_ORGUNIT' },
-            keyAnalysisRelativePeriod: 'LAST_12_MONTHS',
+            relativePeriod: 'LAST_12_MONTHS',
         };
 
         const actualState = reducer(
@@ -95,7 +95,7 @@ describe('reducer: ui', () => {
             itemsByDimension: {
                 ...DEFAULT_UI.itemsByDimension,
                 [ouId]: [settings.rootOrganisationUnit.id],
-                [peId]: [settings.keyAnalysisRelativePeriod],
+                [peId]: [settings.relativePeriod],
             },
         });
     });

--- a/packages/app/src/reducers/settings.js
+++ b/packages/app/src/reducers/settings.js
@@ -7,6 +7,7 @@ export const DEFAULT_SETTINGS = {
     keyAnalysisDigitGroupSeparator: 'SPACE',
     displayNameProperty: 'displayName',
     uiLocale: 'en',
+    rootOrganisationUnit: {},
 };
 
 export default (state = DEFAULT_SETTINGS, action) => {
@@ -28,5 +29,12 @@ export default (state = DEFAULT_SETTINGS, action) => {
 // Selectors
 
 export const sGetSettings = state => state.settings;
+
 export const sGetDisplayNameProperty = state =>
     sGetSettings(state).displayNameProperty;
+
+export const sGetRootOrgUnit = state =>
+    sGetSettings(state).rootOrganisationUnit;
+
+export const sGetRelativePeriod = state =>
+    sGetSettings(state).keyAnalysisRelativePeriod;

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -187,17 +187,14 @@ export default (state = DEFAULT_UI, action) => {
             };
         }
         case CLEAR_UI:
-            const {
-                rootOrganisationUnit,
-                keyAnalysisRelativePeriod,
-            } = action.value;
+            const { rootOrganisationUnit, relativePeriod } = action.value;
 
             return {
                 ...DEFAULT_UI,
                 itemsByDimension: {
                     ...DEFAULT_UI.itemsByDimension,
                     [ouId]: [rootOrganisationUnit.id],
-                    [peId]: [keyAnalysisRelativePeriod],
+                    [peId]: [relativePeriod],
                 },
                 parentGraphMap: {
                     ...DEFAULT_UI.parentGraphMap,


### PR DESCRIPTION
Bug was introduced where clear_ui reducer expected an argument, but not all action calls provided the argument