### PR TITLE
DHIS2-5281: fix problem with LoadingMask which prevented chart to load

### DIFF
--- a/packages/app/src/components/Visualization/BlankCanvas.js
+++ b/packages/app/src/components/Visualization/BlankCanvas.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import LoadingMask from '../../widgets/LoadingMask';
@@ -11,11 +11,11 @@ export const defaultCanvasMessage =
     'Create a new visualization by adding dimensions to the layout';
 
 export const BlankCanvas = ({ loading, error }) => {
-    let canvasContent = <p style={styles.title}>{defaultCanvasMessage}</p>;
+    let canvasContent = (
+        <p style={styles.title}>{i18n.t(defaultCanvasMessage)}</p>
+    );
 
-    if (loading) {
-        canvasContent = <LoadingMask />;
-    } else if (error) {
+    if (error) {
         canvasContent = (
             <div>
                 <img src={chartErrorImg} alt={i18n.t('Chart error')} />
@@ -28,9 +28,12 @@ export const BlankCanvas = ({ loading, error }) => {
     }
 
     return (
-        <div id={visContainerId} style={styles.outer}>
-            <div style={styles.inner}>{canvasContent}</div>
-        </div>
+        <Fragment>
+            {loading ? <LoadingMask /> : null}
+            <div id={visContainerId} style={styles.outer}>
+                <div style={styles.inner}>{canvasContent}</div>
+            </div>
+        </Fragment>
     );
 };
 


### PR DESCRIPTION
The error in IE11 was a DOM not found error.
My explanation is that the LoadingMask component was removed when
Highcharts replaces the content of the div with the chart.
React/IE11 does not seem to like that.
Solution is to put the LoadingMask component outside the div used by
Highcharts, LoadingMask is still controlled by the loading state prop.