### PR TITLE
chore: Make axis dialog help text more readable with increased line height (1.5)

### DIFF
--- a/packages/app/src/components/AxisSetup/AxisSetup.js
+++ b/packages/app/src/components/AxisSetup/AxisSetup.js
@@ -165,7 +165,7 @@ class AxisSetup extends Component {
             >
                 <DialogTitle>{i18n.t('Manage axes')}</DialogTitle>
                 <DialogContent className={classes.dialogContent}>
-                    <p>
+                    <p className={classes.helpText}>
                         {i18n.t(
                             'A chart can have two axes. Each axis will have its own scale. Set the axis for each data selection below.'
                         )}

--- a/packages/app/src/components/AxisSetup/styles/AxisSetup.style.js
+++ b/packages/app/src/components/AxisSetup/styles/AxisSetup.style.js
@@ -25,6 +25,8 @@ export default {
     },
     dialogContent: {
         marginBottom: '0px',
+    },
+    helpText: {
         lineHeight: '1.5',
     },
     dialogActions: {

--- a/packages/app/src/components/AxisSetup/styles/AxisSetup.style.js
+++ b/packages/app/src/components/AxisSetup/styles/AxisSetup.style.js
@@ -25,6 +25,7 @@ export default {
     },
     dialogContent: {
         marginBottom: '0px',
+        lineHeight: '1.5',
     },
     dialogActions: {
         border: 'none',


### PR DESCRIPTION
Fixes [DHIS2-6625](https://jira.dhis2.org/browse/DHIS2-6625).

**Problem**
Line-height on paragraph text in the Manage axes dialog is too low, making it slightly hard to read.

**Solution**
Apply `line-height: 1.5` css rule to dialog's help text block.