### PR TITLE
Fix/dimension context menu [DHIS2-5211]

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-11-14T09:24:36.331Z\n"
-"PO-Revision-Date: 2018-11-14T09:24:36.331Z\n"
+"POT-Creation-Date: 2018-11-14T17:41:53.471Z\n"
+"PO-Revision-Date: 2018-11-14T17:41:53.471Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -59,6 +59,12 @@ msgstr ""
 msgid "DESELECT ALL"
 msgstr ""
 
+msgid "Move to"
+msgstr ""
+
+msgid "Remove"
+msgstr ""
+
 msgid "Search dimensions"
 msgstr ""
 
@@ -108,12 +114,6 @@ msgid "Category"
 msgstr ""
 
 msgid "Filter"
-msgstr ""
-
-msgid "Move to"
-msgstr ""
-
-msgid "Remove"
 msgstr ""
 
 msgid "None selected"

--- a/packages/app/src/components/DimensionOptions/OptionsButton.js
+++ b/packages/app/src/components/DimensionOptions/OptionsButton.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import IconButton from '@material-ui/core/IconButton';
+import MoreHorizontalIcon from '../../assets/MoreHorizontalIcon';
+
+export const OptionsButton = ({ style, onClick }) => (
+    <IconButton style={style} onClick={onClick} tabIndex={0}>
+        <MoreHorizontalIcon />
+    </IconButton>
+);
+
+export default OptionsButton;

--- a/packages/app/src/components/Dimensions/DimensionItem.js
+++ b/packages/app/src/components/Dimensions/DimensionItem.js
@@ -5,13 +5,13 @@ import i18n from '@dhis2/d2-i18n';
 import DimensionLabel from './DimensionLabel';
 import DimensionOptions from './DimensionOptions';
 import RecommendedIcon from './RecommendedIcon';
-import { FIXED_DIMENSIONS } from '../../modules/fixedDimensions';
 import GenericDimensionIcon from '../../assets/GenericDimensionIcon';
-import { setDataTransfer } from '../../modules/dnd';
-import { styles } from './styles/DimensionItem.style';
-import { SOURCE_DIMENSIONS } from '../../modules/layout';
 import { sGetUiType } from '../../reducers/ui';
+import { setDataTransfer } from '../../modules/dnd';
+import { SOURCE_DIMENSIONS } from '../../modules/layout';
+import { FIXED_DIMENSIONS } from '../../modules/fixedDimensions';
 import { isYearOverYear } from '../../modules/chartTypes';
+import { styles } from './styles/DimensionItem.style';
 
 const peId = FIXED_DIMENSIONS.pe.id;
 
@@ -61,11 +61,14 @@ export class DimensionItem extends Component {
     render = () => {
         const Icon = this.getDimensionIcon();
         const Label = this.getDimensionType();
+        const containerStyle =
+            this.props.isSelected && !this.props.isDeactivated
+                ? { ...styles.listItem, ...styles.selectedListItem }
+                : styles.listItem;
 
         return (
             <li
-                key={this.props.id}
-                style={styles.itemContainer}
+                style={containerStyle}
                 onMouseOver={this.onMouseOver}
                 onMouseLeave={this.onMouseExit}
             >
@@ -79,21 +82,23 @@ export class DimensionItem extends Component {
                         id={this.props.id}
                         isSelected={this.props.isSelected}
                     />
-                    <DimensionOptions
-                        id={this.props.id}
-                        showButton={Boolean(
-                            this.state.mouseOver && !this.isDeactivated()
-                        )}
-                        onClose={this.onMouseExit}
-                    />
                 </DimensionLabel>
+                <DimensionOptions
+                    id={this.props.id}
+                    type={this.props.type}
+                    isSelected={this.props.isSelected}
+                    showButton={Boolean(
+                        this.state.mouseOver && !this.isDeactivated()
+                    )}
+                    onCloseMenu={this.onMouseExit}
+                />
             </li>
         );
     };
 }
 
 DimensionItem.propTypes = {
-    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     isSelected: PropTypes.bool.isRequired,
     type: PropTypes.string.isRequired,

--- a/packages/app/src/components/Dimensions/DimensionLabel.js
+++ b/packages/app/src/components/Dimensions/DimensionLabel.js
@@ -1,36 +1,24 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-
-import Close from '@material-ui/icons/Close';
-import {
-    acRemoveUiLayoutDimensions,
-    acSetUiActiveModalDialog,
-    acSetUiItems,
-} from '../../actions/ui';
-import { sGetUiLayout, sGetUiItems } from '../../reducers/ui';
-
+import { acSetUiActiveModalDialog } from '../../actions/ui';
 import { styles } from './styles/DimensionLabel.style';
-
-export const RemoveDimensionButton = ({ action }) => (
-    <button style={styles.deleteButton} onClick={action} tabIndex={0}>
-        <Close style={styles.deleteButtonIcon} />
-    </button>
-);
 
 export class DimensionLabel extends Component {
     static propTypes = {
-        openDialog: PropTypes.func.isRequired,
         id: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
-        isSelected: PropTypes.bool.isRequired,
         isDeactivated: PropTypes.bool.isRequired,
-        removeDimension: PropTypes.func.isRequired,
+        isSelected: PropTypes.bool.isRequired,
+        openDialog: PropTypes.func.isRequired,
         children: PropTypes.arrayOf(PropTypes.element).isRequired,
     };
 
     onLabelClick = () => {
-        this.props.openDialog(this.props.id);
+        if (!this.props.isDeactivated) {
+            this.props.openDialog(this.props.id);
+        }
     };
 
     onKeyPress = event => {
@@ -45,7 +33,7 @@ export class DimensionLabel extends Component {
             onClick={this.onLabelClick}
             onKeyPress={this.onKeyPress}
             tabIndex={0}
-            style={styles.unselected}
+            style={styles.label}
         >
             {this.props.children}
         </div>
@@ -54,29 +42,13 @@ export class DimensionLabel extends Component {
     render = () => {
         const Label = this.renderLabel();
 
-        const containerStyle =
-            this.props.isSelected && !this.props.isDeactivated
-                ? styles.selected
-                : styles.unselected;
-
-        return (
-            <div className="labelContainer" style={containerStyle}>
-                {Label}
-            </div>
-        );
+        return Label;
     };
 }
 
-const mapStateToProps = state => ({
-    currentLayout: sGetUiLayout(state),
-    items: sGetUiItems(state),
-});
-
 export default connect(
-    mapStateToProps,
+    null,
     {
         openDialog: id => acSetUiActiveModalDialog(id),
-        removeDimension: id => acRemoveUiLayoutDimensions(id),
-        setUiItems: items => acSetUiItems(items),
     }
 )(DimensionLabel);

--- a/packages/app/src/components/Dimensions/DimensionList.js
+++ b/packages/app/src/components/Dimensions/DimensionList.js
@@ -38,7 +38,7 @@ export class DimensionList extends Component {
                     : this.renderItem(listItem)
         );
 
-        return <ul style={styles.listContainer}>{dimensionsList}</ul>;
+        return <ul style={styles.list}>{dimensionsList}</ul>;
     };
 }
 

--- a/packages/app/src/components/Dimensions/DimensionOptions.js
+++ b/packages/app/src/components/Dimensions/DimensionOptions.js
@@ -1,61 +1,111 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import i18n from '@dhis2/d2-i18n';
 import MenuItem from '@material-ui/core/MenuItem';
+import OptionsButton from '../DimensionOptions/OptionsButton';
 import DropDown from './DropDown';
-import MoreHorizontalIcon from '../../assets/MoreHorizontalIcon';
 import {
     acAddUiLayoutDimensions,
-    acSetUiItems,
     acRemoveUiLayoutDimensions,
     acSetUiActiveModalDialog,
 } from '../../actions/ui';
 import { sGetUiLayout, sGetUiItems } from '../../reducers/ui';
-
-import { ADD_TO_LAYOUT_OPTIONS } from '../../modules/layout';
+import { axisLabels } from '../../modules/layout';
+import { isYearOverYear } from '../../modules/chartTypes';
 import { styles } from './styles/DimensionOptions.style';
 
-export const OptionsButton = ({ action }) => {
-    return (
-        <button style={styles.dropDownButton} onClick={action} tabIndex={1}>
-            <MoreHorizontalIcon />
-        </button>
-    );
-};
-
+const FILTER = 'filters';
 export class DimensionOptions extends Component {
     state = { anchorEl: null };
 
-    handleClick = event => {
-        event && event.stopPropagation();
+    onOpenMenu = event => {
         this.setState({ anchorEl: event.currentTarget });
     };
 
-    handleClose = event => {
-        event && event.stopPropagation();
+    onCloseMenu = () => {
         this.setState({ anchorEl: null });
-        this.props.onClose();
+        this.props.onCloseMenu();
     };
 
     addDimension = axisName => {
+        this.onCloseMenu();
         this.props.onAddDimension({ [this.props.id]: axisName });
-        this.handleClose();
-        setTimeout(() => this.props.openDialog(this.props.id), 10);
+
+        const items = this.props.items[this.props.id];
+        const hasNoItems = Boolean(!items || !items.length);
+
+        if (hasNoItems) {
+            this.props.openDialog(this.props.id);
+        }
     };
 
+    removeDimension = id => {
+        this.onCloseMenu();
+        this.props.removeDimension(id);
+    };
+
+    getAddToItems = () => [
+        isYearOverYear(this.props.type)
+            ? this.renderMenuItem(
+                  `add-to-${this.props.id}`,
+                  FILTER,
+                  this.addDimension,
+                  `Add to ${axisLabels[FILTER]}`
+              )
+            : Object.entries(axisLabels).map(([key, label]) =>
+                  this.renderMenuItem(
+                      `add-to-${key}`,
+                      key,
+                      this.addDimension,
+                      `${i18n.t('Add to')} ${label}`
+                  )
+              ),
+    ];
+
+    getMoveToItems = () => {
+        if (isYearOverYear(this.props.type)) {
+            return [];
+        }
+        const layout = Object.entries(this.props.currentLayout);
+
+        return layout
+            .filter(([axisKey, axisIds]) => !axisIds.includes(this.props.id))
+            .map(([axisKey, axisIds]) =>
+                this.renderMenuItem(
+                    `${this.props.id}-to-${axisKey}`,
+                    axisKey,
+                    this.addDimension,
+                    `${i18n.t('Move to')} ${axisLabels[axisKey]}`
+                )
+            );
+    };
+
+    getRemoveMenuItem = () =>
+        this.renderMenuItem(
+            `remove-${this.props.id}`,
+            this.props.id,
+            this.removeDimension,
+            i18n.t('Remove')
+        );
+
     getMenuItems = () =>
-        ADD_TO_LAYOUT_OPTIONS.map(option => (
-            <MenuItem
-                key={option.axisName}
-                onClick={() => this.addDimension(option.axisName)}
-            >
-                {option.name}
-            </MenuItem>
-        ));
+        this.props.isSelected
+            ? [...this.getMoveToItems(), this.getRemoveMenuItem()]
+            : this.getAddToItems();
+
+    renderMenuItem = (key, id, onClick, displayName) => (
+        <MenuItem key={key} onClick={() => onClick(id)}>
+            {displayName}
+        </MenuItem>
+    );
 
     renderOptionsOnHover = () =>
         this.props.showButton ? (
-            <OptionsButton action={this.handleClick} />
+            <OptionsButton
+                style={styles.dropDownButton}
+                onClick={this.onOpenMenu}
+            />
         ) : null;
 
     render = () => {
@@ -68,7 +118,7 @@ export class DimensionOptions extends Component {
                 <DropDown
                     id={this.props.id}
                     anchorEl={this.state.anchorEl}
-                    handleClose={this.handleClose}
+                    onClose={this.onCloseMenu}
                     menuItems={menuItems}
                 />
             </div>
@@ -78,10 +128,14 @@ export class DimensionOptions extends Component {
 
 DimensionOptions.propTypes = {
     id: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    isSelected: PropTypes.bool.isRequired,
+    currentLayout: PropTypes.object.isRequired,
+    items: PropTypes.object.isRequired,
     showButton: PropTypes.bool.isRequired,
     onAddDimension: PropTypes.func.isRequired,
     openDialog: PropTypes.func.isRequired,
-    onClose: PropTypes.func.isRequired,
+    onCloseMenu: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -95,6 +149,5 @@ export default connect(
         openDialog: id => acSetUiActiveModalDialog(id),
         onAddDimension: dimension => acAddUiLayoutDimensions(dimension),
         removeDimension: dimension => acRemoveUiLayoutDimensions(dimension),
-        setUiItems: items => acSetUiItems(items),
     }
 )(DimensionOptions);

--- a/packages/app/src/components/Dimensions/DropDown.js
+++ b/packages/app/src/components/Dimensions/DropDown.js
@@ -2,20 +2,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Menu from '@material-ui/core/Menu';
 
-export const DropDown = ({ id, anchorEl, handleClose, menuItems }) => (
+export const DropDown = ({ id, anchorEl, onClose, menuItems }) => (
     <Menu
         id={id}
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
-        onClose={handleClose}
+        onClose={onClose}
+        onExited={onClose}
     >
         {menuItems}
     </Menu>
 );
 
+DropDown.defaultProps = {
+    anchorEl: null,
+};
+
 DropDown.propTypes = {
     id: PropTypes.string.isRequired,
-    handleClose: PropTypes.func.isRequired,
+    anchorEl: PropTypes.object,
+    onClose: PropTypes.func.isRequired,
     menuItems: PropTypes.array.isRequired,
 };
 

--- a/packages/app/src/components/Dimensions/RecommendedIcon.js
+++ b/packages/app/src/components/Dimensions/RecommendedIcon.js
@@ -18,10 +18,6 @@ export class RecommendedIcon extends Component {
         this.setState({ anchorEl: null });
     };
 
-    checkIfRecommended = () =>
-        // this.props.isRecommended && !this.props.isSelected;
-        Boolean(this.props.isRecommended);
-
     showTooltip = () => (
         <Popper
             anchorEl={this.state.anchorEl}
@@ -39,7 +35,7 @@ export class RecommendedIcon extends Component {
             ? this.showTooltip()
             : null;
 
-        return this.checkIfRecommended() ? (
+        return Boolean(this.props.isRecommended) ? (
             <div style={styles.recommendedWrapper}>
                 <div
                     style={styles.recommendedIcon}

--- a/packages/app/src/components/Dimensions/__tests__/DimensionItem.spec.js
+++ b/packages/app/src/components/Dimensions/__tests__/DimensionItem.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { DimensionItem } from '../DimensionItem';
 import DimensionLabel from '../DimensionLabel';
+import { styles } from '../styles/DimensionItem.style';
 import DimensionOptions from '../DimensionOptions';
 import RecommendedIcon from '../RecommendedIcon';
 
@@ -55,5 +56,16 @@ describe('The DimensionItem component ', () => {
         const dimOptions = dimItem().find(DimensionOptions);
 
         expect(dimOptions.length).toEqual(1);
+    });
+
+    it('renders a DimensionLabel with additional styling properties if props isSelected = true', () => {
+        props.isSelected = true;
+
+        const selectedStyle = {
+            ...styles.listItem,
+            ...styles.selectedListItem,
+        };
+
+        expect(dimItem().props().style).toEqual(selectedStyle);
     });
 });

--- a/packages/app/src/components/Dimensions/__tests__/DimensionLabel.spec.js
+++ b/packages/app/src/components/Dimensions/__tests__/DimensionLabel.spec.js
@@ -13,12 +13,12 @@ describe('The DimensionList component ', () => {
     };
     beforeEach(() => {
         props = {
-            openDialog: jest.fn(),
             id: 'idstring',
+            type: 'COLUMN',
+            name: 'labelname',
             isSelected: false,
             isDeactivated: false,
-            name: 'labelname',
-            removeDimension: jest.fn(),
+            openDialog: jest.fn(),
             children: [],
         };
         shallowDimLabel = undefined;
@@ -42,5 +42,36 @@ describe('The DimensionList component ', () => {
             .first();
 
         expect(wrappingDiv.children()).toEqual(dimLabel().children());
+    });
+
+    it('should open a dialog when the label is presssed', () => {
+        dimLabel()
+            .props()
+            .onClick();
+
+        expect(props.openDialog).toHaveBeenCalled();
+    });
+
+    it('should open a dialog when user press the "Enter" key on a focused DimensionLabel', () => {
+        const mockEvent = {
+            key: 'Enter',
+            ctrlKey: false,
+        };
+
+        dimLabel()
+            .props()
+            .onKeyPress(mockEvent);
+
+        expect(props.openDialog).toHaveBeenCalled();
+    });
+
+    it('should not open the Period Selector dialog if current layout is equal to YearOnYear/ prop isDeactivated = true', () => {
+        props.isDeactivated = true;
+
+        dimLabel()
+            .props()
+            .onClick();
+
+        expect(props.openDialog).toHaveBeenCalledTimes(0);
     });
 });

--- a/packages/app/src/components/Dimensions/__tests__/DimensionOptions.spec.js
+++ b/packages/app/src/components/Dimensions/__tests__/DimensionOptions.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import MenuItem from '@material-ui/core/MenuItem';
 import { DimensionOptions } from '../DimensionOptions';
 import { OptionsButton } from '../DimensionOptions';
 import DropDown from '../DropDown';
@@ -17,10 +18,14 @@ describe('The DimensionOptions component ', () => {
     beforeEach(() => {
         props = {
             id: 'IdString',
+            type: 'COLLUMN',
+            isSelected: false,
+            currentLayout: {},
+            items: {},
             showButton: false,
             onAddDimension: jest.fn(),
             openDialog: jest.fn(),
-            onClose: jest.fn(),
+            onCloseMenu: jest.fn(),
         };
         shallowDimOptions = undefined;
     });
@@ -36,5 +41,20 @@ describe('The DimensionOptions component ', () => {
         const dropDown = dimOptions().find(DropDown);
 
         expect(dropDown.length).toEqual(1);
+    });
+
+    it.only('passes only 1 element ("Add to Filter", or "Remove") as menuItems to <DropDown /> if prop isSelected is true and prop type is equal to YearOnYear', () => {
+        props.isSelected = true;
+        props.type = 'YEAR_OVER_YEAR_LINE';
+
+        const dropDown = dimOptions().find(DropDown);
+
+        expect(dropDown.dive().find(MenuItem).length).toEqual(1);
+    });
+
+    it.only('passes 3 elements ("Move to X" + "Remove" or "Add to X") as menuItems if prop "type" is NOT equal to YearOnYear', () => {
+        const dropDown = dimOptions().find(DropDown);
+
+        expect(dropDown.dive().find(MenuItem).length).toEqual(3);
     });
 });

--- a/packages/app/src/components/Dimensions/styles/DimensionItem.style.js
+++ b/packages/app/src/components/Dimensions/styles/DimensionItem.style.js
@@ -14,10 +14,14 @@ export const styles = {
         cursor: 'auto',
         color: colors.grey,
     },
-    itemContainer: {
+    listItem: {
         display: 'flex',
         paddingTop: 2,
         paddingBottom: 2,
+    },
+    selectedListItem: {
+        backgroundColor: colors.accentSecondaryTransparent,
+        fontWeight: 500,
     },
     fixedDimensionIcon: {
         paddingLeft: '6px',

--- a/packages/app/src/components/Dimensions/styles/DimensionLabel.style.js
+++ b/packages/app/src/components/Dimensions/styles/DimensionLabel.style.js
@@ -1,31 +1,5 @@
-import { colors } from '../../../modules/colors';
-
 export const styles = {
-    unselected: {
+    label: {
         display: 'flex',
-        borderRadius: '2px',
-    },
-    selected: {
-        backgroundColor: colors.accentSecondaryTransparent,
-        display: 'flex',
-        borderRadius: '2px',
-        width: '100%',
-        fontWeight: 500,
-    },
-    deleteButton: {
-        border: 'none',
-        background: 'none',
-        marginLeft: '6px',
-        marginRight: '4px',
-        padding: '0px',
-        width: '12px',
-    },
-    deleteButtonIcon: {
-        fill: colors.blue,
-        cursor: 'pointer',
-        position: 'relative',
-        top: '1px',
-        height: '13px',
-        width: '10px',
     },
 };

--- a/packages/app/src/components/Dimensions/styles/DimensionList.style.js
+++ b/packages/app/src/components/Dimensions/styles/DimensionList.style.js
@@ -1,5 +1,5 @@
 export const styles = {
-    listContainer: {
+    list: {
         height: 'calc(100vh - 157px)',
         overflow: 'auto',
         padding: '0 8px 0 0',

--- a/packages/app/src/modules/layout.js
+++ b/packages/app/src/modules/layout.js
@@ -24,6 +24,12 @@ export const ADD_TO_LAYOUT_OPTIONS = [
     { axisName: 'filters', name: i18n.t('Add to filter') },
 ];
 
+export const axisLabels = {
+    columns: i18n.t('Series'),
+    rows: i18n.t('Category'),
+    filters: i18n.t('Filter'),
+};
+
 // Layout utility functions
 
 // Accepts: dimensionId, [itemIds]


### PR DESCRIPTION
This PR includes fixes to the context menu for dimensions in  left pane:

**if current layout is Year on Year, menu shows:**
- unselected: "Add to filter"
- selected: "Remove"

**if current layout is not Year on Year, context menu shows:**
- unselected: "Add to series/category/filter"
- selected: "Move to [layout not currently selected]" + "Remove"

I've moved the Context menu component outside the dimension label (instead of being rendered as a child) to not cause any propagation issues.

**Theres additional refactoring in this PR (apologies):**
- Removing unused styling after the new UI change
- Removing unused props.
- Removing unused code (e.g RemoveDimensionButton)
- Adding more test cases and some changes to existing ones.



**Additional Notes:**
- The context menu dismounts a bit slow (because of animation)? resulting in the menu to render  "Move To" during onClose/dismount.

Sometimes, If i spam the MenuItem, the alternatives have changed from, "add to" to "move to".
If i double click fast enough, the dimension can potentially be added to the given layout, and then the second click will move it to the alternative that is being re-rendered (try it yourself).

Im open to feedback/pointers to fix this (might happen often on wooden computers).
A work-around could be to assign the onDoubleClick as well (?), or override some transition styling on the Menu component? 

Ive tried using the other callbacks from the Material-UI's Menu component (onExit, onExiting etc.).
And tried to have a dedicated boolean instead of the anchorEl for the "open" prop. But the same behaviour persists.