### PR TITLE
Fix/select deselect buttons in IE11

### DIFF
--- a/packages/app/src/components/Dimensions/Dialogs/styles/buttons.style.js
+++ b/packages/app/src/components/Dimensions/Dialogs/styles/buttons.style.js
@@ -3,7 +3,9 @@ import { colors } from '../../../../modules/colors';
 export const styles = {
     arrowButton: {
         padding: '0px',
+        minWidth: '40px',
         width: '40px',
+        minHeight: '36px',
         height: '36px',
         backgroundColor: colors.white,
     },

--- a/packages/app/src/components/Dimensions/Dialogs/styles/buttons.style.js
+++ b/packages/app/src/components/Dimensions/Dialogs/styles/buttons.style.js
@@ -3,8 +3,8 @@ import { colors } from '../../../../modules/colors';
 export const styles = {
     arrowButton: {
         padding: '0px',
-        minWidth: '40px',
-        minHeight: '36px',
+        width: '40px',
+        height: '36px',
         backgroundColor: colors.white,
     },
     arrowIcon: {


### PR DESCRIPTION
This PR includes setting height, and minHeight (redundant) to the select / deselect buttons.
I inspected the element in IE11, minHeight is not registered.
It is sufficient with only specifying height /width but to be sure i left the minHeight/ minWidth value in there.