### PR TITLE
Cancel requests

### DIFF
--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -27,11 +27,9 @@ import { sGetVisualization } from '../../reducers/visualization';
 import { computeGenericPeriodNames } from '../../modules/analytics';
 
 export class Visualization extends Component {
-    constructor(props) {
-        super(props);
+    // renderId = null;
 
-        this.recreateChart = Function.prototype;
-    }
+    recreateChart = Function.prototype;
 
     addResizeHandler = () => {
         window.addEventListener(
@@ -46,13 +44,16 @@ export class Visualization extends Component {
         this.addResizeHandler();
 
         if (this.props.current) {
-            this.renderVisualization(this.props.current);
+            // this.renderId = 1;
+            this.renderVisualization(this.props.current, this.renderId);
         }
     }
 
     componentDidUpdate(prevProps) {
+        // new chart
         if (this.props.current !== prevProps.current) {
             this.renderVisualization(this.props.current);
+            return;
         }
 
         // avoid redrawing the chart if the interpretation content remains the same
@@ -67,14 +68,17 @@ export class Visualization extends Component {
                 : this.props.current;
 
             this.renderVisualization(vis);
+            return;
         }
 
+        // open sidebar
         if (this.props.rightSidebarOpen !== prevProps.rightSidebarOpen) {
             this.recreateChart();
+            return;
         }
     }
 
-    renderVisualization = async vis => {
+    renderVisualization = async (vis, renderId) => {
         const { interpretation } = this.props;
 
         const options = getOptionsForRequest().reduce(
@@ -94,6 +98,11 @@ export class Visualization extends Component {
         }
 
         try {
+            // debounce the process
+            // if (renderId !== this.renderId) {
+            //     return;
+            // }
+
             this.props.acClearLoadError();
             this.props.acSetLoading(true);
 

--- a/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
+++ b/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
@@ -247,7 +247,11 @@ describe('Visualization', () => {
         vis.instance().recreateChart = recreateChartFn;
 
         it('triggers a reflow when rightSidebarOpen prop changes', () => {
-            vis.setProps({ ...props, rightSidebarOpen: true });
+            vis.setProps({
+                ...props,
+                current: undefined,
+                rightSidebarOpen: true,
+            });
 
             expect(recreateChartFn).toHaveBeenCalled();
 


### PR DESCRIPTION
Gives each process (by process I mean everything that happens from the update button is clicked to the chart is rendered) an id. When a process starts we keep this id as the renderId (active id). Then in the middle of the process we check if the process id is still the active id or if it has been replaced by a new process. We check that three places:
- before fetching analytics data from the server
- before rendering the chart
- before showing an error message if the server request failed

If the process id is no longer the active id we cancel the process so that is doesn't conflict with the new process or do unnecessary work/server requests.