### PR TITLE
Fix/ie11 numberfield [DHIS2-5281]

### DIFF
--- a/packages/app/src/components/VisualizationOptions/Options/BaseLineLabel.js
+++ b/packages/app/src/components/VisualizationOptions/Options/BaseLineLabel.js
@@ -4,7 +4,6 @@ import i18n from '@dhis2/d2-i18n';
 
 const BaseLineLabel = () => (
     <TextBaseOption
-        type="text"
         option={{
             name: 'baseLineLabel',
             label: i18n.t('Base line title'),

--- a/packages/app/src/components/VisualizationOptions/Options/BaseLineValue.js
+++ b/packages/app/src/components/VisualizationOptions/Options/BaseLineValue.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import TextBaseOption from './TextBaseOption';
+import NumberBaseOption from './NumberBaseOption';
 import i18n from '@dhis2/d2-i18n';
 
 const BaseLineValue = () => (
-    <TextBaseOption
-        type="number"
+    <NumberBaseOption
         option={{
             name: 'baseLineValue',
             label: i18n.t('Base line value'),

--- a/packages/app/src/components/VisualizationOptions/Options/DomainAxisLabel.js
+++ b/packages/app/src/components/VisualizationOptions/Options/DomainAxisLabel.js
@@ -4,7 +4,6 @@ import i18n from '@dhis2/d2-i18n';
 
 const DomainAxisLabel = () => (
     <TextBaseOption
-        type="text"
         option={{
             name: 'domainAxisLabel',
             label: i18n.t('Domain axis title'),

--- a/packages/app/src/components/VisualizationOptions/Options/NumberBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/NumberBaseOption.js
@@ -7,20 +7,16 @@ import { acSetUiOptions } from '../../../actions/ui';
 
 const emptyString = '';
 
-const incrementByOne = value => (parseInt(value, 10) + 1).toString();
-const decrementByOne = value => (parseInt(value, 10) - 1).toString();
+const incrementByOne = value =>
+    value === emptyString ? 1 : (parseInt(value, 10) + 1).toString();
 
-const handleArrowInput = (value, onChange, INCREMENT = true) => {
-    if (INCREMENT) {
-        value === emptyString
-            ? onChange(incrementByOne(0))
-            : onChange(incrementByOne(value));
-    } else {
-        value === emptyString
-            ? onChange(decrementByOne(0))
-            : onChange(decrementByOne(value));
-    }
-};
+const decrementByOne = value =>
+    value === emptyString ? -1 : (parseInt(value, 10) - 1).toString();
+
+const handleArrowInput = (value, onChange, INCREMENT = true) =>
+    INCREMENT
+        ? onChange(incrementByOne(value))
+        : onChange(decrementByOne(value));
 
 const onKeyWrapper = (event, value, onChange) => {
     if (event.key === 'ArrowUp') {

--- a/packages/app/src/components/VisualizationOptions/Options/NumberBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/NumberBaseOption.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import TextField from '@material-ui/core/TextField';
+import { sGetUiOptions } from '../../../reducers/ui';
+import { acSetUiOptions } from '../../../actions/ui';
+
+const emptyString = '';
+
+const incrementByOne = value => (parseInt(value, 10) + 1).toString();
+const decrementByOne = value => (parseInt(value, 10) - 1).toString();
+
+const handleArrowInput = (value, onChange, INCREMENT = true) => {
+    if (INCREMENT) {
+        value === emptyString
+            ? onChange(incrementByOne(0))
+            : onChange(incrementByOne(value));
+    } else {
+        value === emptyString
+            ? onChange(decrementByOne(0))
+            : onChange(decrementByOne(value));
+    }
+};
+
+const onKeyWrapper = (event, value, onChange) => {
+    if (event.key === 'ArrowUp') {
+        event.preventDefault();
+
+        handleArrowInput(value, onChange);
+    }
+
+    if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        const DECREMENT = false;
+
+        handleArrowInput(value, onChange, DECREMENT);
+    }
+};
+
+export const NumberBaseOption = ({ className, option, value, onChange }) => (
+    <TextField
+        className={className}
+        type="number"
+        label={option.label}
+        value={value}
+        helperText={option.helperText}
+        onKeyDown={event => onKeyWrapper(event, value, onChange)}
+        onChange={event =>
+            !isNaN(event.target.value) && onChange(event.target.value)
+        }
+    />
+);
+
+NumberBaseOption.propTypes = {
+    className: PropTypes.string,
+    option: PropTypes.object,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    onChange: PropTypes.func,
+};
+
+const mapStateToProps = (state, ownProps) => ({
+    value: sGetUiOptions(state)[ownProps.option.name] || emptyString,
+});
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+    onChange: value =>
+        dispatch(acSetUiOptions({ [ownProps.option.name]: value })),
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(NumberBaseOption);

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisDecimals.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisDecimals.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import TextBaseOption from './TextBaseOption';
+import NumberBaseOption from './NumberBaseOption';
 import i18n from '@dhis2/d2-i18n';
 
 const RangeAxisDecimals = () => (
-    <TextBaseOption
-        type="number"
+    <NumberBaseOption
         option={{
             name: 'rangeAxisDecimals',
             label: i18n.t('Range axis decimals'),

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisLabel.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisLabel.js
@@ -4,7 +4,6 @@ import i18n from '@dhis2/d2-i18n';
 
 const RangeAxisLabel = () => (
     <TextBaseOption
-        type="text"
         option={{
             name: 'rangeAxisLabel',
             label: i18n.t('Range axis title'),

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisMaxValue.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisMaxValue.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import TextBaseOption from './TextBaseOption';
+import NumberBaseOption from './NumberBaseOption';
 import i18n from '@dhis2/d2-i18n';
 
 const RangeAxisMaxValue = () => (
-    <TextBaseOption
-        type="number"
+    <NumberBaseOption
         option={{
             name: 'rangeAxisMaxValue',
             label: i18n.t('Range axis max'),

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisMinValue.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisMinValue.js
@@ -1,18 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
-import TextBaseOption from './TextBaseOption';
+import NumberBaseOption from './NumberBaseOption';
 import i18n from '@dhis2/d2-i18n';
 import styles from '../styles/VisualizationOptions.style';
 
 const RangeAxisMinValue = ({ classes }) => (
-    <TextBaseOption
+    <NumberBaseOption
         className={classes.rangeAxisMin}
-        type="number"
         option={{
             name: 'rangeAxisMinValue',
             label: i18n.t('Range axis min'),
         }}
     />
 );
+
+RangeAxisMinValue.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
 
 export default withStyles(styles)(RangeAxisMinValue);

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisSteps.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisSteps.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import TextBaseOption from './TextBaseOption';
+import NumberBaseOption from './NumberBaseOption';
 import i18n from '@dhis2/d2-i18n';
 import { sGetUiOptions } from '../../../reducers/ui';
 
 export const RangeAxisSteps = ({ showHelperText }) => (
-    <TextBaseOption
-        type="number"
+    <NumberBaseOption
         option={{
             name: 'rangeAxisSteps',
             label: i18n.t('Range axis tick steps'),

--- a/packages/app/src/components/VisualizationOptions/Options/Subtitle.js
+++ b/packages/app/src/components/VisualizationOptions/Options/Subtitle.js
@@ -4,7 +4,6 @@ import i18n from '@dhis2/d2-i18n';
 
 const Subtitle = () => (
     <TextBaseOption
-        type="text"
         option={{
             name: 'subtitle',
             label: i18n.t('Chart subtitle'),

--- a/packages/app/src/components/VisualizationOptions/Options/TargetLineLabel.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TargetLineLabel.js
@@ -4,7 +4,6 @@ import i18n from '@dhis2/d2-i18n';
 
 const TargetLineLabel = () => (
     <TextBaseOption
-        type="text"
         option={{
             name: 'targetLineLabel',
             label: i18n.t('Target line title'),

--- a/packages/app/src/components/VisualizationOptions/Options/TargetLineValue.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TargetLineValue.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import TextBaseOption from './TextBaseOption';
+import NumberBaseOption from './NumberBaseOption';
 import i18n from '@dhis2/d2-i18n';
 
 const TargetLineValue = () => (
-    <TextBaseOption
-        type="number"
+    <NumberBaseOption
         option={{
             name: 'targetLineValue',
             label: i18n.t('Target line value'),

--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -7,34 +7,34 @@ import { acSetUiOptions } from '../../../actions/ui';
 
 const emptyString = '';
 
+const isNumberField = type => type === 'number';
+
 const incrementByOne = value => (parseInt(value, 10) + 1).toString();
 const decrementByOne = value => (parseInt(value, 10) - 1).toString();
 
-const onKeyWrapper = (event, props) => {
-    if (props.type === 'number') {
-        if (event.key === 'ArrowUp') {
-            event.preventDefault();
+const onKeyWrapper = (event, value, onChange) => {
+    if (event.key === 'ArrowUp') {
+        event.preventDefault();
 
-            !props.value.length
-                ? props.onChange(incrementByOne(0))
-                : props.onChange(incrementByOne(props.value));
-        }
+        !value.length
+            ? onChange(incrementByOne(0))
+            : onChange(incrementByOne(value));
+    }
 
-        if (event.key === 'ArrowDown') {
-            event.preventDefault();
+    if (event.key === 'ArrowDown') {
+        event.preventDefault();
 
-            !props.value.length
-                ? props.onChange(decrementByOne(0))
-                : props.onChange(decrementByOne(props.value));
-        }
+        !value.length
+            ? onChange(decrementByOne(0))
+            : onChange(decrementByOne(value));
     }
 };
 
-const onChangeWrapper = (event, props) => {
-    if (props.type === 'number') {
-        !isNaN(event.target.value) && props.onChange(event.target.value);
+const onChangeWrapper = (value, props) => {
+    if (isNumberField(props.type)) {
+        !isNaN(value) && props.onChange(value);
     } else {
-        props.onChange(event.target.value);
+        props.onChange(value);
     }
 };
 
@@ -43,10 +43,13 @@ export const TextBaseOption = props => (
         className={props.className}
         type={props.type}
         label={props.option.label}
-        onKeyDown={event => onKeyWrapper(event, props)}
-        onChange={event => onChangeWrapper(event, props)}
         value={props.value}
         helperText={props.option.helperText}
+        onChange={event => onChangeWrapper(event.target.value, props)}
+        onKeyDown={event =>
+            isNumberField(props.type) &&
+            onKeyWrapper(event, props.value, props.onChange)
+        }
     />
 );
 

--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -7,57 +7,21 @@ import { acSetUiOptions } from '../../../actions/ui';
 
 const emptyString = '';
 
-const isNumberField = type => type === 'number';
-
-const incrementByOne = value => (parseInt(value, 10) + 1).toString();
-const decrementByOne = value => (parseInt(value, 10) - 1).toString();
-
-const onKeyWrapper = (event, value, onChange) => {
-    if (event.key === 'ArrowUp') {
-        event.preventDefault();
-
-        !value.length
-            ? onChange(incrementByOne(0))
-            : onChange(incrementByOne(value));
-    }
-
-    if (event.key === 'ArrowDown') {
-        event.preventDefault();
-
-        !value.length
-            ? onChange(decrementByOne(0))
-            : onChange(decrementByOne(value));
-    }
-};
-
-const onChangeWrapper = (value, props) => {
-    if (isNumberField(props.type)) {
-        !isNaN(value) && props.onChange(value);
-    } else {
-        props.onChange(value);
-    }
-};
-
-export const TextBaseOption = props => (
+export const TextBaseOption = ({ className, option, value, onChange }) => (
     <TextField
-        className={props.className}
-        type={props.type}
-        label={props.option.label}
-        value={props.value}
-        helperText={props.option.helperText}
-        onChange={event => onChangeWrapper(event.target.value, props)}
-        onKeyDown={event =>
-            isNumberField(props.type) &&
-            onKeyWrapper(event, props.value, props.onChange)
-        }
+        className={className}
+        type="text"
+        label={option.label}
+        value={value}
+        helperText={option.helperText}
+        onChange={event => onChange(event.target.value)}
     />
 );
 
 TextBaseOption.propTypes = {
     className: PropTypes.string,
-    type: PropTypes.string,
     option: PropTypes.object,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    value: PropTypes.string,
     onChange: PropTypes.func,
 };
 

--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -30,14 +30,21 @@ const onKeyWrapper = (event, props) => {
     }
 };
 
+const onChangeWrapper = (event, props) => {
+    if (props.type === 'number') {
+        !isNaN(event.target.value) && props.onChange(event.target.value);
+    } else {
+        props.onChange(event.target.value);
+    }
+};
+
 export const TextBaseOption = props => (
     <TextField
         className={props.className}
         type={props.type}
         label={props.option.label}
         onKeyDown={event => onKeyWrapper(event, props)}
-        onChange={event => props.onChange(event.target.value)}
-        InputProps={{ type: props.type }}
+        onChange={event => onChangeWrapper(event, props)}
         value={props.value}
         helperText={props.option.helperText}
     />

--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -5,24 +5,21 @@ import TextField from '@material-ui/core/TextField';
 import { sGetUiOptions } from '../../../reducers/ui';
 import { acSetUiOptions } from '../../../actions/ui';
 
-export const TextBaseOption = ({
-    className,
-    type,
-    option,
-    value,
-    onChange,
-}) => (
+const emptyString = '';
+
+export const TextBaseOption = props => (
     <TextField
-        className={className}
-        type={type}
-        label={option.label}
-        onChange={event => onChange(event.target.value)}
-        value={value}
-        helperText={option.helperText}
+        className={props.className}
+        type={props.type}
+        label={props.option.label}
+        onChange={event => props.onChange(event.target.value)}
+        value={props.value}
+        helperText={props.option.helperText}
     />
 );
 
 TextBaseOption.propTypes = {
+    className: PropTypes.string,
     type: PropTypes.string,
     option: PropTypes.object,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -30,7 +27,7 @@ TextBaseOption.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-    value: sGetUiOptions(state)[ownProps.option.name] || '',
+    value: sGetUiOptions(state)[ownProps.option.name] || emptyString,
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -5,28 +5,26 @@ import TextField from '@material-ui/core/TextField';
 import { sGetUiOptions } from '../../../reducers/ui';
 import { acSetUiOptions } from '../../../actions/ui';
 
-const emptyString = '';
-
 export const TextBaseOption = ({ className, option, value, onChange }) => (
     <TextField
         className={className}
         type="text"
         label={option.label}
+        onChange={event => onChange(event.target.value)}
         value={value}
         helperText={option.helperText}
-        onChange={event => onChange(event.target.value)}
     />
 );
 
 TextBaseOption.propTypes = {
-    className: PropTypes.string,
+    type: PropTypes.string,
     option: PropTypes.object,
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     onChange: PropTypes.func,
 };
 
 const mapStateToProps = (state, ownProps) => ({
-    value: sGetUiOptions(state)[ownProps.option.name] || emptyString,
+    value: sGetUiOptions(state)[ownProps.option.name] || '',
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -10,7 +10,23 @@ const emptyString = '';
 const incrementByOne = value => (value += 1).toString();
 const decrementByOne = value => (value -= 1).toString();
 
-const onKeyWrapper = (event, props) => {};
+const onKeyWrapper = (event, props) => {
+    if (props.type === 'number') {
+        if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            return !props.value.length
+                ? props.onChange(incrementByOne(0))
+                : props.onChange(incrementByOne(parseInt(props.value, 10)));
+        }
+
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            return !props.value.length
+                ? props.onChange(decrementByOne(0))
+                : props.onChange(decrementByOne(parseInt(props.value, 10)));
+        }
+    }
+};
 
 export const TextBaseOption = props => (
     <TextField

--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -7,11 +7,17 @@ import { acSetUiOptions } from '../../../actions/ui';
 
 const emptyString = '';
 
+const incrementByOne = value => (value += 1).toString();
+const decrementByOne = value => (value -= 1).toString();
+
+const onKeyWrapper = (event, props) => {};
+
 export const TextBaseOption = props => (
     <TextField
         className={props.className}
         type={props.type}
         label={props.option.label}
+        onKeyDown={event => onKeyWrapper(event, props)}
         onChange={event => props.onChange(event.target.value)}
         value={props.value}
         helperText={props.option.helperText}

--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -7,23 +7,25 @@ import { acSetUiOptions } from '../../../actions/ui';
 
 const emptyString = '';
 
-const incrementByOne = value => (value += 1).toString();
-const decrementByOne = value => (value -= 1).toString();
+const incrementByOne = value => (parseInt(value, 10) + 1).toString();
+const decrementByOne = value => (parseInt(value, 10) - 1).toString();
 
 const onKeyWrapper = (event, props) => {
     if (props.type === 'number') {
         if (event.key === 'ArrowUp') {
             event.preventDefault();
-            return !props.value.length
+
+            !props.value.length
                 ? props.onChange(incrementByOne(0))
-                : props.onChange(incrementByOne(parseInt(props.value, 10)));
+                : props.onChange(incrementByOne(props.value));
         }
 
         if (event.key === 'ArrowDown') {
             event.preventDefault();
-            return !props.value.length
+
+            !props.value.length
                 ? props.onChange(decrementByOne(0))
-                : props.onChange(decrementByOne(parseInt(props.value, 10)));
+                : props.onChange(decrementByOne(props.value));
         }
     }
 };
@@ -35,6 +37,7 @@ export const TextBaseOption = props => (
         label={props.option.label}
         onKeyDown={event => onKeyWrapper(event, props)}
         onChange={event => props.onChange(event.target.value)}
+        InputProps={{ type: props.type }}
         value={props.value}
         helperText={props.option.helperText}
     />

--- a/packages/app/src/components/VisualizationOptions/Options/Title.js
+++ b/packages/app/src/components/VisualizationOptions/Options/Title.js
@@ -4,7 +4,6 @@ import i18n from '@dhis2/d2-i18n';
 
 const Title = () => (
     <TextBaseOption
-        type="text"
         option={{
             name: 'title',
             label: i18n.t('Chart title'),

--- a/packages/app/src/components/VisualizationOptions/__tests__/RangeAxisSteps.spec.js
+++ b/packages/app/src/components/VisualizationOptions/__tests__/RangeAxisSteps.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import TextBaseOption from '../Options/TextBaseOption';
+import NumberBaseOption from '../Options/NumberBaseOption';
 import { RangeAxisSteps } from '../Options/RangeAxisSteps';
 
 describe('DV > Options > RangeAxisSteps', () => {
@@ -22,14 +22,14 @@ describe('DV > Options > RangeAxisSteps', () => {
         shallowRangeAxisSteps = undefined;
     });
 
-    it('renders a <TextBaseOption />', () => {
-        expect(rangeAxisSteps(props).find(TextBaseOption)).toHaveLength(1);
+    it('renders a <NumberBaseOption />', () => {
+        expect(rangeAxisSteps(props).find(NumberBaseOption)).toHaveLength(1);
     });
 
     it('sets the label prop to what passed in the option prop', () => {
         expect(
             rangeAxisSteps(props)
-                .find(TextBaseOption)
+                .find(NumberBaseOption)
                 .props().option.label
         ).toEqual('Range axis tick steps');
     });
@@ -37,7 +37,7 @@ describe('DV > Options > RangeAxisSteps', () => {
     it('does not show the helper text when showHelperText is false', () => {
         expect(
             rangeAxisSteps(props)
-                .find(TextBaseOption)
+                .find(NumberBaseOption)
                 .props().option.helperText
         ).toBe(null);
     });
@@ -47,7 +47,7 @@ describe('DV > Options > RangeAxisSteps', () => {
 
         expect(
             rangeAxisSteps(props)
-                .find(TextBaseOption)
+                .find(NumberBaseOption)
                 .props().option.helperText
         ).toEqual(`Tick steps may extend the chart beyond 'Range axis max'`);
     });


### PR DESCRIPTION
THIS PR Includes adding new file NumberBaseOption.js and enabling increment / decrement on number fields in Internet Explorer:

The TextField is similar to TextBaseOption but have a new prop "onKeyDown" to catch the arrowUp or arrowDown input events.

On arrow Up or Left i am preventing the default behaviour ( Textfield firing the onChange callBack ) and incrementing / decrementing manually.
 
- Since the value is an empty string, i had to add a terniary check to increment/decrement the empty string with 0. 

- I also had to parse the value to int, then back to string.

- If key event is not an ArrowLeft or Right, the event propagates to the onChange callback which includes checking the type (text or number) and handling the input accordingly.


Additional info:
There are some limitations with both the TextField in general, and input components of type='number' in Internet Explorer. Currently i've only found nasty hacks but no concrete and neat solutions.

The user are still able to type in characters in internet explorer (I am not sure why, as the input has type='number' and i am not able to find solutions or relevant information on google regarding this behaviour) - but I think this is because the input starts as an uncontrolled component due to the value being an empty string (?)

I have tried to add additional checks to ignore characters but the input field still receives A-F as valid (however, only on the first input, after adding the onChange wrapper):

```
const onChangeWrapper = (value, props) => {
   // check if type is number
    if (isNumberField(props.type)) {

      // check if input is a valid Number, this does not work on the first input in IE11
        !isNaN(value) && props.onChange(value);

    } else {
      // type == 'text' , pass the change
        props.onChange(value);
    }
};

```

The Material-UI folks simply states that the TextField component is already too complex and it can't handle all the limitations from IE.

I have tried to use InputProps / inputProps but the issue remains.
 
Also, when using the mathematical number 'e' and then increments, it resets the field (both in chrome and in IE11) - but i assume this is rarely if not never used.


I looked into using [other Material-UI components](https://material-ui.com/demos/text-fields/#formatted-inputs) to format the input but this involved adding third library packages like `react-text-mask` and `react-number-format`.

But since the idea of this PR relates to increment / decrement. i chose to open a pull request with only these changes.

However, do not hesitate to request changes! 