### PR TITLE
fix/datadimenision-dialog-styling

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-11-07T21:50:49.328Z\n"
-"PO-Revision-Date: 2018-11-07T21:50:49.328Z\n"
+"POT-Creation-Date: 2018-11-09T14:29:27.471Z\n"
+"PO-Revision-Date: 2018-11-09T14:29:27.471Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -126,6 +126,9 @@ msgid "Remove"
 msgstr ""
 
 msgid "None selected"
+msgstr ""
+
+msgid "Viewing interpretation from {{date}}"
 msgstr ""
 
 msgid "Update"

--- a/packages/app/src/assets/SelectedIcon.js
+++ b/packages/app/src/assets/SelectedIcon.js
@@ -2,16 +2,12 @@ import React from 'react';
 import { colors } from '../modules/colors';
 
 export const SelectedIcon = () => (
-    <div style={{ minWidth: 20 }}>
-        <div
-            style={{
-                position: 'relative',
-                top: '39%',
-                left: '40%',
-                backgroundColor: colors.accentPrimary,
-                height: 6,
-                width: 6,
-            }}
-        />
-    </div>
+    <div
+        style={{
+            backgroundColor: colors.accentPrimary,
+            height: 6,
+            width: 6,
+            margin: '0px 5px',
+        }}
+    />
 );

--- a/packages/app/src/assets/UnselectedIcon.js
+++ b/packages/app/src/assets/UnselectedIcon.js
@@ -2,16 +2,12 @@ import React from 'react';
 import { colors } from '../modules/colors';
 
 export const UnselectedIcon = () => (
-    <div style={{ minWidth: 20 }}>
-        <div
-            style={{
-                position: 'relative',
-                top: '30%',
-                left: '38%',
-                backgroundColor: colors.grey,
-                height: 6,
-                width: 6,
-            }}
-        />
-    </div>
+    <div
+        style={{
+            backgroundColor: colors.grey,
+            height: 6,
+            width: 6,
+            margin: '0px 5px 0px 5px',
+        }}
+    />
 );

--- a/packages/app/src/components/Dimensions/Dialogs/DataSelector/Detail.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DataSelector/Detail.js
@@ -13,6 +13,7 @@ export const Detail = ({ value, onDetailChange, detailAlternatives }) => (
             onChange={event => onDetailChange(event.target.value)}
             value={value}
             disableUnderline
+            SelectDisplayProps={{ style: styles.dropDown }}
         >
             {Object.entries(detailAlternatives).map(item => {
                 return (

--- a/packages/app/src/components/Dimensions/Dialogs/DataSelector/styles/DataTypesSelector.style.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DataSelector/styles/DataTypesSelector.style.js
@@ -15,7 +15,7 @@ export const styles = {
         color: colors.greyDark,
         fontSize: 13,
         fontWeight: 300,
-        paddingBottom: 15,
+        paddingBottom: 10,
     },
     dropDown: {
         outline: 'none',

--- a/packages/app/src/components/Dimensions/Dialogs/DataSelector/styles/Details.style.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DataSelector/styles/Details.style.js
@@ -9,7 +9,10 @@ export const styles = {
     titleText: {
         color: '#616161', // color
         fontSize: 12,
-        paddingBottom: 15,
+        paddingBottom: 10,
         fontWeight: 300,
+    },
+    dropDown: {
+        padding: 0,
     },
 };

--- a/packages/app/src/components/Dimensions/Dialogs/DataSelector/styles/Groups.style.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DataSelector/styles/Groups.style.js
@@ -21,7 +21,7 @@ export const styles = {
         color: colors.greyDark,
         fontSize: 13,
         fontWeight: 300,
-        paddingBottom: 15,
+        paddingBottom: 10,
     },
     dropDown: {
         padding: 0,

--- a/packages/app/src/components/Dimensions/Dialogs/Item.js
+++ b/packages/app/src/components/Dimensions/Dialogs/Item.js
@@ -24,9 +24,7 @@ export const Item = props => {
             onClick={highlightItem}
         >
             <Icon iconType={props.className} />
-            <span className={`${props.className}-label`}>
-                {props.displayName}
-            </span>
+            <span className={'item-label'}>{props.displayName}</span>
             <RemoveSelectedItemButton
                 showButton={props.className}
                 action={() => props.onRemoveItem(props.id)}

--- a/packages/app/src/components/Dimensions/Dialogs/styles/Dialog.css
+++ b/packages/app/src/components/Dimensions/Dialogs/styles/Dialog.css
@@ -1,6 +1,6 @@
 .dimension-item {
     display: flex;
-    margin: 5px;
+    margin: 2px;
 }
 
 .dimension-item:hover {
@@ -16,7 +16,7 @@
 }
 
 .data-dimension-list {
-    height: 340px;
+    height: 351px;
 }
 
 .generic-dimension-list {
@@ -72,16 +72,19 @@
 }
 
 .unselected-label {
-    padding: 0px 2px 1px 2px;
+    padding: 2px;
 }
-.selected-label {
-    padding-top: 2px;
+.item-label {
+    font-family: Roboto;
+    font-size: 14px;
+    padding: 2px;
 }
 
 .unselected-list-item,
 .selected-list-item {
     display: flex;
-    padding: 2px 5px 2px 2px;
+    align-items: center;
+    padding: 3px 8px 3px 3px;
     border-radius: 4px;
 }
 

--- a/packages/app/src/components/Dimensions/Dialogs/styles/DialogManager.style.js
+++ b/packages/app/src/components/Dimensions/Dialogs/styles/DialogManager.style.js
@@ -1,8 +1,5 @@
-import { colors } from '../../../../modules/colors';
-
 export const styles = {
     dialogActions: {
-        borderTop: `1px solid ${colors.blueGrey}`,
         margin: 0,
         paddingTop: 0,
         paddingBottom: 0,


### PR DESCRIPTION
This PR includes minor styling fixes for the data dimension dialog component:
- Select fields have been moved 5 px up
- border-top line on **DialogContent** is removed
- the list and list items have styling (mirrored with Period Selector component):
**ul** margin and padding: 0
**li** = margin: 2px
**div** = padding: 3px 8px 3px 3px
**span** = padding: 2px 