### PR TITLE
Fix/dual axis item check

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,7 +46,7 @@
         "chalk": "2.4.1",
         "css-loader": "0.28.7",
         "d2": "31.2.1",
-        "d2-charts-api": "32.0.3",
+        "d2-charts-api": "32.0.4",
         "d2-manifest": "^1.0.0",
         "data-visualizer-plugin": "32.0.3",
         "dotenv": "6.0.0",

--- a/packages/app/src/components/DownloadMenu/DownloadMenu.js
+++ b/packages/app/src/components/DownloadMenu/DownloadMenu.js
@@ -104,7 +104,6 @@ export class DownloadMenu extends Component {
                     anchorEl={this.state.anchorEl}
                     anchorOrigin={styles.menuAnchorOrigin}
                     getContentAnchorEl={null}
-                    disableAutoFocusItem={true}
                     onClose={() => this.toggleMenu()}
                 >
                     <ListSubheader component="div">
@@ -202,7 +201,6 @@ export class DownloadMenu extends Component {
                     open={Boolean(this.state.schemeSubmenu.anchorEl)}
                     anchorEl={this.state.schemeSubmenu.anchorEl}
                     anchorOrigin={styles.submenuAnchorOrigin}
-                    disableAutoFocusItem={true}
                     onClose={event => this.toggleSubmenu('scheme')}
                 >
                     <ListSubheader component="div">
@@ -237,7 +235,6 @@ export class DownloadMenu extends Component {
                     open={Boolean(this.state.advancedSubmenu.anchorEl)}
                     anchorEl={this.state.advancedSubmenu.anchorEl}
                     anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-                    disableAutoFocusItem={true}
                     onClose={event => this.toggleSubmenu('advanced')}
                 >
                     <ListSubheader component="div">

--- a/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -66,14 +66,15 @@ class Axis extends React.Component {
 
     isData = dimensionId => dimensionId === FIXED_DIMENSIONS.dx.id;
 
-    getItemsArrayByDimension = dimensionId => this.props.itemsByDimension[dimensionId] || [];
+    getItemsArrayByDimension = dimensionId =>
+        this.props.itemsByDimension[dimensionId] || [];
 
     shouldHaveDualAxis = dimensionId =>
         Boolean(
             this.isSeries() &&
-            this.isData(dimensionId) &&
-            isDualAxisType(this.props.type) &&
-            this.getItemsArrayByDimension(this.props.axis[0]).length > 1
+                this.isData(dimensionId) &&
+                isDualAxisType(this.props.type) &&
+                this.getItemsArrayByDimension(this.props.axis[0]).length > 1
         );
 
     getDualAxisItem = dimensionId => (
@@ -97,7 +98,9 @@ class Axis extends React.Component {
     getDividerItem = key => <Divider light key={key} />;
 
     getMenuItems = dimensionId => [
-        this.shouldHaveDualAxis(dimensionId) ? this.getDualAxisItem(dimensionId) : null,
+        this.shouldHaveDualAxis(dimensionId)
+            ? this.getDualAxisItem(dimensionId)
+            : null,
         this.shouldHaveDualAxis(dimensionId)
             ? this.getDividerItem('dual-axis-menu-divider')
             : null,

--- a/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -22,6 +22,7 @@ import styles from './styles/DefaultAxis.style';
 import { getAdaptedUiByType } from '../../../modules/ui';
 import { isYearOverYear, isDualAxisType } from '../../../modules/chartTypes';
 import { AXIS_SETUP_DIALOG_ID } from '../../AxisSetup/AxisSetup';
+import { FIXED_DIMENSIONS } from '../../../modules/fixedDimensions';
 
 const axisLabels = {
     columns: i18n.t('Series'),
@@ -63,11 +64,16 @@ class Axis extends React.Component {
 
     isSeries = () => this.props.axisName === AXIS_NAME_COLUMNS;
 
-    shouldHaveDualAxis = () =>
+    isData = dimensionId => dimensionId === FIXED_DIMENSIONS.dx.id;
+
+    getItemsArrayByDimension = dimensionId => this.props.itemsByDimension[dimensionId] || [];
+
+    shouldHaveDualAxis = dimensionId =>
         Boolean(
             this.isSeries() &&
-                isDualAxisType(this.props.type) &&
-                this.props.itemsByDimension[this.props.axis[0]]
+            this.isData(dimensionId) &&
+            isDualAxisType(this.props.type) &&
+            this.getItemsArrayByDimension(this.props.axis[0]).length > 1
         );
 
     getDualAxisItem = dimensionId => (
@@ -91,8 +97,8 @@ class Axis extends React.Component {
     getDividerItem = key => <Divider light key={key} />;
 
     getMenuItems = dimensionId => [
-        this.shouldHaveDualAxis() ? this.getDualAxisItem(dimensionId) : null,
-        this.shouldHaveDualAxis()
+        this.shouldHaveDualAxis(dimensionId) ? this.getDualAxisItem(dimensionId) : null,
+        this.shouldHaveDualAxis(dimensionId)
             ? this.getDividerItem('dual-axis-menu-divider')
             : null,
         ...(this.isMoveSupported() ? this.getAxisMenuItems(dimensionId) : []),

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "@material-ui/core": "^3.1.2",
-        "d2-charts-api": "32.0.3",
+        "d2-charts-api": "32.0.4",
         "lodash-es": "^4.17.11",
         "react": "^16.6.0",
         "react-dom": "^16.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4332,10 +4332,10 @@ cypress@^3.1.1:
     url "0.11.0"
     yauzl "2.10.0"
 
-d2-charts-api@32.0.3:
-  version "32.0.3"
-  resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-32.0.3.tgz#a487161587863d2c0f100d5dbf2b214ac01cd738"
-  integrity sha512-RWioHmFVhPkiv+hDi7p/qHfhl1kW6q9bWpxOBy12rO105nA2m6y4CZ0Vva30iSPj36HqBE+aHXTtB87/sfPc2A==
+d2-charts-api@32.0.4:
+  version "32.0.4"
+  resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-32.0.4.tgz#22ff088d3d86bbb0bdfa13d0256e7bc24462cffd"
+  integrity sha512-xzLnnSFPQziwrbN57cku3XalKC0UG7dvNRHXTUeCnfJ18E78/3u+KYKztnGpfdyXv6lw/L9phRZUo2H8DasTSQ==
   dependencies:
     d2-utilizr "0.2.13"
     d3-color "1.0.1"


### PR DESCRIPTION
- Add d2ca 32.0.4
- Remove Menu.disableAutoFocusItem, will add it to the theme
- Only show dual axis menu item when data is series and when more than one item is selected