### PR TITLE
chore: generate missing snapshots for tests

### DIFF
--- a/packages/app/src/components/DimensionsPanel/Dialogs/__tests__/DialogManager.spec.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/__tests__/DialogManager.spec.js
@@ -60,43 +60,43 @@ describe('The DialogManager component', () => {
         expect(dialog.state().ouMounted).toBe(true);
     });
 
-    // it('renders the DataDimension content in dialog', () => {
-    //     const dialog = dialogManager().setProps({
-    //         dialogId: FIXED_DIMENSIONS.dx.id,
-    //     });
+    it('renders the DataDimension content in dialog', () => {
+        const dialog = dialogManager().setProps({
+            dialogId: FIXED_DIMENSIONS.dx.id,
+        });
 
-    //     expect(dialog).toMatchSnapshot();
-    // });
+        expect(dialog).toMatchSnapshot();
+    });
 
-    // it('renders the OrgUnitDimension content in dialog', () => {
-    //     const dialog = dialogManager().setProps({
-    //         dialogId: FIXED_DIMENSIONS.ou.id,
-    //     });
+    it('renders the OrgUnitDimension content in dialog', () => {
+        const dialog = dialogManager().setProps({
+            dialogId: FIXED_DIMENSIONS.ou.id,
+        });
 
-    //     expect(dialog).toMatchSnapshot();
-    // });
+        expect(dialog).toMatchSnapshot();
+    });
 
-    // it('renders the PeriodDimension content in dialog', () => {
-    //     const dialog = dialogManager().setProps({
-    //         dialogId: FIXED_DIMENSIONS.pe.id,
-    //     });
+    it('renders the PeriodDimension content in dialog', () => {
+        const dialog = dialogManager().setProps({
+            dialogId: FIXED_DIMENSIONS.pe.id,
+        });
 
-    //     expect(dialog).toMatchSnapshot();
-    // });
+        expect(dialog).toMatchSnapshot();
+    });
 
-    // it('renders OUDimension content with display:none when previously mounted', () => {
-    //     const dialog = dialogManager().setProps({
-    //         dialogId: FIXED_DIMENSIONS.ou.id,
-    //     });
+    it('renders OUDimension content with display:none when previously mounted', () => {
+        const dialog = dialogManager().setProps({
+            dialogId: FIXED_DIMENSIONS.ou.id,
+        });
 
-    //     expect(dialog).toMatchSnapshot();
+        expect(dialog).toMatchSnapshot();
 
-    //     dialog.setProps({ dialogId: null });
-    //     expect(dialog).toMatchSnapshot();
+        dialog.setProps({ dialogId: null });
+        expect(dialog).toMatchSnapshot();
 
-    //     dialog.setProps({ dialogId: FIXED_DIMENSIONS.dx.id });
-    //     expect(dialog).toMatchSnapshot();
-    // });
+        dialog.setProps({ dialogId: FIXED_DIMENSIONS.dx.id });
+        expect(dialog).toMatchSnapshot();
+    });
 
     it('sets the recommended Ids (with debounced delay) when a change in dx (Data) or ou (Organisation Unit) occurs', () => {
         const dialog = dialogManager();

--- a/packages/app/src/components/DimensionsPanel/Dialogs/__tests__/__snapshots__/DialogManager.spec.js.snap
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/__tests__/__snapshots__/DialogManager.spec.js.snap
@@ -1,5 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`The DialogManager component renders OUDimension content with display:none when previously mounted 1`] = `
+<Component
+  data-test="dialog-manager"
+  disableEnforceFocus={true}
+  keepMounted={true}
+  maxWidth="lg"
+  onClose={[Function]}
+  open={false}
+>
+  <div
+    key="ou"
+    style={
+      Object {
+        "display": "block",
+      }
+    }
+  >
+    <Connect(OrgUnitDimension) />
+  </div>
+  <Component>
+    <Connect(HideButton) />
+    <Connect(WithStyles(AddToLayoutButton))
+      dialogId="ou"
+    />
+  </Component>
+</Component>
+`;
+
+exports[`The DialogManager component renders OUDimension content with display:none when previously mounted 2`] = `
+<Component
+  data-test="dialog-manager"
+  disableEnforceFocus={true}
+  keepMounted={true}
+  maxWidth="lg"
+  onClose={[Function]}
+  open={false}
+>
+  <div
+    key="ou"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  >
+    <Connect(OrgUnitDimension) />
+  </div>
+  <Component>
+    <Connect(HideButton) />
+  </Component>
+</Component>
+`;
+
+exports[`The DialogManager component renders OUDimension content with display:none when previously mounted 3`] = `
+<Component
+  data-test="dialog-manager"
+  disableEnforceFocus={true}
+  keepMounted={false}
+  maxWidth="lg"
+  onClose={[Function]}
+  open={false}
+>
+  <div
+    key="ou"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  >
+    <Connect(OrgUnitDimension) />
+  </div>
+  <Connect(DataDimension) />
+  <Component>
+    <Connect(HideButton) />
+    <Connect(WithStyles(AddToLayoutButton))
+      dialogId="dx"
+    />
+  </Component>
+</Component>
+`;
+
 exports[`The DialogManager component renders a closed dialog 1`] = `
 <Component
   data-test="dialog-manager"
@@ -11,6 +93,25 @@ exports[`The DialogManager component renders a closed dialog 1`] = `
 >
   <Component>
     <Connect(HideButton) />
+  </Component>
+</Component>
+`;
+
+exports[`The DialogManager component renders the DataDimension content in dialog 1`] = `
+<Component
+  data-test="dialog-manager"
+  disableEnforceFocus={true}
+  keepMounted={false}
+  maxWidth="lg"
+  onClose={[Function]}
+  open={false}
+>
+  <Connect(DataDimension) />
+  <Component>
+    <Connect(HideButton) />
+    <Connect(WithStyles(AddToLayoutButton))
+      dialogId="dx"
+    />
   </Component>
 </Component>
 `;
@@ -31,6 +132,53 @@ exports[`The DialogManager component renders the DynamicDimension content in dia
     <Connect(HideButton) />
     <Connect(WithStyles(AddToLayoutButton))
       dialogId="test"
+    />
+  </Component>
+</Component>
+`;
+
+exports[`The DialogManager component renders the OrgUnitDimension content in dialog 1`] = `
+<Component
+  data-test="dialog-manager"
+  disableEnforceFocus={true}
+  keepMounted={true}
+  maxWidth="lg"
+  onClose={[Function]}
+  open={false}
+>
+  <div
+    key="ou"
+    style={
+      Object {
+        "display": "block",
+      }
+    }
+  >
+    <Connect(OrgUnitDimension) />
+  </div>
+  <Component>
+    <Connect(HideButton) />
+    <Connect(WithStyles(AddToLayoutButton))
+      dialogId="ou"
+    />
+  </Component>
+</Component>
+`;
+
+exports[`The DialogManager component renders the PeriodDimension content in dialog 1`] = `
+<Component
+  data-test="dialog-manager"
+  disableEnforceFocus={true}
+  keepMounted={false}
+  maxWidth="lg"
+  onClose={[Function]}
+  open={false}
+>
+  <Connect(PeriodDimension) />
+  <Component>
+    <Connect(HideButton) />
+    <Connect(WithStyles(AddToLayoutButton))
+      dialogId="pe"
     />
   </Component>
 </Component>

--- a/packages/shared/src/components/ItemSelector/__tests__/SelectedItems.spec.js
+++ b/packages/shared/src/components/ItemSelector/__tests__/SelectedItems.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { SelectedItems } from '../SelectedItems';
 
 describe('The SelectedItems component', () => {
@@ -22,10 +22,6 @@ describe('The SelectedItems component', () => {
         selectedItemsWrapper = undefined;
     });
 
-    // it('matches the snapshot when list is empty', () => {
-    //     expect(selectedItems()).toMatchSnapshot();
-    // });
-
     describe('list with items', () => {
         beforeEach(() => {
             props.items = [
@@ -36,9 +32,6 @@ describe('The SelectedItems component', () => {
                 { id: 'rr', name: 'rarity' },
             ];
         });
-        // it('matches the snapshot with list has items', () => {
-        //     expect(selectedItems()).toMatchSnapshot();
-        // });
 
         it('triggers onDeselect when item double-clicked', () => {
             selectedItems()


### PR DESCRIPTION
Changes include:
* generate and check snapshots for DataDimension component
* removed a few ItemSelector tests as the ItemSelector component is being moved to a different repo, so test fixes/changes will not be dealt with here