### PR TITLE
Subscribe to analytic object id to remount org units selector

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-11-28T18:00:46.280Z\n"
-"PO-Revision-Date: 2018-11-28T18:00:46.280Z\n"
+"POT-Creation-Date: 2018-12-04T10:07:21.729Z\n"
+"PO-Revision-Date: 2018-12-04T10:07:21.729Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -80,6 +80,9 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
+msgid "An error occurred in the DHIS2 Data Visualizer application."
+msgstr ""
+
 msgid "Something went wrong"
 msgstr ""
 
@@ -90,9 +93,6 @@ msgid "Hide technical details"
 msgstr ""
 
 msgid "Show technical details"
-msgstr ""
-
-msgid "An error occurred in the DHIS2 {{AppName}} application."
 msgstr ""
 
 msgid "The following information may be requested by technical support."
@@ -237,6 +237,9 @@ msgid "Range axis min"
 msgstr ""
 
 msgid "Range axis tick steps"
+msgstr ""
+
+msgid "Tick steps may extend the chart beyond 'Range axis max'"
 msgstr ""
 
 msgid "Trend line"

--- a/packages/app/src/components/Dimensions/Dialogs/OrgUnitDimension/OrgUnitDimension.js
+++ b/packages/app/src/components/Dimensions/Dialogs/OrgUnitDimension/OrgUnitDimension.js
@@ -76,7 +76,7 @@ export class OrgUnitDimension extends Component {
         const previousId = prevProps.current ? prevProps.current.id : null;
         const currentId = this.props.current ? this.props.current.id : null;
 
-        // remount org units selector component to esnure
+        // remount org units selector component to ensure
         // only selected org units are expanded
         if (previousId !== currentId) {
             this.hideOrgUnitsTree();

--- a/packages/app/src/components/Dimensions/Dialogs/OrgUnitDimension/OrgUnitDimension.js
+++ b/packages/app/src/components/Dimensions/Dialogs/OrgUnitDimension/OrgUnitDimension.js
@@ -18,6 +18,7 @@ import {
 } from '../../../../reducers/ui';
 import { acSetCurrentFromUi } from '../../../../actions/current';
 import { acAddMetadata } from '../../../../actions/metadata';
+import { sGetCurrent } from '../../../../reducers/current';
 import { sGetMetadata } from '../../../../reducers/metadata';
 
 import {
@@ -56,6 +57,7 @@ export const defaultState = {
     selected: [],
     levelOptions: [],
     groupOptions: [],
+    showOrgUnitsTree: true,
 };
 
 export class OrgUnitDimension extends Component {
@@ -69,6 +71,27 @@ export class OrgUnitDimension extends Component {
         this.loadOrgUnitLevels();
         this.loadOrgUnitGroups();
     }
+
+    componentDidUpdate(prevProps) {
+        const previousId = prevProps.current ? prevProps.current.id : null;
+        const currentId = this.props.current ? this.props.current.id : null;
+
+        // remount org units selector component to esnure
+        // only selected org units are expanded
+        if (previousId !== currentId) {
+            this.hideOrgUnitsTree();
+
+            setTimeout(this.showOrgUnitsTree, 0);
+        }
+    }
+
+    showOrgUnitsTree = () => {
+        this.setState({ showOrgUnitsTree: true });
+    };
+
+    hideOrgUnitsTree = () => {
+        this.setState({ showOrgUnitsTree: false });
+    };
 
     addOrgUnitToMetadata = orgUnit => {
         this.props.acAddMetadata({
@@ -245,7 +268,7 @@ export class OrgUnitDimension extends Component {
             <Fragment>
                 <DialogTitle>{i18n.t('Organisation units')}</DialogTitle>
                 <DialogContent style={styles.dialogContent}>
-                    {this.state.root && (
+                    {this.state.root && this.state.showOrgUnitsTree && (
                         <OrgUnitSelector
                             root={this.state.root}
                             selected={selected}
@@ -283,12 +306,14 @@ OrgUnitDimension.propTypes = {
     acAddParentGraphMap: PropTypes.func.isRequired,
     acSetUiItems: PropTypes.func.isRequired,
     acSetCurrentFromUi: PropTypes.func.isRequired,
+    current: PropTypes.object,
 };
 
 const mapStateToProps = state => ({
     ouItems: sGetUiItemsByDimension(state, ouId),
     parentGraphMap: sGetUiParentGraphMap(state),
     metadata: sGetMetadata(state),
+    current: sGetCurrent(state),
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
This PR includes bug-fix for org units dimension.

Steps to reproduce (do not refresh the page during the process):
1) Open AO with preselected org units (multiple levels)
2) Open org units dimension dialog
3) Open another AO
4) Open org units dimension dialog again
5) Previously expanded org units are not selected anymore, but they are still expanded

Correct behaviour - only selected org units should be expanded.

I had a discussion with @joeDHIS about keeping org units expanded during opening/closing the dialog.
Although it is not the exact use case, the main idea was that whenever user chooses some org units and then clicks "deselect all" or reopens the dialog, org units should stay expanded (so that user wouldn't have to expand them again) even if they are not selected.

This applies some limitations to implementation, in particular - inability to tweak `org-units-tree` d2-ui component so that it would automatically collapse unselected org units. It is technically possible and I have implemented it locally, but preserving org units opened on AO change would require passing AO id as a prop all the way down to `org-unit-tree` component.

Current implementation uses sort of "subscribe" approach and re-renders `org-units-selector` component only when user changes AO (still uses lazy mount approach, so reopening the dialog does not cause additional requests). It does not repeat network requests and only fetches data for org units not expanded before.