### PR TITLE
fix/hover-effect-selected-dimensions [DHIS2-5266]

### DIFF
--- a/packages/app/src/components/Layout/styles/Menu.style.js
+++ b/packages/app/src/components/Layout/styles/Menu.style.js
@@ -2,6 +2,7 @@ export const styles = {
     icon: {
         width: 22,
         height: 22,
+        background: 'none',
         color: '#000',
         padding: 0,
     },


### PR DESCRIPTION
This PR includes:
adding style
```
background: 'none'
```

to the Layout's IconButton  in order to remove hover effect on the MoreHorizontalIcon for selected dimensions.