### PR TITLE
fix: dashboard items resize should trigger chart reload

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -43,7 +43,7 @@ class ChartPlugin extends Component {
         }
 
         // id set by DV app, style works in dashboards
-        if (this.props.id !== prevProps.id || this.props.style !== prevProps.style) {
+        if (this.props.id !== prevProps.id || !isEqual(this.props.style, prevProps.style)) {
             this.recreateChart(0); // disable animation
             return;
         }

--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -42,7 +42,8 @@ class ChartPlugin extends Component {
             return;
         }
 
-        if (this.props.id !== prevProps.id) {
+        // id set by DV app, style works in dashboards
+        if (this.props.id !== prevProps.id || this.props.style !== prevProps.style) {
             this.recreateChart(0); // disable animation
             return;
         }


### PR DESCRIPTION
The style prop seems to change when a dashboard item is resize, and
can be used for triggering recreateChart() which also disables chart
animation.

Related to DHIS2-6597.