### PR TITLE
fix: manifest credentials bug in chrome

### DIFF
--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -11,7 +11,7 @@
             manifest.json provides metadata used when your web app is added to the
             homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
         -->
-        <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+        <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials"/>
         <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
 
         <%= htmlWebpackPlugin.options.vendorScripts %>


### PR DESCRIPTION
See https://jira.dhis2.org/browse/DHIS2-6122.

From my comment in the Jira-issue: 
> This bug only seem to affect Chrome. The reason is that chrome does not seem to send credential-headers or cookies for 'rel=manifest' attributes on the link-tag, even for same origin requests. This means that the server responds with a 302-redirect to the login-page, and the browser tries to parse this as JSON, which fails since its html (the login page).
The solution is to add the attribute `crossorigin='use-credentials'`/ to the manifest-link-tag.
See https://github.com/w3c/manifest/issues/186#issuecomment-43939505 and https://github.com/w3c/manifest/issues/535#issuecomment-435739223 for discussion about this weird behaviour.
