### PR TITLE
Revert "Use deep equality check for plugin props (#254)"

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import isEqual from 'lodash-es/isEqual';
+
 import { createChart } from 'd2-charts-api';
 
 import { apiFetchVisualization } from './api/visualization';
@@ -32,12 +32,12 @@ class ChartPlugin extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (!isEqual(this.props.config, prevProps.config)) {
+        if (this.props.config !== prevProps.config) {
             this.renderChart();
             return;
         }
 
-        if (!isEqual(this.props.filters, prevProps.filters)) {
+        if (this.props.filters !== prevProps.filters) {
             this.renderChart();
             return;
         }


### PR DESCRIPTION
This reverts commit 93f71ab9b5a46bb83fce377531137d371cf6a6a6.

This fix causes a different bug - when resizing a chart in edit mode, the chart is not regenerated