### PR TITLE
check if groupId is selected and render displayName instead of always…

### DIFF
--- a/packages/app/src/components/Dimensions/Dialogs/DataDimension/Groups.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DataDimension/Groups.js
@@ -29,7 +29,9 @@ const Groups = props => {
 
     const groupDetail = dataTypes[props.dataType].groupDetail;
 
-    const havePlaceholder = Boolean(dataTypes[props.dataType].placeholder);
+    const havePlaceholder = Boolean(
+        !props.groupId && dataTypes[props.dataType].placeholder
+    );
 
     return (
         <div style={styles.container}>


### PR DESCRIPTION
This PR Includes:
Backporting fix for ticket no. [DHIS2-5452](https://jira.dhis2.org/browse/DHIS2-5452)

Check if groupId exist and render its displayName onChange instead of always rendering placeholder for Data Types: "Event Data Items" and "Program Indicator"