### PR TITLE
fix: Use deep equality check for plugin props on componentDidUpdate to avoid unnecessary updates

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-
+import isEqual from 'lodash-es/isEqual';
 import { createChart } from 'd2-charts-api';
 
 import { apiFetchVisualization } from './api/visualization';
@@ -32,12 +32,12 @@ class ChartPlugin extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.config !== prevProps.config) {
+        if (!isEqual(this.props.config, prevProps.config)) {
             this.renderChart();
             return;
         }
 
-        if (this.props.filters !== prevProps.filters) {
+        if (!isEqual(this.props.filters, prevProps.filters)) {
             this.renderChart();
             return;
         }


### PR DESCRIPTION
Fixes [DHIS2-6597](https://jira.dhis2.org/browse/DHIS2-6597).

#### Problem:
Chart items re-render in dashboards app even if props stay the same (triggers by editing text item).

#### Proposal:
Use `lodash/isEqual` function to check equality of props (config & filter) to determine if component should re-render the chart.