### PR TITLE
Check period items existence in metadata before rendering

### DIFF
--- a/packages/app/src/components/Dimensions/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/packages/app/src/components/Dimensions/Dialogs/PeriodDimension/PeriodDimension.js
@@ -44,10 +44,12 @@ export class PeriodDimension extends Component {
     };
 
     getSelectedPeriods = () => {
-        return this.props.ui.itemsByDimension[peId].map(item => ({
-            id: item,
-            name: this.props.metadata[item].name,
-        }));
+        return this.props.ui.itemsByDimension[peId]
+            .filter(item => this.props.metadata[item])
+            .map(item => ({
+                id: item,
+                name: this.props.metadata[item].name,
+            }));
     };
 
     render = () => {


### PR DESCRIPTION
This PR includes adjusting periods dimension component for lazy mount approach.

The error happens because `ui.itemsByDimension[pe]` is populated by ids before metadata,
that causes undefined error while rendering.

Steps to reproduce the bug (make sure you have latest version of period selector component):
- Create and save custom AO with couple of fixed periods.
- Open another existing AO
- Refresh the page
- Open and close periods dimension dialog (so that it would stay mounted)
- Open the AO we created in the first step
- App crashes