### PR TITLE
fix: only act on path if it exists

### DIFF
--- a/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
@@ -77,7 +77,7 @@ export class DialogManager extends Component {
     }, 1000);
 
     onSelect = ({ dimensionId, items }) => {
-        this.props.addUiItems({
+        this.props.setUiItems({
             dimensionId,
             itemIds: items.map(item => item.id),
         });
@@ -94,10 +94,12 @@ export class DialogManager extends Component {
                         displayName: ou.displayName,
                     };
 
-                    const path = removeOrgUnitLastPathSegment(ou.path);
+                    if (ou.path) {
+                        const path = removeOrgUnitLastPathSegment(ou.path);
 
-                    forParentGraphMap[ou.id] =
-                        path === `/${ou.id}` ? '' : path.replace(/^\//, '');
+                        forParentGraphMap[ou.id] =
+                            path === `/${ou.id}` ? '' : path.replace(/^\//, '');
+                    }
                 });
 
                 this.props.addMetadata(forMetadata);


### PR DESCRIPTION
Fixes include:
* call "Set" instead of "Add" since the returned list contains the complete selected list
* check that ou.path exists before acting on it. In the case of user org units, path does not exist, which resulted in the app crashing

To reproduce the org unit bug:
1. Open the OrgUnit Dimension
2. Select one or more of the User org unit checkboxes. The app will crash.