### PR TITLE
Fix/options dialog components spacing

### DIFF
--- a/packages/app/src/components/VisualizationOptions/AxisAndLegendTab.js
+++ b/packages/app/src/components/VisualizationOptions/AxisAndLegendTab.js
@@ -12,7 +12,7 @@ import DomainAxisLabel from './Options/DomainAxisLabel';
 import styles from './styles/VisualizationOptions.style';
 
 export const AxisAndLegendTab = ({ classes }) => (
-    <FormGroup className={classes.axisFormGroup}>
+    <FormGroup className={classes.axisTabFormGroup}>
         <FormGroup row={true}>
             <RangeAxisMinValue />
             <RangeAxisMaxValue />

--- a/packages/app/src/components/VisualizationOptions/DataTab.js
+++ b/packages/app/src/components/VisualizationOptions/DataTab.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import FormGroup from '@material-ui/core/FormGroup';
+import { withStyles } from '@material-ui/core/styles';
 
 import CumulativeValues from './Options/CumulativeValues';
 import PercentStackedValues from './Options/PercentStackedValues';
@@ -10,9 +12,10 @@ import TargetLine from './Options/TargetLine';
 import BaseLine from './Options/BaseLine';
 import SortOrder from './Options/SortOrder';
 import AggregationType from './Options/AggregationType';
+import styles from './styles/VisualizationOptions.style';
 
-export const DataTab = () => (
-    <FormGroup>
+export const DataTab = ({ classes }) => (
+    <FormGroup className={classes.dataTabFormGroup}>
         <ShowData />
         <PercentStackedValues />
         <CumulativeValues />
@@ -25,4 +28,8 @@ export const DataTab = () => (
     </FormGroup>
 );
 
-export default DataTab;
+DataTab.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(DataTab);

--- a/packages/app/src/components/VisualizationOptions/Options/AggregationType.js
+++ b/packages/app/src/components/VisualizationOptions/Options/AggregationType.js
@@ -1,10 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
+import { withStyles } from '@material-ui/core/styles';
+import styles from '../styles/VisualizationOptions.style';
 
 import SelectBaseOption from './SelectBaseOption';
 
-const AggregationType = () => (
+const AggregationType = ({ classes }) => (
     <SelectBaseOption
+        className={classes.aggregationType}
         option={{
             name: 'aggregationType',
             label: i18n.t('Aggregation type'),
@@ -31,4 +35,8 @@ const AggregationType = () => (
     />
 );
 
-export default AggregationType;
+AggregationType.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(AggregationType);

--- a/packages/app/src/components/VisualizationOptions/Options/BaseLine.js
+++ b/packages/app/src/components/VisualizationOptions/Options/BaseLine.js
@@ -14,7 +14,7 @@ import BaseLineLabel from './BaseLineLabel';
 import styles from '../styles/VisualizationOptions.style';
 
 export const BaseLine = ({ classes, enabled, onChange }) => (
-    <FormGroup className={classes.formGroupContainer} row={true}>
+    <FormGroup className={classes.baseLine} row={true}>
         <FormControlLabel
             className={classes.baseLineRoot}
             control={

--- a/packages/app/src/components/VisualizationOptions/Options/CumulativeValues.js
+++ b/packages/app/src/components/VisualizationOptions/Options/CumulativeValues.js
@@ -1,9 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
+import { withStyles } from '@material-ui/core/styles';
 import CheckboxBaseOption from './CheckboxBaseOption';
+import styles from '../styles/VisualizationOptions.style';
 
-const CumulativeValues = () => (
+const CumulativeValues = ({ classes }) => (
     <CheckboxBaseOption
+        className={classes.dataTabCheckbox}
         option={{
             name: 'cumulativeValues',
             label: i18n.t('Use cumulative values'),
@@ -11,4 +15,8 @@ const CumulativeValues = () => (
     />
 );
 
-export default CumulativeValues;
+CumulativeValues.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(CumulativeValues);

--- a/packages/app/src/components/VisualizationOptions/Options/HideEmptyRowItems.js
+++ b/packages/app/src/components/VisualizationOptions/Options/HideEmptyRowItems.js
@@ -7,7 +7,7 @@ import styles from '../styles/VisualizationOptions.style';
 
 const HideEmptyRowItems = ({ classes }) => (
     <SelectBaseOption
-        className={classes.selectBaseRoot}
+        className={classes.selectBaseOption}
         option={{
             name: 'hideEmptyRowItems',
             label: i18n.t('Hide empty categories'),

--- a/packages/app/src/components/VisualizationOptions/Options/PercentStackedValues.js
+++ b/packages/app/src/components/VisualizationOptions/Options/PercentStackedValues.js
@@ -1,9 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
+import { withStyles } from '@material-ui/core/styles';
 import CheckboxBaseOption from './CheckboxBaseOption';
+import styles from '../styles/VisualizationOptions.style';
 
-const PercentStackedValues = () => (
+const PercentStackedValues = ({ classes }) => (
     <CheckboxBaseOption
+        className={classes.dataTabCheckbox}
         option={{
             name: 'percentStackedValues',
             label: i18n.t('Use 100% stacked values'),
@@ -11,4 +15,8 @@ const PercentStackedValues = () => (
     />
 );
 
-export default PercentStackedValues;
+PercentStackedValues.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(PercentStackedValues);

--- a/packages/app/src/components/VisualizationOptions/Options/RegressionType.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RegressionType.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import { withStyles } from '@material-ui/core/styles';
 import SelectBaseOption from './SelectBaseOption';
@@ -6,7 +7,7 @@ import styles from '../styles/VisualizationOptions.style';
 
 const RegressionType = ({ classes }) => (
     <SelectBaseOption
-        className={classes.selectBaseRoot}
+        className={classes.regressionType}
         option={{
             name: 'regressionType',
             label: i18n.t('Trend line'),
@@ -19,5 +20,9 @@ const RegressionType = ({ classes }) => (
         }}
     />
 );
+
+RegressionType.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
 
 export default withStyles(styles)(RegressionType);

--- a/packages/app/src/components/VisualizationOptions/Options/ShowData.js
+++ b/packages/app/src/components/VisualizationOptions/Options/ShowData.js
@@ -1,9 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
+import { withStyles } from '@material-ui/core/styles';
 import CheckboxBaseOption from './CheckboxBaseOption';
+import styles from '../styles/VisualizationOptions.style';
 
-const ShowData = () => (
+const ShowData = ({ classes }) => (
     <CheckboxBaseOption
+        className={classes.dataTabCheckbox}
         option={{
             name: 'showData',
             label: i18n.t('Show values'),
@@ -11,4 +15,8 @@ const ShowData = () => (
     />
 );
 
-export default ShowData;
+ShowData.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(ShowData);

--- a/packages/app/src/components/VisualizationOptions/Options/SortOrder.js
+++ b/packages/app/src/components/VisualizationOptions/Options/SortOrder.js
@@ -8,7 +8,7 @@ import styles from '../styles/VisualizationOptions.style';
 
 const SortOrder = ({ classes }) => (
     <SelectBaseOption
-        className={classes.selectBaseRoot}
+        className={classes.selectBaseOption}
         option={{
             name: 'sortOrder',
             label: i18n.t('Sort order'),

--- a/packages/app/src/components/VisualizationOptions/Options/TargetLine.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TargetLine.js
@@ -14,7 +14,7 @@ import TargetLineLabel from './TargetLineLabel';
 import styles from '../styles/VisualizationOptions.style';
 
 export const TargetLine = ({ classes, enabled, onChange }) => (
-    <FormGroup className={classes.formGroupContainer} row={true}>
+    <FormGroup className={classes.targetLine} row={true}>
         <FormControlLabel
             className={classes.targetLineRoot}
             control={

--- a/packages/app/src/components/VisualizationOptions/__tests__/DataTab.spec.js
+++ b/packages/app/src/components/VisualizationOptions/__tests__/DataTab.spec.js
@@ -1,17 +1,26 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import FormGroup from '@material-ui/core/FormGroup';
+import { DataTab } from '../DataTab';
+import ShowData from '../Options/ShowData';
+import PercentStackedValues from '../Options/PercentStackedValues';
+import CumulativeValues from '../Options/CumulativeValues';
 import HideEmptyRowItems from '../Options/HideEmptyRowItems';
 import RegressionType from '../Options/RegressionType';
 import SortOrder from '../Options/SortOrder';
-import { DataTab } from '../DataTab';
+import TargetLine from '../Options/TargetLine';
+import BaseLine from '../Options/BaseLine';
+import AggregationType from '../Options/AggregationType';
 
 describe('The DataTab component', () => {
+    const props = {
+        classes: {},
+    };
     let shallowDataTab;
 
     const dataTab = () => {
         if (!shallowDataTab) {
-            shallowDataTab = shallow(<DataTab />);
+            shallowDataTab = shallow(<DataTab {...props} />);
         }
         return shallowDataTab;
     };
@@ -28,14 +37,15 @@ describe('The DataTab component', () => {
     });
 
     [
-        'CumulativeValues',
-        'PercentStackedValues',
-        'ShowData',
+        ShowData,
+        PercentStackedValues,
+        CumulativeValues,
         HideEmptyRowItems,
         RegressionType,
         SortOrder,
-        'AggregationType',
-        // TODO find a way to test BaseLine and TargetLine
+        TargetLine,
+        BaseLine,
+        AggregationType,
     ].forEach(component => {
         it(`should render a ${component} component`, () => {
             expect(dataTab().find(component)).toHaveLength(1);

--- a/packages/app/src/components/VisualizationOptions/styles/VisualizationOptions.style.js
+++ b/packages/app/src/components/VisualizationOptions/styles/VisualizationOptions.style.js
@@ -10,10 +10,17 @@ export default {
     tab: {
         width: '33.33%',
     },
-    rangeAxisMin: {
-        marginRight: '15px',
+    dataTabFormGroup: {
+        paddingTop: '8px',
     },
-    selectBaseRoot: {
+    axisTabFormGroup: {
+        height: '325px',
+        justifyContent: 'space-around',
+    },
+    dataTabCheckbox: {
+        height: '35px',
+    },
+    selectBaseOption: {
         margin: '15px 0px 10px',
     },
     regressionType: {
@@ -28,32 +35,26 @@ export default {
         top: '8px',
         marginRight: '25px',
     },
-    axisFormGroup: {
-        height: '325px',
-        justifyContent: 'space-around',
+    checkboxRoot: {
+        position: 'relative',
+        top: '10px',
+        marginLeft: '5px',
     },
     targetLine: {
         justifyContent: 'space-between',
         marginBottom: '8px',
     },
     baseLine: {
+        marginBottom: '5px',
         justifyContent: 'space-between',
-    },
-    titleFormGroup: {
-        marginBottom: '12px',
-    },
-    checkboxRoot: {
-        position: 'relative',
-        top: '10px',
-        marginLeft: '5px',
-    },
-    dataTabCheckbox: {
-        height: '35px',
     },
     aggregationType: {
         marginTop: '10px',
     },
-    dataTabFormGroup: {
-        paddingTop: '8px',
+    rangeAxisMin: {
+        marginRight: '15px',
+    },
+    titleFormGroup: {
+        marginBottom: '12px',
     },
 };

--- a/packages/app/src/components/VisualizationOptions/styles/VisualizationOptions.style.js
+++ b/packages/app/src/components/VisualizationOptions/styles/VisualizationOptions.style.js
@@ -14,7 +14,10 @@ export default {
         marginRight: '15px',
     },
     selectBaseRoot: {
-        marginBottom: '12px',
+        margin: '15px 0px 10px',
+    },
+    regressionType: {
+        margin: '10px 0px 10px',
     },
     targetLineRoot: {
         position: 'relative',
@@ -25,13 +28,16 @@ export default {
         top: '8px',
         marginRight: '25px',
     },
-    formGroupContainer: {
-        justifyContent: 'space-between',
-        marginBottom: '5px',
-    },
     axisFormGroup: {
         height: '325px',
         justifyContent: 'space-around',
+    },
+    targetLine: {
+        justifyContent: 'space-between',
+        marginBottom: '8px',
+    },
+    baseLine: {
+        justifyContent: 'space-between',
     },
     titleFormGroup: {
         marginBottom: '12px',
@@ -40,5 +46,14 @@ export default {
         position: 'relative',
         top: '10px',
         marginLeft: '5px',
+    },
+    dataTabCheckbox: {
+        height: '35px',
+    },
+    aggregationType: {
+        marginTop: '10px',
+    },
+    dataTabFormGroup: {
+        paddingTop: '8px',
     },
 };


### PR DESCRIPTION
This PR includes minor styling adjustments for the Options dialog's datatab.

The height of the checkbox containers ( Show Data / Stacked Values / Cumulative Values ) is reduced from default `height: 48px´ to `height: 35px`.

The DataTab FormGroup container have `padding-bottom: 8px` (to increase a bit of space between the first checkbox and the TabsBar).

The Selects have `marginTop/Bottom` instead of only `marginBottom` (HideEmptyRows and Sort Order have `marginTop: 15px` to increase the spacing and make the coupling of the components relation more distinct).

Additionally, propTypes have been added now that im using classes.

Some changes to the className.

Test cases have been modified now that im wrapping more components in withStyles.

Checked the build in IE11 and the changes are reflected equally between the different browsers .