### PR TITLE
fix: Fetching analytics for analytical object with undefined aggregationType in plugin

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -52,12 +52,9 @@ class ChartPlugin extends Component {
         const options = getOptionsForRequest().reduce(
             (map, [option, props]) => {
                 // only add parameter if value !== default
-                // only assign undefined if defaultValue is/can be undefined
                 if (
-                    (visualization[option] !== undefined &&
-                        visualization[option] !== props.defaultValue) ||
-                    (visualization[option] === undefined &&
-                        visualization[option] === props.defaultValue)
+                    visualization[option] !== undefined &&
+                    visualization[option] !== props.defaultValue
                 ) {
                     map[option] = visualization[option];
                 }

--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -52,7 +52,13 @@ class ChartPlugin extends Component {
         const options = getOptionsForRequest().reduce(
             (map, [option, props]) => {
                 // only add parameter if value !== default
-                if (visualization[option] !== props.defaultValue) {
+                // only assign undefined if defaultValue is/can be undefined
+                if (
+                    (visualization[option] !== undefined &&
+                        visualization[option] !== props.defaultValue) ||
+                    (visualization[option] === undefined &&
+                        visualization[option] === props.defaultValue)
+                ) {
                     map[option] = visualization[option];
                 }
 


### PR DESCRIPTION
### Problem:
When we pass full analytical to the plugin without `aggregationType` property specified, it passes it to analytics request.

As a result we have request like this:
_localhost:8080/api/29/analytics.json?dimension=dx:ntzmpYRSKGg&dimension=ou:ImspTQPwCqd;LEVEL-3&filter=pe:2018&**aggregationType=undefined**&skipMeta=false&skipData=true&includeMetadataDetails=true_

This request returns 500 server error.
Removing `aggregationType=undefined` from analytics URL makes request correct and it returns correct response. 

### Proposal:
To fix this we can check if option value (e.g. aggregationType) is undefined and if it is - check if defaultValue is/can be undefined. If the answer to both questions is yes, then assume we can assign undefined to option value, otherwise skip assigning (see files changed).