### PR TITLE
Fix/consistent height for options dialog

### DIFF
--- a/packages/app/src/components/Dimensions/Dialogs/DialogManager.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DialogManager.js
@@ -104,23 +104,25 @@ export class DialogManager extends Component {
         </Fragment>
     );
 
-    render = () => (
-        <Dialog
-            open={!!this.props.dialogId}
-            onClose={() => this.props.closeDialog(null)}
-            maxWidth={false}
-            disableEnforceFocus
-            keepMounted
-        >
-            {this.renderDialogContent()}
-            <DialogActions>
-                <HideButton />
-                {this.props.dialogId && (
-                    <AddToLayoutButton dialogId={this.props.dialogId} />
-                )}
-            </DialogActions>
-        </Dialog>
-    );
+    render() {
+        return (
+            <Dialog
+                open={!!this.props.dialogId}
+                onClose={() => this.props.closeDialog(null)}
+                maxWidth="lg"
+                disableEnforceFocus
+                keepMounted
+            >
+                {this.renderDialogContent()}
+                <DialogActions>
+                    <HideButton />
+                    {this.props.dialogId && (
+                        <AddToLayoutButton dialogId={this.props.dialogId} />
+                    )}
+                </DialogActions>
+            </Dialog>
+        );
+    }
 }
 
 DialogManager.propTypes = {

--- a/packages/app/src/components/VisualizationOptions/VisualizationOptionsManager.js
+++ b/packages/app/src/components/VisualizationOptions/VisualizationOptionsManager.js
@@ -5,10 +5,12 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
 
 import UpdateButton from '../UpdateButton/UpdateButton';
 import VisualizationOptions from './VisualizationOptions';
+import styles from './styles/VisualizationOptions.style';
 
 class VisualizationOptionsManager extends Component {
     constructor(props) {
@@ -42,7 +44,7 @@ class VisualizationOptionsManager extends Component {
                     maxWidth="md"
                 >
                     <DialogTitle>{i18n.t('Chart options')}</DialogTitle>
-                    <DialogContent>
+                    <DialogContent className={this.props.classes.dialogContent}>
                         <VisualizationOptions />
                     </DialogContent>
                     <DialogActions>
@@ -58,7 +60,8 @@ class VisualizationOptionsManager extends Component {
 }
 
 VisualizationOptionsManager.propTypes = {
+    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
 };
 
-export default VisualizationOptionsManager;
+export default withStyles(styles)(VisualizationOptionsManager);

--- a/packages/app/src/components/VisualizationOptions/styles/VisualizationOptions.style.js
+++ b/packages/app/src/components/VisualizationOptions/styles/VisualizationOptions.style.js
@@ -1,4 +1,7 @@
 export default {
+    dialogContent: {
+        flex: '1 1 480px',
+    },
     rangeAxisMin: {
         paddingRight: '15px',
     },


### PR DESCRIPTION
This PR includes:
* setting maxWidth="lg" to Dimension Dialogs in order to use d2-ui-theme rules for large dialogs (width and flex property - as of yet this effectively does not add any visual changes).

* wrapping and exporting VisualizationOptionsManager  in withStyles

* setting flex="1 1 480px" (default is: flex="1 1 auto") on DialogContent rendered in the Options Dialog, for consistent height across the three tabs (Data / Axes and Legends / Styles).

Steps to verify that Dimension Dialogs have d2-ui-theme rules:
1. Open Dimension Dialogs
2. Inspect Paper element
3. Verify that Component have rules overriden from d2-ui (mui3.theme.js file):

```
.MuiDialog-paperWidthLg-70 {
    flex: 0 1 800px;
    width: 800px;
    max-width: 800px;
}
```

Height should remain the same and be unaffected as it is defined by the dialog's content.
Graphical user interface of dimension dialogs should not be affected, they should remain the same.

This is the first PR for completing the consistent "dialogs height/styling" ticket / [[DHIS2-5452]](https://jira.dhis2.org/browse/DHIS2-5452)  

Steps to verify that height is consistent in the options dialog:
1. Open Options Dialog
2. Change Tabs
3. Resize / provoke any form of errors.

Current behaviour: The height of dialog content decreases depending on the amount of components rendered.

Correct behaviour: The height should remain the same for better UX performance.