### PR TITLE
Use name or displayName for org units in metadata

### DIFF
--- a/packages/app/src/components/Dimensions/Dialogs/OrgUnitSelector/OrgUnitDimension.js
+++ b/packages/app/src/components/Dimensions/Dialogs/OrgUnitSelector/OrgUnitDimension.js
@@ -164,7 +164,7 @@ export class OrgUnitDimension extends Component {
             this.props.acAddMetadata({
                 [orgUnit.id]: {
                     id: orgUnit.id,
-                    name: orgUnit.name,
+                    name: orgUnit.name || orgUnit.displayName,
                     displayName: orgUnit.displayName,
                 },
             });


### PR DESCRIPTION
This PR includes:
- Fix for displaying selected org units counter in org units chip