### PR TITLE
chore: Upgrade d2-charts-api to move gauge title to top

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "@material-ui/core": "^3.1.2",
-        "d2-charts-api": "32.0.6",
+        "d2-charts-api": "33.0.0",
         "lodash-es": "^4.17.11",
         "react": "^16.6.0",
         "react-dom": "^16.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4320,6 +4320,19 @@ d2-charts-api@32.0.6:
     highcharts-no-data-to-display "^0.1.7"
     highcharts-solid-gauge "^0.1.7"
 
+d2-charts-api@33.0.0:
+  version "33.0.0"
+  resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-33.0.0.tgz#b8e479b3af721a10eff334c026a48300038966a1"
+  integrity sha512-X++TprMt07djneAT6YvdEZ+CYwHHDM2/0nNfipNdEiu2SL/DjC9qAeOeBATUL3MFHyU6XK06FDS/9rgDfwUY5A==
+  dependencies:
+    d2-utilizr "0.2.13"
+    d3-color "1.0.1"
+    highcharts "^6.2.0"
+    highcharts-exporting "^0.1.7"
+    highcharts-more "^0.1.7"
+    highcharts-no-data-to-display "^0.1.7"
+    highcharts-solid-gauge "^0.1.7"
+
 d2-manifest@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d2-manifest/-/d2-manifest-1.0.0.tgz#19d4a4c4e8151442ab730e932c9c2170be9ebcc9"


### PR DESCRIPTION
Relates to [DHIS2-6989](https://jira.dhis2.org/browse/DHIS2-6989).

Changes include:
- Upgrading `d2-charts-api` version to 33.0.0 to move title to top for gauge chart type