### PR TITLE
chore(v32): update dv plugin

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -30,7 +30,7 @@
         "@dhis2/d2-ui-core": "5.3.8",
         "@dhis2/d2-ui-file-menu": "5.3.9",
         "@dhis2/d2-ui-interpretations": "5.2.10",
-        "@dhis2/data-visualizer-plugin": "^32.0.3",
+        "@dhis2/data-visualizer-plugin": "32.0.6",
         "@dhis2/ui": "^1.0.0-beta.11",
         "@material-ui/core": "^3.1.2",
         "@material-ui/icons": "^3.0.1",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/data-visualizer-plugin",
-    "version": "32.0.5",
+    "version": "32.0.6",
     "description": "DHIS2 Data Visualizer plugin",
     "main": "./build/index.js",
     "license": "BSD-3-Clause",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,19 +4307,6 @@ cypress@^3.1.1:
     url "0.11.0"
     yauzl "2.10.0"
 
-d2-charts-api@32.0.1:
-  version "32.0.1"
-  resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-32.0.1.tgz#f402a5352a08fe3281a437652afc2dc8fd7fd22e"
-  integrity sha512-s6VlDLCkcjNluOXwUp1csa/6ZaNDBtbu9RWmaa8kb5gPpc1BDovwx0lE34FPrEUIefF5JNpisl3fwlrLrH592Q==
-  dependencies:
-    d2-utilizr "0.2.13"
-    d3-color "1.0.1"
-    highcharts "^6.2.0"
-    highcharts-exporting "^0.1.7"
-    highcharts-more "^0.1.7"
-    highcharts-no-data-to-display "^0.1.7"
-    highcharts-solid-gauge "^0.1.7"
-
 d2-charts-api@32.0.6:
   version "32.0.6"
   resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-32.0.6.tgz#e733a5417a78186a0c4a9cce72bc616aa9dfbf79"


### PR DESCRIPTION
New version of DV plugin published v32.0.6 and DV app uses it.