### PR TITLE
Fetch vis by id only when passed config contains only id

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -98,7 +98,7 @@ class ChartPlugin extends Component {
 
         try {
             const visualization =
-                forDashboard || Object.keys(config).length === 1
+                Object.keys(config).length === 1 && config.id
                     ? await this.getConfigById(config.id)
                     : config;
 

--- a/packages/plugin/src/__tests__/ChartPlugin.spec.js
+++ b/packages/plugin/src/__tests__/ChartPlugin.spec.js
@@ -182,11 +182,10 @@ describe('ChartPlugin', () => {
             });
         });
 
-        it('fetches the AO by id when forDashboard is passed', done => {
+        it('fetches the AO by id when only id is passed in config', done => {
             props.forDashboard = true;
             props.config = {
                 id: 'test1',
-                type: COLUMN,
             };
 
             canvas();


### PR DESCRIPTION
In the other cases always use the config object directly.
This is to allow dashboards to set filters directly on the AO.