### PR TITLE
DHIS2-5434: fix flashing chart when loading interpretation directly from URL (#168)

### DIFF
--- a/packages/app/src/actions/__tests__/index.spec.js
+++ b/packages/app/src/actions/__tests__/index.spec.js
@@ -9,7 +9,12 @@ import {
     CLEAR_VISUALIZATION,
 } from '../../reducers/visualization';
 import { SET_CURRENT, CLEAR_CURRENT } from '../../reducers/current';
-import { SET_UI_FROM_VISUALIZATION, CLEAR_UI } from '../../reducers/ui';
+import {
+    SET_UI_FROM_VISUALIZATION,
+    CLEAR_UI,
+    OPEN_UI_RIGHT_SIDEBAR_OPEN,
+    SET_UI_INTERPRETATION,
+} from '../../reducers/ui';
 import { SET_LOAD_ERROR, CLEAR_LOAD_ERROR } from '../../reducers/loader';
 import {
     RECEIVED_SNACKBAR_MESSAGE,
@@ -28,7 +33,11 @@ selectors.sGetRelativePeriod = () => relativePeriod;
 describe('index', () => {
     describe('tDoLoadVisualization', () => {
         it('dispatches the correct actions after successfully fetching visualization', () => {
-            const vis = 'hey';
+            const vis = {
+                name: 'hey',
+                interpretations: [{ id: 1, created: '2018-12-03' }],
+            };
+
             api.apiFetchVisualization = () =>
                 Promise.resolve({
                     toJSON: () => vis,
@@ -51,6 +60,48 @@ describe('index', () => {
 
             return store
                 .dispatch(fromActions.tDoLoadVisualization())
+                .then(() => {
+                    expect(store.getActions()).toEqual(expectedActions);
+                });
+        });
+
+        it('dispatches the correct actions after successfully fetching visualization and interpretation', () => {
+            const interpretation = { id: 1, created: '2018-12-03' };
+
+            const vis = {
+                name: 'hey',
+                interpretations: [interpretation],
+            };
+
+            api.apiFetchVisualization = () =>
+                Promise.resolve({
+                    toJSON: () => vis,
+                });
+
+            const expectedActions = [
+                {
+                    type: SET_UI_INTERPRETATION,
+                    value: interpretation,
+                },
+                {
+                    type: OPEN_UI_RIGHT_SIDEBAR_OPEN,
+                },
+                {
+                    type: SET_VISUALIZATION,
+                    value: vis,
+                },
+                { type: SET_CURRENT, value: vis },
+                {
+                    type: SET_UI_FROM_VISUALIZATION,
+                    value: vis,
+                },
+                { type: CLEAR_LOAD_ERROR },
+            ];
+
+            const store = mockStore({});
+
+            return store
+                .dispatch(fromActions.tDoLoadVisualization('test', 1, 1))
                 .then(() => {
                     expect(store.getActions()).toEqual(expectedActions);
                 });

--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -44,12 +44,23 @@ export const onError = (action, error) => {
 
 // visualization, current, ui
 
-export const tDoLoadVisualization = (type, id) => async (
+export const tDoLoadVisualization = (type, id, interpretationId) => async (
     dispatch,
     getState
 ) => {
     const onSuccess = model => {
         const visualization = model.toJSON();
+
+        if (interpretationId) {
+            const interpretation = visualization.interpretations.find(
+                i => i.id === interpretationId
+            );
+
+            if (interpretation) {
+                dispatch(fromUi.acSetUiInterpretation(interpretation));
+                dispatch(fromUi.acOpenUiRightSidebarOpen());
+            }
+        }
 
         dispatch(fromVisualization.acSetVisualization(visualization));
         dispatch(fromCurrent.acSetCurrent(visualization));

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -70,19 +70,12 @@ export class App extends Component {
                     fromActions.tDoLoadVisualization(
                         this.props.apiObjectName,
                         id,
-                        this.props.settings
+                        interpretationId
                     )
                 );
             }
 
-            if (interpretationId) {
-                store.dispatch(
-                    fromActions.fromUi.acSetUiInterpretation({
-                        id: interpretationId,
-                    })
-                );
-                store.dispatch(fromActions.fromUi.acOpenUiRightSidebarOpen());
-            } else {
+            if (!interpretationId) {
                 store.dispatch(fromActions.fromUi.acClearUiInterpretation());
             }
         } else {
@@ -203,6 +196,9 @@ const mapStateToProps = state => {
     return {
         settings: fromReducers.fromSettings.sGetSettings(state),
         current: fromReducers.fromCurrent.sGetCurrent(state),
+        interpretations: fromReducers.fromVisualization.sGetInterpretations(
+            state
+        ),
         loadError: fromReducers.fromLoader.sGetLoadError(state),
         ui: sGetUi(state),
     };

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -83,9 +83,9 @@ export class Visualization extends Component {
         // avoid redrawing the chart if the interpretation content remains the same
         // this is the case when the panel is toggled but the selected interpretation is not changed
         if (
-            prevProps.interpretation &&
-            this.props.interpretation.created !==
-                prevProps.interpretation.created
+            !prevProps.interpretation ||
+            (this.props.interpretation &&
+                this.props.interpretation.id !== prevProps.interpretation.id)
         ) {
             const vis = this.props.interpretation.id
                 ? this.props.visualization

--- a/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
+++ b/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
@@ -247,11 +247,10 @@ describe('Visualization', () => {
         vis.instance().recreateChart = recreateChartFn;
 
         it('triggers a reflow when rightSidebarOpen prop changes', () => {
-            vis.setProps({
-                ...props,
-                current: undefined,
-                rightSidebarOpen: true,
-            });
+            // simulate prevProps ?!
+            vis.setProps(props);
+
+            vis.setProps({ ...props, rightSidebarOpen: true });
 
             expect(recreateChartFn).toHaveBeenCalled();
 

--- a/packages/app/src/components/__tests__/App.spec.js
+++ b/packages/app/src/components/__tests__/App.spec.js
@@ -35,6 +35,7 @@ describe('App', () => {
             snackbarOpen: false,
             snackbarMessage: '',
             loadError: null,
+            interpretations: [],
             current: {},
             ui: { rightSidebarOpen: false },
             location: { pathname: '/' },
@@ -50,8 +51,6 @@ describe('App', () => {
 
         actions.tDoLoadVisualization = jest.fn();
         actions.clearVisualization = jest.fn();
-        actions.fromUi.acSetUiInterpretation = jest.fn();
-        actions.fromUi.acOpenUiRightSidebarOpen = jest.fn();
     });
 
     afterEach(() => {
@@ -95,9 +94,6 @@ describe('App', () => {
 
             setTimeout(() => {
                 expect(actions.tDoLoadVisualization).toBeCalledTimes(1);
-                expect(
-                    actions.fromUi.acSetUiInterpretation
-                ).not.toHaveBeenCalled();
                 expect(actions.clearVisualization).not.toHaveBeenCalled();
                 done();
             });
@@ -141,27 +137,6 @@ describe('App', () => {
                     history.push('/applejack');
                     expect(actions.tDoLoadVisualization).toBeCalledTimes(1);
 
-                    done();
-                });
-            });
-
-            it('calls setUiInterpretation action', done => {
-                const interpId = 'xyzpdq';
-                props.location.pathname = `/spike/interpretation/${interpId}`;
-                app();
-
-                setTimeout(() => {
-                    expect(actions.tDoLoadVisualization).toBeCalledTimes(1);
-                    expect(
-                        actions.fromUi.acSetUiInterpretation
-                    ).toBeCalledTimes(1);
-                    expect(
-                        actions.fromUi.acSetUiInterpretation
-                    ).toHaveBeenCalledWith({ id: interpId });
-                    expect(
-                        actions.fromUi.acOpenUiRightSidebarOpen
-                    ).toBeCalledTimes(1);
-                    expect(actions.clearVisualization).not.toHaveBeenCalled();
                     done();
                 });
             });

--- a/packages/app/src/modules/fields/baseFields.js
+++ b/packages/app/src/modules/fields/baseFields.js
@@ -106,6 +106,7 @@ export const fieldsByType = {
         getFieldObject('hideTitle', { option: true }),
         getFieldObject('href', { excluded: true }),
         getFieldObject('id'),
+        getFieldObject('interpretations'),
         getFieldObject('itemOrganisationUnitGroups', { excluded: true }),
         getFieldObject('lastUpdated'),
         getFieldObject('lastUpdatedBy'),

--- a/packages/app/src/modules/fields/nestedFields.js
+++ b/packages/app/src/modules/fields/nestedFields.js
@@ -11,6 +11,7 @@ const ITEMS = `items[${DIMENSION_ITEM},${NAME},dimensionItemType]`;
 const COMMENTS = `comments[${ID},${USER},lastUpdated,text`;
 
 const AXIS = `dimension,filter,${LEGEND_SET},${ITEMS}`;
+const INTERPRETATIONS = 'id,created';
 
 // nested fields map
 export const nestedFields = {
@@ -19,6 +20,7 @@ export const nestedFields = {
     filters: AXIS,
     user: USER,
     comments: COMMENTS,
+    interpretations: INTERPRETATIONS,
 };
 
 export const extendFields = field =>

--- a/packages/app/src/reducers/visualization.js
+++ b/packages/app/src/reducers/visualization.js
@@ -19,3 +19,5 @@ export default (state = DEFAULT_VISUALIZATION, action) => {
 // Selectors
 
 export const sGetVisualization = state => state.visualization;
+export const sGetInterpretations = state =>
+    state.visualization ? state.visualization.interpretations : [];


### PR DESCRIPTION
- fetch interpretations fields id and created
- avoid unnecessary analytics request and chart recreation

(cherry picked from commit b4fd6d5fa0619d30e96cc70d210166e1ab8cea53)