### PR TITLE
fix/add url-polyfill for URLSearchParams

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -79,6 +79,7 @@
         "sw-precache-webpack-plugin": "0.11.5",
         "ui": "github:d2-ci/ui#a14c74a62a5baefe84786282b145ba20e19bc907",
         "url-loader": "0.6.2",
+        "url-polyfill": "^1.1.2",
         "webpack": "^3.10.0",
         "webpack-dev-server": "^2.9.4",
         "webpack-manifest-plugin": "2.0.3",

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { MuiThemeProvider } from '@material-ui/core/styles';
+import 'url-polyfill';
 import history from './modules/history';
 
 import { init as d2Init, config, getUserSettings } from 'd2';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12327,6 +12327,11 @@ url-parse@^1.1.8, url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url-polyfill@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.2.tgz#88cd1aa29e6771f13baa29ea58ebf38bb0e14420"
+  integrity sha512-ysIPB51YdpgGYcAJgY64QbBLQCR1DhR/oemwAMKy6yRuMRd1eWRxTHxqv9ZvHb+Jv8xyEg9MIBg42q0ds6tYLg==
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
In IE, opening a file from the file->menu crashes. This was due to URLSearchParams not being supported in IE. Solution was to add the url-polyfill. Note that URLSearchParams is not actually in the File-menu component. It is in the data-visualizer DownloadMenu component.

url-polyfill is used in maps-app to solve the same problem.