### PR TITLE
Remove default empty dx array

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-12-05T13:37:06.230Z\n"
-"PO-Revision-Date: 2018-12-05T13:37:06.230Z\n"
+"POT-Creation-Date: 2018-12-07T09:58:42.714Z\n"
+"PO-Revision-Date: 2018-12-07T09:58:42.714Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -239,6 +239,9 @@ msgstr ""
 msgid "Range axis tick steps"
 msgstr ""
 
+msgid "Tick steps may extend the chart beyond 'Range axis max'"
+msgstr ""
+
 msgid "Trend line"
 msgstr ""
 
@@ -278,7 +281,7 @@ msgstr ""
 msgid "Chart title"
 msgstr ""
 
-msgid "Axes & legend"
+msgid "Axis & legend"
 msgstr ""
 
 msgid "Style"

--- a/packages/app/src/components/Dimensions/Dialogs/DataDimension/DataDimension.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DataDimension/DataDimension.js
@@ -257,11 +257,15 @@ export class DataDimension extends Component {
 
 DataDimension.propTypes = {
     displayNameProp: PropTypes.string.isRequired,
-    selectedItems: PropTypes.array.isRequired,
+    selectedItems: PropTypes.array,
     addDxItems: PropTypes.func.isRequired,
     setDxItems: PropTypes.func.isRequired,
     removeDxItems: PropTypes.func.isRequired,
     addMetadata: PropTypes.func.isRequired,
+};
+
+DataDimension.defaultProps = {
+    selectedItems: [],
 };
 
 const mapStateToProps = state => ({

--- a/packages/app/src/components/Dimensions/Dialogs/DialogManager.js
+++ b/packages/app/src/components/Dimensions/Dialogs/DialogManager.js
@@ -127,7 +127,7 @@ export class DialogManager extends Component {
 
 DialogManager.propTypes = {
     dialogId: PropTypes.string,
-    dxIds: PropTypes.array.isRequired,
+    dxIds: PropTypes.array,
     ouIds: PropTypes.array.isRequired,
     closeDialog: PropTypes.func.isRequired,
     setRecommendedIds: PropTypes.func.isRequired,
@@ -135,6 +135,7 @@ DialogManager.propTypes = {
 
 DialogManager.defaultProps = {
     dialogId: null,
+    dxIds: [],
 };
 
 const mapStateToProps = state => ({

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -44,7 +44,6 @@ export const DEFAULT_UI = {
         filters: [ouId],
     },
     itemsByDimension: {
-        [dxId]: [],
         [ouId]: [],
         [peId]: [],
     },


### PR DESCRIPTION
Current default state:

layout:
- columns: ["dx"]
- rows: ["pe"]
- filters: ["ou"]

itemsByDimension
- dx: [ ]
- pe: ["LAST_12_MONTHS"]
- ou: ["ImspTQPwCqd"]

This PR removes the empty array for dx. It is not possible to produce this state for other dimensions. There are only two valid options:
- If no items are selected for a dimension it should not be present in the object
- If the dimension has items it should appear and key:value should be dimensionId:[dimensionItemIds] 