### PR TITLE
Fix dnd in Firefox

### DIFF
--- a/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -28,8 +28,10 @@ class Axis extends React.Component {
     };
 
     onDrop = e => {
+        // Prevent redirect in Firefox
+        e.preventDefault();
+
         const { dimensionId, source } = decodeDataTransfer(e);
-        e.dataTransfer.clearData();
 
         this.props.onAddDimension({
             [dimensionId]: this.props.axisName,


### PR DESCRIPTION
- Data can only be cleared (writable) in the onDrag event, so we're no longer doing that in onDrop
- preventDefault must be called on the event in the onDrop handler, otherwise FF tries to redirect us