### PR TITLE
chore/reduce component re-renders by optimizing gets from store

### DIFF
--- a/packages/app/src/components/Dimensions/Dialogs/DataDimension/DataDimension.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DataDimension/DataDimension.js
@@ -17,7 +17,7 @@ import {
     apiFetchGroups,
     apiFetchAlternatives,
 } from '../../../../api/dimensions';
-import { sGetUiItems } from '../../../../reducers/ui';
+import { sGetUiItemsByDimension } from '../../../../reducers/ui';
 import { sGetDisplayNameProperty } from '../../../../reducers/settings';
 
 import {
@@ -265,7 +265,7 @@ DataDimension.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    selectedItems: sGetUiItems(state)[dxId] || [],
+    selectedItems: sGetUiItemsByDimension(state, dxId),
     displayNameProp: sGetDisplayNameProperty(state),
 });
 

--- a/packages/app/src/components/Dimensions/Dialogs/DialogManager.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DialogManager.js
@@ -18,7 +18,10 @@ import AddToLayoutButton from '../../AddToLayoutButton/AddToLayoutButton';
 import { acSetUiActiveModalDialog } from '../../../actions/ui';
 import { acSetRecommendedIds } from '../../../actions/recommendedIds';
 
-import { sGetUiItems, sGetUiActiveModalDialog } from '../../../reducers/ui';
+import {
+    sGetUiItemsByDimension,
+    sGetUiActiveModalDialog,
+} from '../../../reducers/ui';
 import { sGetDimensions } from '../../../reducers/dimensions';
 
 import { apiFetchRecommendedIds } from '../../../api/dimensions';
@@ -98,8 +101,8 @@ DialogManager.defaultProps = {
 const mapStateToProps = state => ({
     dialogId: sGetUiActiveModalDialog(state),
     dimensions: sGetDimensions(state),
-    dxIds: sGetUiItems(state)[dxId] || [],
-    ouIds: sGetUiItems(state)[ouId] || [],
+    dxIds: sGetUiItemsByDimension(state, dxId),
+    ouIds: sGetUiItemsByDimension(state, ouId),
 });
 
 export default connect(

--- a/packages/app/src/components/Dimensions/Dialogs/DynamicDimension/DynamicDimension.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DynamicDimension/DynamicDimension.js
@@ -128,7 +128,7 @@ export class DynamicDimension extends Component {
 }
 
 DynamicDimension.propTypes = {
-    selectedItems: PropTypes.array,
+    selectedItems: PropTypes.array.isRequired,
     addItems: PropTypes.func.isRequired,
     setItems: PropTypes.func.isRequired,
     removeItems: PropTypes.func.isRequired,

--- a/packages/app/src/components/Dimensions/Dialogs/DynamicDimension/DynamicDimension.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DynamicDimension/DynamicDimension.js
@@ -12,7 +12,7 @@ import SelectedItems from '../SelectedItems';
 
 import { apiFetchItemsByDimension } from '../../../../api/dimensions';
 
-import { sGetUiItems } from '../../../../reducers/ui';
+import { sGetUiItemsByDimension } from '../../../../reducers/ui';
 import {
     acRemoveUiItems,
     acAddUiItems,
@@ -22,6 +22,8 @@ import { acAddMetadata } from '../../../../actions/metadata';
 
 import { styles } from './styles/DynamicDimension.style';
 import '../styles/Dialog.css';
+
+const emptyItems = [];
 
 export class DynamicDimension extends Component {
     state = {
@@ -126,7 +128,7 @@ export class DynamicDimension extends Component {
 }
 
 DynamicDimension.propTypes = {
-    selectedItems: PropTypes.array.isRequired,
+    selectedItems: PropTypes.array,
     addItems: PropTypes.func.isRequired,
     setItems: PropTypes.func.isRequired,
     removeItems: PropTypes.func.isRequired,
@@ -134,7 +136,8 @@ DynamicDimension.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-    selectedItems: sGetUiItems(state)[ownProps.dialogId] || [],
+    selectedItems:
+        sGetUiItemsByDimension(state, ownProps.dialogId) || emptyItems,
 });
 
 export default connect(

--- a/packages/app/src/components/Dimensions/Dialogs/OrgUnitDimension/OrgUnitDimension.js
+++ b/packages/app/src/components/Dimensions/Dialogs/OrgUnitDimension/OrgUnitDimension.js
@@ -12,7 +12,10 @@ import {
     removeOrgUnitLastPathSegment,
 } from '@dhis2/d2-ui-org-unit-dialog';
 
-import { sGetUi } from '../../../../reducers/ui';
+import {
+    sGetUiItemsByDimension,
+    sGetUiParentGraphMap,
+} from '../../../../reducers/ui';
 import { acSetCurrentFromUi } from '../../../../actions/current';
 import { acAddMetadata } from '../../../../actions/metadata';
 import { sGetMetadata } from '../../../../reducers/metadata';
@@ -79,9 +82,7 @@ export class OrgUnitDimension extends Component {
         const levelIds = event.target.value.filter(id => !!id);
 
         this.setOuUiItems([
-            ...this.props.ui.itemsByDimension[ouId].filter(
-                id => !isLevelId(id)
-            ),
+            ...this.props.ouItems.filter(id => !isLevelId(id)),
             ...levelIds.map(
                 id => `${LEVEL_ID_PREFIX}-${this.props.metadata[id].level}`
             ),
@@ -92,9 +93,7 @@ export class OrgUnitDimension extends Component {
         const optionIds = event.target.value.filter(id => !!id);
 
         this.setOuUiItems([
-            ...this.props.ui.itemsByDimension[ouId].filter(
-                id => !isGroupId(id)
-            ),
+            ...this.props.ouItems.filter(id => !isGroupId(id)),
             ...optionIds.map(id => `${GROUP_ID_PREFIX}-${id}`),
         ]);
     };
@@ -142,9 +141,9 @@ export class OrgUnitDimension extends Component {
 
     handleOrgUnitClick = (event, orgUnit) => {
         const selected = getOrgUnitsFromIds(
-            this.props.ui.itemsByDimension[ouId],
+            this.props.ouItems,
             this.props.metadata,
-            this.props.ui.parentGraphMap
+            this.props.parentGraphMap
         );
 
         if (selected.some(ou => ou.path === orgUnit.path)) {
@@ -178,19 +177,19 @@ export class OrgUnitDimension extends Component {
         if (checked) {
             if (!this.state.selected.length) {
                 this.setState({
-                    selected: this.props.ui.itemsByDimension[ouId].slice(),
+                    selected: this.props.ouItems.slice(),
                 });
             }
 
             this.setOuUiItems([
-                ...this.props.ui.itemsByDimension[ouId].filter(id =>
+                ...this.props.ouItems.filter(id =>
                     this.userOrgUnitIds.includes(id)
                 ),
                 event.target.name,
             ]);
         } else {
             if (
-                this.props.ui.itemsByDimension[ouId].length === 1 &&
+                this.props.ouItems.length === 1 &&
                 this.state.selected.length > 0
             ) {
                 this.setOuUiItems(this.state.selected);
@@ -208,11 +207,11 @@ export class OrgUnitDimension extends Component {
     };
 
     render = () => {
-        const ids = this.props.ui.itemsByDimension[ouId];
+        const ids = this.props.ouItems;
         const selected = getOrgUnitsFromIds(
             ids,
             this.props.metadata,
-            this.props.ui.parentGraphMap,
+            this.props.parentGraphMap,
             this.userOrgUnitIds
         );
         const userOrgUnits = this.getUserOrgUnitsFromIds(ids);
@@ -248,7 +247,8 @@ export class OrgUnitDimension extends Component {
 }
 
 OrgUnitDimension.propTypes = {
-    ui: PropTypes.object.isRequired,
+    ouItems: PropTypes.array.isRequired,
+    parentGraphMap: PropTypes.object.isRequired,
     metadata: PropTypes.object.isRequired,
     acAddUiItems: PropTypes.func.isRequired,
     acRemoveUiItems: PropTypes.func.isRequired,
@@ -259,7 +259,8 @@ OrgUnitDimension.propTypes = {
 };
 
 const mapStateToProps = state => ({
-    ui: sGetUi(state),
+    ouItems: sGetUiItemsByDimension(state, ouId),
+    parentGraphMap: sGetUiParentGraphMap(state),
     metadata: sGetMetadata(state),
 });
 

--- a/packages/app/src/components/Dimensions/Dialogs/OrgUnitDimension/__tests__/OrgUnitDimension.spec.js
+++ b/packages/app/src/components/Dimensions/Dialogs/OrgUnitDimension/__tests__/OrgUnitDimension.spec.js
@@ -34,11 +34,8 @@ describe('The OrgUnitDimension component ', () => {
 
     beforeEach(() => {
         props = {
-            ui: {
-                itemsByDimension: {
-                    ou: [],
-                },
-            },
+            ouItems: [],
+            parentGraphMap: {},
             metadata: {},
             acAddUiItems: jest.fn(),
             acRemoveUiItems: jest.fn(),

--- a/packages/app/src/components/Dimensions/DimensionLabel.js
+++ b/packages/app/src/components/Dimensions/DimensionLabel.js
@@ -7,7 +7,7 @@ import {
     acRemoveUiLayoutDimensions,
     acSetUiActiveModalDialog,
 } from '../../actions/ui';
-import { sGetUiLayout, sGetUiItems } from '../../reducers/ui';
+import { sGetUiLayout } from '../../reducers/ui';
 
 import { styles } from './styles/DimensionLabel.style';
 
@@ -68,7 +68,6 @@ export class DimensionLabel extends Component {
 
 const mapStateToProps = state => ({
     currentLayout: sGetUiLayout(state),
-    items: sGetUiItems(state),
 });
 
 export default connect(

--- a/packages/app/src/components/Dimensions/DimensionOptions.js
+++ b/packages/app/src/components/Dimensions/DimensionOptions.js
@@ -9,7 +9,7 @@ import {
     acRemoveUiLayoutDimensions,
     acSetUiActiveModalDialog,
 } from '../../actions/ui';
-import { sGetUiLayout, sGetUiItems } from '../../reducers/ui';
+import { sGetUiLayout } from '../../reducers/ui';
 
 import { ADD_TO_LAYOUT_OPTIONS } from '../../modules/layout';
 import { styles } from './styles/DimensionOptions.style';
@@ -85,7 +85,6 @@ DimensionOptions.propTypes = {
 
 const mapStateToProps = state => ({
     currentLayout: sGetUiLayout(state),
-    items: sGetUiItems(state),
 });
 
 export default connect(

--- a/packages/app/src/components/Layout/Chip.js
+++ b/packages/app/src/components/Layout/Chip.js
@@ -6,13 +6,15 @@ import Menu from './Menu';
 import Tooltip from './Tooltip';
 import { setDataTransfer } from '../../modules/dnd';
 import { sGetDimensions } from '../../reducers/dimensions';
-import { sGetUiItems } from '../../reducers/ui';
+import { sGetUiItemsByDimension } from '../../reducers/ui';
 import { styles } from './styles/Chip.style';
 import { FIXED_DIMENSIONS } from '../../modules/fixedDimensions';
 import DynamicDimensionIcon from '../../assets/DynamicDimensionIcon';
 import { sGetMetadata } from '../../reducers/metadata';
 
 const TOOLTIP_ENTER_DELAY = 500;
+
+const emptyItems = [];
 
 class Chip extends React.Component {
     state = {
@@ -122,7 +124,7 @@ class Chip extends React.Component {
 
 const mapStateToProps = (state, ownProps) => ({
     dimensionName: sGetDimensions(state)[ownProps.dimensionId].name,
-    items: sGetUiItems(state)[ownProps.dimensionId] || [],
+    items: sGetUiItemsByDimension(state, ownProps.dimensionId) || emptyItems,
     metadata: sGetMetadata(state),
 });
 

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -5,13 +5,15 @@ import Popper from '@material-ui/core/Popper';
 import Paper from '@material-ui/core/Paper';
 import i18n from '@dhis2/d2-i18n';
 
-import { sGetUiItems } from '../../reducers/ui';
+import { sGetUiItemsByDimension } from '../../reducers/ui';
 import { sGetMetadata } from '../../reducers/metadata';
 import { styles } from './styles/Tooltip.style';
 
 const labels = {
     noneSelected: i18n.t('None selected'),
 };
+
+const emptyItems = [];
 
 export class Tooltip extends React.Component {
     renderTooltip = names => (
@@ -37,7 +39,7 @@ export class Tooltip extends React.Component {
     render() {
         const { itemIds, metadata } = this.props;
 
-        const names = (itemIds || []).length
+        const names = itemIds.length
             ? itemIds.map(id => (metadata[id] ? metadata[id].name : id))
             : [labels.noneSelected];
 
@@ -52,7 +54,7 @@ Tooltip.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-    itemIds: sGetUiItems(state)[ownProps.dimensionId],
+    itemIds: sGetUiItemsByDimension(state, ownProps.dimensionId) || emptyItems,
     metadata: sGetMetadata(state),
 });
 

--- a/packages/app/src/components/Layout/__tests__/Tooltip.spec.js
+++ b/packages/app/src/components/Layout/__tests__/Tooltip.spec.js
@@ -19,7 +19,7 @@ describe('Tooltip', () => {
             anchorEl: {},
             dimensionId: 'abc',
             metadata: {},
-            itemIds: null,
+            itemIds: [],
         };
         shallowTooltip = undefined;
     });

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -43,7 +43,11 @@ export const DEFAULT_UI = {
         rows: [peId],
         filters: [ouId],
     },
-    itemsByDimension: {},
+    itemsByDimension: {
+        [dxId]: [],
+        [ouId]: [],
+        [peId]: [],
+    },
     yearOverYearSeries: ['THIS_YEAR', 'LAST_YEAR'],
     yearOverYearCategory: ['MONTHS_THIS_YEAR'],
     parentGraphMap: {},
@@ -240,6 +244,10 @@ export const sGetUiType = state => sGetUi(state).type;
 export const sGetUiOptions = state => sGetUi(state).options;
 export const sGetUiLayout = state => sGetUi(state).layout;
 export const sGetUiItems = state => sGetUi(state).itemsByDimension;
+
+export const sGetUiItemsByDimension = (state, dimension) =>
+    sGetUiItems(state)[dimension] || DEFAULT_UI.itemsByDimension[dimension];
+
 export const sGetUiYearOverYearSeries = state =>
     sGetUi(state).yearOverYearSeries;
 export const sGetUiYearOverYearCategory = state =>


### PR DESCRIPTION
In OrgUnitDimension, get only the properties actually needed
In the other files, use empty array from a variable as default, rather than [], which is a new reference and will trigger an update every time.