### PR TITLE
Append correct paths for org units

### DIFF
--- a/packages/app/src/components/DimensionsPanel/Dialogs/OrgUnitDimension/OrgUnitDimension.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/OrgUnitDimension/OrgUnitDimension.js
@@ -6,12 +6,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import i18n from '@dhis2/d2-i18n';
 import PropTypes from 'prop-types';
 import { colors } from 'analytics-shared';
-
-import {
-    OrgUnitSelector,
-    userOrgUnits,
-    removeOrgUnitLastPathSegment,
-} from '@dhis2/d2-ui-org-unit-dialog';
+import { OrgUnitSelector, userOrgUnits } from '@dhis2/d2-ui-org-unit-dialog';
 
 import {
     sGetUiItemsByDimension,
@@ -46,6 +41,7 @@ import {
     getGroupsFromIds,
     sortOrgUnitLevels,
     transformOptionsIntoMetadata,
+    removeOrgUnitLastPathSegment,
 } from '../../../../modules/orgUnitDimensions';
 
 import { FIXED_DIMENSIONS } from '../../../../modules/fixedDimensions';

--- a/packages/app/src/components/DimensionsPanel/Dialogs/OrgUnitDimension/OrgUnitDimension.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/OrgUnitDimension/OrgUnitDimension.js
@@ -102,10 +102,18 @@ export class OrgUnitDimension extends Component {
     };
 
     addOrgUnitPathToParentGraphMap = orgUnit => {
-        const path = removeOrgUnitLastPathSegment(orgUnit.path);
+        let value;
+
+        if ('/' + orgUnit.id === orgUnit.path) {
+            // root org unit case
+            value = '';
+        } else {
+            const path = removeOrgUnitLastPathSegment(orgUnit.path);
+            value = path[0] === '/' ? path.substr(1) : path;
+        }
 
         this.props.acAddParentGraphMap({
-            [orgUnit.id]: path[0] === '/' ? path.substr(1) : path,
+            [orgUnit.id]: value,
         });
     };
 

--- a/packages/app/src/modules/__tests__/currentAnalyticalObject.spec.js
+++ b/packages/app/src/modules/__tests__/currentAnalyticalObject.spec.js
@@ -1,4 +1,5 @@
 import {
+    appendCompleteParentGraphMap,
     appendDimensionItemNamesToAnalyticalObject,
     appendPathsToOrgUnits,
     getPathForOrgUnit,
@@ -218,8 +219,27 @@ describe('currentAnalyticalObject', () => {
         });
     });
 
+    describe('appendCompleteParentGraphMap', () => {
+        it('appends complete parent graph map property', () => {
+            const parentGraphMap = {
+                SOME_ORG_UNIT_ID: 'SOME_ORG_UNIT_PARENT',
+            };
+            const expected = {
+                ...mockCurrent,
+                parentGraphMap: {
+                    ...mockCurrent.parentGraphMap,
+                    SOME_ORG_UNIT_ID: 'SOME_ORG_UNIT_PARENT',
+                },
+            };
+
+            expect(
+                appendCompleteParentGraphMap(mockCurrent, { parentGraphMap })
+            ).toEqual(expected);
+        });
+    });
+
     describe('prepareCurrentAnalyticalObject', () => {
-        it('appends org unit paths, dimension item names and removes attributes and ', () => {
+        it('prepares current analytical object for user data store', () => {
             const expected = {
                 key: 'value',
                 columns: [
@@ -233,6 +253,10 @@ describe('currentAnalyticalObject', () => {
                         ],
                     },
                 ],
+                parentGraphMap: {
+                    qhqAxPSTUXp: 'ImspTQPwCqd',
+                    Vth0fbpFcsO: 'ImspTQPwCqd',
+                },
                 filters: [
                     {
                         dimension: 'ou',

--- a/packages/app/src/modules/__tests__/currentAnalyticalObject.spec.js
+++ b/packages/app/src/modules/__tests__/currentAnalyticalObject.spec.js
@@ -87,6 +87,13 @@ describe('currentAnalyticalObject', () => {
                 expectedPath
             );
         });
+
+        it('returns undefined if parentGraphMap does not contain specified parent path', () => {
+            const orgUnit = 'USER_ORG_UNIT_CHILDREN';
+            const parentGraphMap = {};
+
+            expect(getPathForOrgUnit(orgUnit, parentGraphMap)).toBeUndefined();
+        });
     });
 
     describe('appendPathsToOrgUnits', () => {

--- a/packages/app/src/modules/__tests__/currentAnalyticalObject.spec.js
+++ b/packages/app/src/modules/__tests__/currentAnalyticalObject.spec.js
@@ -1,6 +1,7 @@
 import {
     appendDimensionItemNamesToAnalyticalObject,
     appendPathsToOrgUnits,
+    getPathForOrgUnit,
     prepareCurrentAnalyticalObject,
     removeUnnecessaryAttributesFromAnalyticalObject,
 } from '../currentAnalyticalObject';
@@ -64,6 +65,30 @@ describe('currentAnalyticalObject', () => {
         };
     });
 
+    describe('getPathForOrgUnit', () => {
+        it('generates path for orgunit using ui.parentGraphMap', () => {
+            const orgUnit = { id: 'SOME_ID' };
+            const parentGraphMap = { SOME_ID: 'ORG_UNIT/SUB_ORG_UNIT' };
+            const expectedPath = '/ORG_UNIT/SUB_ORG_UNIT/SOME_ID';
+
+            expect(getPathForOrgUnit(orgUnit, parentGraphMap)).toEqual(
+                expectedPath
+            );
+        });
+
+        it('handles root org unit case', () => {
+            const orgUnit = { id: 'ROOT_SIERRA_LEONE_ORG_UNIT' };
+            const parentGraphMap = {
+                ROOT_SIERRA_LEONE_ORG_UNIT: 'ROOT_SIERRA_LEONE_ORG_UNIT',
+            };
+            const expectedPath = '/ROOT_SIERRA_LEONE_ORG_UNIT';
+
+            expect(getPathForOrgUnit(orgUnit, parentGraphMap)).toEqual(
+                expectedPath
+            );
+        });
+    });
+
     describe('appendPathsToOrgUnits', () => {
         it('appends org unit paths to current analytical object', () => {
             const expected = {
@@ -74,11 +99,11 @@ describe('currentAnalyticalObject', () => {
                         items: [
                             {
                                 id: 'qhqAxPSTUXp',
-                                path: 'ImspTQPwCqd',
+                                path: '/ImspTQPwCqd/qhqAxPSTUXp',
                             },
                             {
                                 id: 'Vth0fbpFcsO',
-                                path: 'ImspTQPwCqd',
+                                path: '/ImspTQPwCqd/Vth0fbpFcsO',
                             },
                         ],
                     },
@@ -208,12 +233,12 @@ describe('currentAnalyticalObject', () => {
                             {
                                 id: 'qhqAxPSTUXp',
                                 name: 'Koinadugu',
-                                path: 'ImspTQPwCqd',
+                                path: '/ImspTQPwCqd/qhqAxPSTUXp',
                             },
                             {
                                 id: 'Vth0fbpFcsO',
                                 name: 'Kono',
-                                path: 'ImspTQPwCqd',
+                                path: '/ImspTQPwCqd/Vth0fbpFcsO',
                             },
                         ],
                     },

--- a/packages/app/src/modules/__tests__/currentAnalyticalObject.spec.js
+++ b/packages/app/src/modules/__tests__/currentAnalyticalObject.spec.js
@@ -79,7 +79,7 @@ describe('currentAnalyticalObject', () => {
         it('handles root org unit case', () => {
             const orgUnit = { id: 'ROOT_SIERRA_LEONE_ORG_UNIT' };
             const parentGraphMap = {
-                ROOT_SIERRA_LEONE_ORG_UNIT: 'ROOT_SIERRA_LEONE_ORG_UNIT',
+                ROOT_SIERRA_LEONE_ORG_UNIT: '',
             };
             const expectedPath = '/ROOT_SIERRA_LEONE_ORG_UNIT';
 

--- a/packages/app/src/modules/__tests__/orgUnitDimension.spec.js
+++ b/packages/app/src/modules/__tests__/orgUnitDimension.spec.js
@@ -9,6 +9,7 @@ import {
     getGroupsFromIds,
     sortOrgUnitLevels,
     transformOptionsIntoMetadata,
+    removeOrgUnitLastPathSegment,
 } from '../orgUnitDimensions';
 
 describe('isLevelId', () => {
@@ -313,5 +314,25 @@ describe('transformOptionsIntoMetadata', () => {
                 options.find(option => option.id === id)
             );
         });
+    });
+});
+
+describe('removeOrgUnitLastPathSegment', () => {
+    it('handles a root path', () => {
+        const path = '/';
+
+        expect(removeOrgUnitLastPathSegment(path)).toEqual(path);
+    });
+
+    it('handles a path with single segment', () => {
+        const path = '/abc';
+
+        expect(removeOrgUnitLastPathSegment(path)).toEqual(path);
+    });
+
+    it('handles a path with multiple segments', () => {
+        const path = 'ABC/def/GHI';
+
+        expect(removeOrgUnitLastPathSegment(path)).toEqual('ABC/def');
     });
 });

--- a/packages/app/src/modules/__tests__/ui.spec.js
+++ b/packages/app/src/modules/__tests__/ui.spec.js
@@ -63,11 +63,11 @@ describe('ui', () => {
                         items: [
                             {
                                 id: 'qhqAxPSTUXp',
-                                path: 'ImspTQPwCqd',
+                                path: '/ImspTQPwCqd',
                             },
                             {
                                 id: 'Vth0fbpFcsO',
-                                path: 'ImspTQPwCqd',
+                                path: '/ImspTQPwCqd',
                             },
                         ],
                     },

--- a/packages/app/src/modules/currentAnalyticalObject.js
+++ b/packages/app/src/modules/currentAnalyticalObject.js
@@ -65,12 +65,21 @@ export const appendDimensionItemNamesToAnalyticalObject = (
     };
 };
 
+export const appendCompleteParentGraphMap = (current, { parentGraphMap }) => ({
+    ...current,
+    parentGraphMap: {
+        ...current.parentGraphMap,
+        ...parentGraphMap,
+    },
+});
+
 export const prepareCurrentAnalyticalObject = (current, metadata, ui) => {
     let result;
 
     result = removeUnnecessaryAttributesFromAnalyticalObject(current);
     result = appendDimensionItemNamesToAnalyticalObject(result, metadata);
     result = appendPathsToOrgUnits(result, ui);
+    result = appendCompleteParentGraphMap(result, ui);
 
     return result;
 };

--- a/packages/app/src/modules/currentAnalyticalObject.js
+++ b/packages/app/src/modules/currentAnalyticalObject.js
@@ -2,13 +2,13 @@ import { FIXED_DIMENSIONS } from './fixedDimensions';
 import { getDimensionIdsByAxis, getInverseLayout } from './layout';
 
 export const getPathForOrgUnit = (orgUnit, parentGraphMap) => {
-    if (!parentGraphMap[orgUnit.id]) {
+    if (parentGraphMap[orgUnit.id] === undefined) {
         return undefined;
     }
 
-    // if this is org unit then in parentGraphMap object
-    // it has same value as key
-    if (orgUnit.id === parentGraphMap[orgUnit.id]) {
+    // if this is root org unit then in parentGraphMap object
+    // it has empty string as value and id as key
+    if (parentGraphMap[orgUnit.id] === '') {
         return '/' + orgUnit.id;
     }
 

--- a/packages/app/src/modules/currentAnalyticalObject.js
+++ b/packages/app/src/modules/currentAnalyticalObject.js
@@ -2,6 +2,10 @@ import { FIXED_DIMENSIONS } from './fixedDimensions';
 import { getDimensionIdsByAxis, getInverseLayout } from './layout';
 
 export const getPathForOrgUnit = (orgUnit, parentGraphMap) => {
+    if (!parentGraphMap[orgUnit.id]) {
+        return undefined;
+    }
+
     // if this is org unit then in parentGraphMap object
     // it has same value as key
     if (orgUnit.id === parentGraphMap[orgUnit.id]) {

--- a/packages/app/src/modules/currentAnalyticalObject.js
+++ b/packages/app/src/modules/currentAnalyticalObject.js
@@ -1,6 +1,16 @@
 import { FIXED_DIMENSIONS } from './fixedDimensions';
 import { getDimensionIdsByAxis, getInverseLayout } from './layout';
 
+export const getPathForOrgUnit = (orgUnit, parentGraphMap) => {
+    // if this is org unit then in parentGraphMap object
+    // it has same value as key
+    if (orgUnit.id === parentGraphMap[orgUnit.id]) {
+        return '/' + orgUnit.id;
+    }
+
+    return '/' + parentGraphMap[orgUnit.id] + '/' + orgUnit.id;
+};
+
 export const appendPathsToOrgUnits = (current, ui) => {
     const ouId = FIXED_DIMENSIONS.ou.id;
     const dimensionIdsByAxis = getDimensionIdsByAxis(current);
@@ -18,7 +28,7 @@ export const appendPathsToOrgUnits = (current, ui) => {
             ...dimension,
             items: dimension.items.map(item => ({
                 ...item,
-                path: parentGraphMap[item.id],
+                path: getPathForOrgUnit(item, parentGraphMap),
             })),
         })),
     };

--- a/packages/app/src/modules/orgUnitDimensions.js
+++ b/packages/app/src/modules/orgUnitDimensions.js
@@ -160,3 +160,12 @@ export const transformOptionsIntoMetadata = (
         metadata: result,
     };
 };
+
+export const removeOrgUnitLastPathSegment = path => {
+    // if root path, then return unprocessed path
+    if (path.match(/\//g).length === 1) {
+        return path;
+    }
+
+    return path.substr(0, path.lastIndexOf('/'));
+};

--- a/packages/app/src/modules/ui.js
+++ b/packages/app/src/modules/ui.js
@@ -92,10 +92,14 @@ export const getParentGraphMapFromVisualization = vis => {
     ouDimension.items
         .filter(orgUnit => orgUnit.path)
         .forEach(orgUnit => {
-            const path = removeOrgUnitLastPathSegment(orgUnit.path);
-
-            parentGraphMap[orgUnit.id] =
-                path[0] === '/' ? path.substr(1) : path;
+            if ('/' + orgUnit.id === orgUnit.path) {
+                // root org unit case
+                parentGraphMap[orgUnit.id] = '';
+            } else {
+                const path = removeOrgUnitLastPathSegment(orgUnit.path);
+                parentGraphMap[orgUnit.id] =
+                    path[0] === '/' ? path.substr(1) : path;
+            }
         });
 
     return parentGraphMap;

--- a/packages/app/src/modules/ui.js
+++ b/packages/app/src/modules/ui.js
@@ -15,6 +15,7 @@ import { isYearOverYear } from './chartTypes';
 import { getOptionsFromVisualization } from './options';
 import { BASE_FIELD_YEARLY_SERIES } from './fields/baseFields';
 import { pieLayoutAdapter, yearOverYearLayoutAdapter } from './layoutAdapters';
+import { removeOrgUnitLastPathSegment } from './orgUnitDimensions';
 
 const peId = FIXED_DIMENSIONS.pe.id;
 
@@ -91,7 +92,10 @@ export const getParentGraphMapFromVisualization = vis => {
     ouDimension.items
         .filter(orgUnit => orgUnit.path)
         .forEach(orgUnit => {
-            parentGraphMap[orgUnit.id] = orgUnit.path;
+            const path = removeOrgUnitLastPathSegment(orgUnit.path);
+
+            parentGraphMap[orgUnit.id] =
+                path[0] === '/' ? path.substr(1) : path;
         });
 
     return parentGraphMap;

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -73,8 +73,7 @@ describe('reducer: ui', () => {
             ...ui.DEFAULT_UI,
             parentGraphMap: {
                 ...ui.DEFAULT_UI.parentGraphMap,
-                [settings.rootOrganisationUnit.id]:
-                    settings.rootOrganisationUnit.id,
+                [settings.rootOrganisationUnit.id]: '',
             },
             itemsByDimension: {
                 ...ui.DEFAULT_UI.itemsByDimension,

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -73,9 +73,8 @@ describe('reducer: ui', () => {
             ...ui.DEFAULT_UI,
             parentGraphMap: {
                 ...ui.DEFAULT_UI.parentGraphMap,
-                [settings.rootOrganisationUnit.id]: `/${
-                    settings.rootOrganisationUnit.id
-                }`,
+                [settings.rootOrganisationUnit.id]:
+                    settings.rootOrganisationUnit.id,
             },
             itemsByDimension: {
                 ...ui.DEFAULT_UI.itemsByDimension,

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -207,7 +207,7 @@ export default (state = DEFAULT_UI, action) => {
                 },
                 parentGraphMap: {
                     ...DEFAULT_UI.parentGraphMap,
-                    [rootOrganisationUnit.id]: `/${rootOrganisationUnit.id}`,
+                    [rootOrganisationUnit.id]: rootOrganisationUnit.id,
                 },
             };
         case TOGGLE_UI_RIGHT_SIDEBAR_OPEN:

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -207,7 +207,7 @@ export default (state = DEFAULT_UI, action) => {
                 },
                 parentGraphMap: {
                     ...DEFAULT_UI.parentGraphMap,
-                    [rootOrganisationUnit.id]: rootOrganisationUnit.id,
+                    [rootOrganisationUnit.id]: '',
                 },
             };
         case TOGGLE_UI_RIGHT_SIDEBAR_OPEN:


### PR DESCRIPTION
Relates to [DHIS2-5987](https://jira.dhis2.org/browse/DHIS2-5987).

This PR covers some edge cases for "Open as map" feature and contains:
- Fix for generating correct paths for `ou` dimension items (with `/` prefix) and supplying them to current analytical object in user data store
- Fix for generating correct parentGraphMap *from* current analytical object
- Fix for generating complete correct parentGraphMap *for* current analytical object
- Fix for generating correct parentGraphMap value for root organisation unit upon orgunit selection in `OrgUnitDimension` dialog.
- Tests

P.s. I had to reimplement `removeLastPathSegment` function which was earlier imported from `@dhis2/d2-ui-org-unit-dialog` component, since importing causes circular dependency error (presumably coming from d2).