### PR TITLE
Revert "fix: use lerna to share code instead of copying resources (#214)

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-02-11T15:01:16.680Z\n"
-"PO-Revision-Date: 2019-02-11T15:01:16.680Z\n"
+"POT-Creation-Date: 2019-01-21T11:22:11.007Z\n"
+"PO-Revision-Date: 2019-01-21T11:22:11.007Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -44,10 +44,10 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
-msgid "Search dimensions"
+msgid "Remove"
 msgstr ""
 
-msgid "Remove"
+msgid "Search dimensions"
 msgstr ""
 
 msgid "Dimension recommended with selected data"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,7 +46,7 @@
         "d2": "31.2.1",
         "d2-charts-api": "31.0.12",
         "d2-manifest": "^1.0.0",
-        "data-visualizer-plugin": "^32.0.2",
+        "data-visualizer-plugin": "github:d2-ci/data-visualizer-plugin",
         "dotenv": "6.0.0",
         "dotenv-expand": "4.2.0",
         "eslint": "5.4.0",

--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -3,16 +3,16 @@ import PropTypes from 'prop-types';
 
 import { createChart } from 'd2-charts-api';
 
-import { apiFetchVisualization } from 'data-visualizer-app/src/api/visualization';
+import { apiFetchVisualization } from './api/visualization';
 import {
     apiFetchAnalytics,
     apiFetchAnalyticsForYearOverYear,
-} from 'data-visualizer-app/src/api/analytics';
-import { isYearOverYear } from 'data-visualizer-app/src/modules/chartTypes';
-import { getOptionsForRequest } from 'data-visualizer-app/src/modules/options';
-import { computeGenericPeriodNames } from 'data-visualizer-app/src/modules/analytics';
-import { BASE_FIELD_YEARLY_SERIES } from 'data-visualizer-app/src/modules/fields/baseFields';
-import LoadingMask from 'data-visualizer-app/src/widgets/LoadingMask';
+} from './api/analytics';
+import { isYearOverYear } from './modules/chartTypes';
+import { getOptionsForRequest } from './modules/options';
+import { computeGenericPeriodNames } from './modules/analytics';
+import { BASE_FIELD_YEARLY_SERIES } from './modules/fields/baseFields';
+import LoadingMask from './widgets/LoadingMask';
 
 class ChartPlugin extends Component {
     constructor(props) {

--- a/packages/plugin/src/__tests__/ChartPlugin.spec.js
+++ b/packages/plugin/src/__tests__/ChartPlugin.spec.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import LoadingMask from 'data-visualizer-app/src/widgets/LoadingMask';
+import LoadingMask from '../widgets/LoadingMask';
 import ChartPlugin from '../ChartPlugin';
 import * as chartsApi from 'd2-charts-api';
-import * as api from 'data-visualizer-app/src/api/analytics';
-import * as apiViz from 'data-visualizer-app/src/api/visualization';
-import * as options from 'data-visualizer-app/src/modules/options';
-import { YEAR_OVER_YEAR_LINE, COLUMN } from 'data-visualizer-app/src/modules/chartTypes';
+import * as api from '../api/analytics';
+import * as apiViz from '../api/visualization';
+import * as options from '../modules/options';
+import { YEAR_OVER_YEAR_LINE, COLUMN } from '../modules/chartTypes';
 
 jest.mock('d2-charts-api');
 

--- a/packages/plugin/src/api/analytics.js
+++ b/packages/plugin/src/api/analytics.js
@@ -1,0 +1,58 @@
+import { getInstance } from 'd2';
+
+const peId = 'pe';
+
+export const apiFetchAnalytics = async (current, options) => {
+    const d2 = await getInstance();
+
+    const req = new d2.analytics.request()
+        .fromModel(current)
+        .withParameters(options);
+
+    const rawResponse = await d2.analytics.aggregate.get(req);
+
+    return [new d2.analytics.response(rawResponse)];
+};
+
+export const apiFetchAnalyticsForYearOverYear = async (current, options) => {
+    const d2 = await getInstance();
+
+    let yearlySeriesReq = new d2.analytics.request()
+        .addPeriodDimension(current.yearlySeries)
+        .withSkipData(true)
+        .withSkipMeta(false)
+        .withIncludeMetadataDetails(true);
+
+    if (options.relativePeriodDate) {
+        yearlySeriesReq = yearlySeriesReq.withRelativePeriodDate(
+            options.relativePeriodDate
+        );
+    }
+
+    const yearlySeriesRes = await d2.analytics.aggregate.fetch(yearlySeriesReq);
+
+    const requests = [];
+    const yearlySeriesLabels = [];
+
+    const now = new Date();
+    const currentDay = ('' + now.getDate()).padStart(2, 0);
+    const currentMonth = ('' + (now.getMonth() + 1)).padStart(2, 0);
+
+    yearlySeriesRes.metaData.dimensions[peId].forEach(period => {
+        yearlySeriesLabels.push(yearlySeriesRes.metaData.items[period].name);
+
+        const startDate = `${period}-${currentMonth}-${currentDay}`;
+
+        const req = new d2.analytics.request()
+            .fromModel(current)
+            .withParameters(options)
+            .withRelativePeriodDate(startDate);
+
+        requests.push(d2.analytics.aggregate.get(req));
+    });
+
+    return Promise.all(requests).then(responses => ({
+        responses: responses.map(res => new d2.analytics.response(res)),
+        yearlySeriesLabels,
+    }));
+};

--- a/packages/plugin/src/api/visualization.js
+++ b/packages/plugin/src/api/visualization.js
@@ -1,0 +1,9 @@
+import { getInstance } from 'd2';
+import { getFieldsStringByType } from '../modules/fields';
+
+export const apiFetchVisualization = (type, id) =>
+    getInstance().then(d2 =>
+        d2.models[type].get(id, {
+            fields: getFieldsStringByType(type),
+        })
+    );

--- a/packages/plugin/src/modules/analytics.js
+++ b/packages/plugin/src/modules/analytics.js
@@ -1,0 +1,29 @@
+export const computeGenericPeriodNames = responses => {
+    const xAxisRes = responses.reduce((out, res) => {
+        if (out.metaData) {
+            if (
+                res.metaData.dimensions.pe.length >
+                out.metaData.dimensions.pe.length
+            ) {
+                out = res;
+            }
+        } else {
+            out = res;
+        }
+
+        return out;
+    }, {});
+
+    const metadata = xAxisRes.metaData;
+
+    return metadata.dimensions.pe.reduce((genericPeriodNames, periodId) => {
+        const name = metadata.items[periodId].name;
+
+        // until the day the backend will support this in the API:
+        // trim off the trailing year in the period name
+        // english names should all have the year at the end of the string
+        genericPeriodNames.push(name.replace(/\s+\d{4}$/, ''));
+
+        return genericPeriodNames;
+    }, []);
+};

--- a/packages/plugin/src/modules/chartTypes.js
+++ b/packages/plugin/src/modules/chartTypes.js
@@ -1,0 +1,6 @@
+export const YEAR_OVER_YEAR_LINE = 'YEAR_OVER_YEAR_LINE';
+export const YEAR_OVER_YEAR_COLUMN = 'YEAR_OVER_YEAR_COLUMN';
+
+const yearOverYearTypes = [YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN];
+
+export const isYearOverYear = type => yearOverYearTypes.includes(type);

--- a/packages/plugin/src/modules/fields/baseFields.js
+++ b/packages/plugin/src/modules/fields/baseFields.js
@@ -1,0 +1,167 @@
+export const BASE_FIELD_NAME = 'name';
+export const BASE_FIELD_TYPE = 'type';
+export const BASE_FIELD_YEARLY_SERIES = 'yearlySeries';
+
+const getFieldObject = (name, props = {}) => ({
+    [BASE_FIELD_NAME]: name,
+    ...props,
+});
+
+// fields by type
+
+export const fieldsByType = {
+    reportTable: [
+        getFieldObject('cumulative', { option: true }),
+        getFieldObject('hideEmptyColumns', { option: true }),
+        getFieldObject('legendDisplayStyle', { option: true }),
+        getFieldObject('measureCriteria', { option: true }),
+        getFieldObject('numberType', { option: true }),
+        getFieldObject('regression', { option: true }),
+        getFieldObject('reportParams', { option: true }),
+        getFieldObject('skipRounding', { option: true }),
+    ],
+    chart: [
+        getFieldObject('category', { excluded: true }),
+        getFieldObject('series', { excluded: true }),
+        getFieldObject(BASE_FIELD_YEARLY_SERIES),
+    ],
+    eventReport: [getFieldObject('dataType')],
+    reportTable_eventReport: [
+        getFieldObject('colSubTotals', { option: true }),
+        getFieldObject('colTotals', { option: true }),
+        getFieldObject('displayDensity', { option: true }),
+        getFieldObject('fontSize', { option: true }),
+        getFieldObject('hideEmptyRows', { option: true }),
+        getFieldObject('rowSubTotals', { option: true }),
+        getFieldObject('rowTotals', { option: true }),
+        getFieldObject('showDimensionLabels', { option: true }),
+        getFieldObject('showHierarchy', { option: true }),
+    ],
+    chart_eventChart: [
+        getFieldObject('baseLineLabel', { option: true }),
+        getFieldObject('baseLineValue', { option: true }),
+        getFieldObject('colorSet', { option: true }),
+        getFieldObject('cumulativeValues', { option: true }),
+        getFieldObject('domainAxisLabel', { option: true }),
+        getFieldObject('hideEmptyRowItems', { option: true }),
+        getFieldObject('hideLegend', { option: true }),
+        getFieldObject('noSpaceBetweenColumns', { option: true }),
+        getFieldObject('percentStackedValues', { option: true }),
+        getFieldObject('rangeAxisDecimals', { option: true }),
+        getFieldObject('rangeAxisLabel', { option: true }),
+        getFieldObject('rangeAxisMaxValue', { option: true }),
+        getFieldObject('rangeAxisMinValue', { option: true }),
+        getFieldObject('rangeAxisSteps', { option: true }),
+        getFieldObject('regressionType', { option: true }),
+        getFieldObject('showData', { option: true }),
+        getFieldObject('targetLineLabel', { option: true }),
+        getFieldObject('targetLineValue', { option: true }),
+        getFieldObject(BASE_FIELD_TYPE, { option: true }),
+    ],
+    eventReport_eventChart: [
+        getFieldObject('attributeValueDimension'),
+        getFieldObject('collapseDataDimensions'),
+        getFieldObject('dataElementValueDimension'),
+        getFieldObject('endDate'),
+        getFieldObject('eventStatus', { option: true }),
+        getFieldObject('hideNaData', { option: true }),
+        getFieldObject('outputType', { option: true }),
+        getFieldObject('program'),
+        getFieldObject('programStage'),
+        getFieldObject('programStatus', { option: true }),
+        getFieldObject('startDate'),
+        getFieldObject('value'),
+    ],
+    reportTable_chart_eventReport: [
+        getFieldObject('legendDisplayStrategy', { option: true }),
+        getFieldObject('legendSet', { option: true }),
+    ],
+    reportTable_eventReport_eventChart: [
+        getFieldObject('columnDimensions', { excluded: true }),
+        getFieldObject('rowDimensions', { excluded: true }),
+    ],
+    reportTable_chart_eventReport_eventChart: [
+        getFieldObject('access'),
+        getFieldObject('aggregationType', { option: true }),
+        getFieldObject('attributeDimensions', { excluded: true }),
+        getFieldObject('attributeValues', { excluded: true }),
+        getFieldObject('categoryDimensions', { excluded: true }),
+        getFieldObject('categoryOptionGroupSetDimensions', { excluded: true }),
+        getFieldObject('code', { excluded: true }),
+        getFieldObject('columns'),
+        getFieldObject('completedOnly', { option: true }),
+        getFieldObject('created'),
+        getFieldObject('dataDimensionItems', { excluded: true }),
+        getFieldObject('dataElementDimensions', { excluded: true }),
+        getFieldObject('dataElementGroupSetDimensions', { excluded: true }),
+        getFieldObject('description'),
+        getFieldObject('digitGroupSeparator'),
+        getFieldObject('displayDescription'),
+        getFieldObject('displayName'),
+        getFieldObject('displayShortName'),
+        getFieldObject('externalAccess', { excluded: true }),
+        getFieldObject('favorite'),
+        getFieldObject('favorites'),
+        getFieldObject('filterDimensions', { excluded: true }),
+        getFieldObject('filters'),
+        getFieldObject('hideSubtitle', { option: true }),
+        getFieldObject('hideTitle', { option: true }),
+        getFieldObject('href', { excluded: true }),
+        getFieldObject('id'),
+        getFieldObject('interpretations'),
+        getFieldObject('itemOrganisationUnitGroups', { excluded: true }),
+        getFieldObject('lastUpdated'),
+        getFieldObject('lastUpdatedBy'),
+        getFieldObject('name'),
+        getFieldObject('organisationUnitGroupSetDimensions', {
+            excluded: true,
+        }),
+        getFieldObject('organisationUnitLevels', { excluded: true }),
+        getFieldObject('organisationUnits', { excluded: true }),
+        getFieldObject('parentGraphMap'),
+        getFieldObject('periods', { excluded: true }),
+        getFieldObject('programIndicatorDimensions', { excluded: true }),
+        getFieldObject('publicAccess'),
+        getFieldObject('relativePeriods', { excluded: true }),
+        getFieldObject('rows'),
+        getFieldObject('shortName'),
+        getFieldObject('sortOrder', { option: true }),
+        getFieldObject('subscribed'),
+        getFieldObject('subscribers'),
+        getFieldObject('subtitle', { option: true }),
+        getFieldObject('timeField'),
+        getFieldObject('title', { option: true }),
+        getFieldObject('topLimit', { option: true }),
+        getFieldObject('translations'),
+        getFieldObject('user'),
+        getFieldObject('userAccesses'),
+        getFieldObject('userGroupAccesses'),
+        getFieldObject('userOrganisationUnit', { excluded: true }),
+        getFieldObject('userOrganisationUnitChildren', { excluded: true }),
+        getFieldObject('userOrganisationUnitGrandChildren', { excluded: true }),
+    ],
+};
+
+// actions
+
+export const extractName = propObj => propObj[BASE_FIELD_NAME];
+
+export const markExcluded = fieldObj =>
+    fieldObj.excluded === true
+        ? { ...fieldObj, [BASE_FIELD_NAME]: `!${fieldObj[BASE_FIELD_NAME]}` }
+        : fieldObj;
+
+export const moveExcludedToEnd = (acc, current, curIndex, array) => {
+    !acc && (acc = array.slice());
+    current.charAt(0) === '!' && acc.push(acc.shift());
+    return acc;
+};
+
+// getters
+
+export const getAllFieldObjectsByType = type =>
+    Object.entries(fieldsByType).reduce(
+        (fields, [key, value]) =>
+            key.includes(type) ? fields.concat(value) : fields,
+        []
+    );

--- a/packages/plugin/src/modules/fields/index.js
+++ b/packages/plugin/src/modules/fields/index.js
@@ -1,0 +1,29 @@
+import {
+    getAllFieldObjectsByType,
+    extractName,
+    markExcluded,
+    moveExcludedToEnd,
+} from './baseFields';
+import { extendFields } from './nestedFields';
+
+export { getAllFieldObjectsByType };
+
+export const getOptionsByType = type =>
+    getAllFieldObjectsByType(type).filter(fieldObj => fieldObj.option === true);
+
+export const getIncludedByType = type =>
+    getAllFieldObjectsByType(type).filter(fieldObj => !fieldObj.excluded);
+
+export const getExcludedByType = type =>
+    getAllFieldObjectsByType(type).filter(
+        fieldObj => fieldObj.excluded === true
+    );
+
+export const getFieldsStringByType = type =>
+    getAllFieldObjectsByType(type)
+        .map(markExcluded)
+        .map(extractName)
+        .sort()
+        .reduce(moveExcludedToEnd, null)
+        .map(extendFields)
+        .join(',');

--- a/packages/plugin/src/modules/fields/nestedFields.js
+++ b/packages/plugin/src/modules/fields/nestedFields.js
@@ -1,0 +1,27 @@
+// constants
+
+const ID = 'id';
+const NAME = 'name,displayName,displayShortName';
+
+const DIMENSION_ITEM = `dimensionItem~rename(${ID})`;
+const LEGEND_SET = `legendSet[${ID},${NAME}]`;
+const USER = `user[${NAME},userCredentials[username]]`;
+
+const ITEMS = `items[${DIMENSION_ITEM},${NAME},dimensionItemType]`;
+const COMMENTS = `comments[${ID},${USER},lastUpdated,text`;
+
+const AXIS = `dimension,filter,${LEGEND_SET},${ITEMS}`;
+const INTERPRETATIONS = 'id,created';
+
+// nested fields map
+export const nestedFields = {
+    columns: AXIS,
+    rows: AXIS,
+    filters: AXIS,
+    user: USER,
+    comments: COMMENTS,
+    interpretations: INTERPRETATIONS,
+};
+
+export const extendFields = field =>
+    `${field}${nestedFields[field] ? `[${nestedFields[field]}]` : ''}`;

--- a/packages/plugin/src/modules/options.js
+++ b/packages/plugin/src/modules/options.js
@@ -1,0 +1,80 @@
+import pick from 'lodash-es/pick';
+
+export const options = {
+    baseLineLabel: { defaultValue: undefined, requestable: false },
+    baseLineValue: { defaultValue: undefined, requestable: false },
+    // colorSet:
+    cumulativeValues: { defaultValue: false, requestable: false },
+    domainAxisLabel: { defaultValue: undefined, requestable: false },
+    hideEmptyRowItems: { defaultValue: 'NONE', requestable: false },
+    hideLegend: { defaultValue: false, requestable: false },
+    noSpaceBetweenColumns: { defaultValue: false, requestable: false },
+    percentStackedValues: { defaultValue: false, requestable: false },
+    rangeAxisDecimals: { defaultValue: undefined, requestable: false },
+    rangeAxisLabel: { defaultValue: undefined, requestable: false },
+    rangeAxisMaxValue: { defaultValue: undefined, requestable: false },
+    rangeAxisMinValue: { defaultValue: undefined, requestable: false },
+    rangeAxisSteps: { defaultValue: undefined, requestable: false },
+    regressionType: { defaultValue: 'NONE', requestable: false },
+    showData: { defaultValue: true, requestable: false },
+    targetLineLabel: { defaultValue: undefined, requestable: false },
+    targetLineValue: { defaultValue: undefined, requestable: false },
+    // legendDisplayStrategy
+    // legendSet
+    aggregationType: { defaultValue: 'DEFAULT', requestable: true },
+    completedOnly: { defaultValue: false, requestable: true },
+    hideSubtitle: { defaultValue: false, requestable: false },
+    hideTitle: { defaultValue: false, requestable: false },
+    sortOrder: { defaultValue: 0, requestable: false },
+    subtitle: { defaultValue: undefined, requestable: false },
+    title: { defaultValue: undefined, requestable: false },
+    // topLimit
+};
+
+export const computedOptions = {
+    baseLine: { defaultValue: false, requestable: false },
+    targetLine: { defaultValue: false, requestable: false },
+};
+
+export default options;
+
+export const getOptionsForUi = () => {
+    return Object.entries({ ...options, ...computedOptions }).reduce(
+        (map, [option, props]) => {
+            map[option] = props.defaultValue;
+
+            return map;
+        },
+        {}
+    );
+};
+
+export const getOptionsForRequest = () => {
+    return Object.entries(options).filter(
+        ([option, props]) => props.requestable
+    );
+};
+
+const isNotDefault = (optionsFromVisualization, prop) => {
+    return Boolean(
+        optionsFromVisualization[prop] &&
+            optionsFromVisualization[prop] !== options[prop].defaultValue
+    );
+};
+
+export const getOptionsFromVisualization = visualization => {
+    const optionsFromVisualization = {
+        ...getOptionsForUi(),
+        ...pick(visualization, Object.keys(options)),
+    };
+
+    optionsFromVisualization.baseLine =
+        isNotDefault(optionsFromVisualization, 'baseLineLabel') ||
+        isNotDefault(optionsFromVisualization, 'baseLineValue');
+
+    optionsFromVisualization.targetLine =
+        isNotDefault(optionsFromVisualization, 'targetLineLabel') ||
+        isNotDefault(optionsFromVisualization, 'targetLineValue');
+
+    return optionsFromVisualization;
+};

--- a/packages/plugin/src/widgets/LoadingMask.js
+++ b/packages/plugin/src/widgets/LoadingMask.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+const styles = theme => ({
+    progress: {
+        margin: theme.spacing.unit * 2,
+        maxWidth: 200,
+        textAlign: 'center',
+        alignSelf: 'center',
+    },
+    outer: {
+        display: 'flex',
+        justifyContent: 'center',
+        height: '100%',
+    },
+});
+
+function CircularIndeterminate(props) {
+    const { classes } = props;
+    return (
+        <div className={classes.outer}>
+            <CircularProgress className={classes.progress} />
+        </div>
+    );
+}
+
+CircularIndeterminate.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(CircularIndeterminate);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,6 +4271,17 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+"data-visualizer-plugin@github:d2-ci/data-visualizer-plugin":
+  version "32.0.2"
+  resolved "https://codeload.github.com/d2-ci/data-visualizer-plugin/tar.gz/7791bc7f3f0454e55d4e30213e236ce101f2f844"
+  dependencies:
+    "@material-ui/core" "^3.1.2"
+    d2 "31.2.1"
+    d2-charts-api "^31.0.12"
+    lodash-es "^4.17.11"
+    react "^16.6.0"
+    react-dom "^16.6.0"
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"


### PR DESCRIPTION
This reverts commit eecfea0dd13e7620e0dd5c1f104e8aba0a3b5505.

The code-sharing solution does not work when the plugin is pulled in as a dependency in other apps (e.g., dashboards), since imports like:

`import { apiFetchVisualization } from 'data-visualizer-app/src/api/visualization';`

don't exist in dashboards. This code will have to remain duplicated until we are ready with a published, shared library.