### PR TITLE
fix: Fetching analytics for year over year charts in plugin

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -111,6 +111,7 @@ class ChartPlugin extends Component {
                     responses,
                     yearlySeriesLabels,
                 } = await apiFetchAnalyticsForYearOverYear(
+                    this.props.d2,
                     visualization,
                     options
                 ));

--- a/packages/plugin/src/__tests__/ChartPlugin.spec.js
+++ b/packages/plugin/src/__tests__/ChartPlugin.spec.js
@@ -277,6 +277,7 @@ describe('ChartPlugin', () => {
                     expect(
                         api.apiFetchAnalyticsForYearOverYear.mock.calls[0][1]
                     ).toEqual({
+                        ...yearOverYearCurrentMock,
                         option1: 'def',
                     });
 


### PR DESCRIPTION
Pass required d2 prop to `apiFetchAnalyticsForYearOverYear` function in plugin