### PR TITLE
chore: use specific app class instead of generic 'app' to prevent side effects

### DIFF
--- a/packages/app/src/components/App.css
+++ b/packages/app/src/components/App.css
@@ -1,11 +1,11 @@
 /* App */
 
-.app {
+.data-visualizer-app {
     height: 100vh;
     background-color: #f4f6f8;
     overflow: hidden;
 }
-.app * {
+.data-visualizer-app * {
     outline: none;
 }
 

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import HeaderBar from '@dhis2/ui/widgets/HeaderBar';
-import { withStyles } from '@material-ui/core/styles';
 
 import FatalErrorBoundary from './ErrorBoundaries/FatalErrorBoundary';
 import Snackbar from '../components/Snackbar/Snackbar';

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import HeaderBar from '@dhis2/ui/widgets/HeaderBar';
+import { withStyles } from '@material-ui/core/styles';
 
 import FatalErrorBoundary from './ErrorBoundaries/FatalErrorBoundary';
 import Snackbar from '../components/Snackbar/Snackbar';
@@ -163,7 +164,7 @@ export class App extends Component {
         return (
             <FatalErrorBoundary>
                 <AxisSetup />
-                <div className="app flex-ct flex-dir-col">
+                <div className="data-visualizer-app flex-ct flex-dir-col">
                     <div className="section-headerbar">
                         <HeaderBar appName={i18n.t('Data Visualizer')} />
                     </div>


### PR DESCRIPTION
Fixes issue where the css for the apps in the headerbar app menu was messed up (had extremely big height and wrong bg color)