### PR TITLE
Fix/hover effect selected dimensions v31

### DIFF
--- a/packages/app/src/components/Layout/styles/Menu.style.js
+++ b/packages/app/src/components/Layout/styles/Menu.style.js
@@ -2,6 +2,7 @@ export const styles = {
     icon: {
         width: 22,
         height: 22,
+        background: 'none',
         color: '#000',
         padding: 0,
     },


### PR DESCRIPTION
Set bakcground: 'none'  to IconButton in order to remove hover effect on MoreHorizontalIcon in Layout 