### PR TITLE
refactor(): use @dhis2/analytics in place of @dhis2/d2-ui-analytics

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@dhis2/d2-i18n": "^1.0.3",
-        "@dhis2/d2-ui-analytics": "^1.0.5",
+        "@dhis2/analytics": "^2.0.0",
         "@dhis2/d2-ui-core": "6.1.0",
         "@dhis2/d2-ui-file-menu": "6.1.0",
         "@dhis2/d2-ui-interpretations": "6.1.0",
@@ -46,7 +46,6 @@
         "chalk": "2.4.1",
         "css-loader": "0.28.7",
         "d2": "31.2.1",
-        "d2-charts-api": "33.0.1",
         "d2-manifest": "^1.0.0",
         "dotenv": "6.0.0",
         "dotenv-expand": "4.2.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -25,8 +25,8 @@
         "webpack-bundle-analyzer": "^3.0.3"
     },
     "dependencies": {
+        "@dhis2/analytics": "2.1.1",
         "@dhis2/d2-i18n": "^1.0.3",
-        "@dhis2/analytics": "^2.0.0",
         "@dhis2/d2-ui-core": "6.1.0",
         "@dhis2/d2-ui-file-menu": "6.1.0",
         "@dhis2/d2-ui-interpretations": "6.1.0",

--- a/packages/app/src/api/analytics.js
+++ b/packages/app/src/api/analytics.js
@@ -1,4 +1,4 @@
-import { DIMENSION_ID_PERIOD } from '@dhis2/d2-ui-analytics';
+import { DIMENSION_ID_PERIOD } from '@dhis2/analytics';
 import { getInstance } from 'd2';
 
 export const apiDownloadImage = async (type, formData) => {

--- a/packages/app/src/components/DimensionsPanel/Dialogs/AddToLayoutButton/AddToLayoutButton.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/AddToLayoutButton/AddToLayoutButton.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import Button from '@material-ui/core/Button';
 import MenuItem from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
-import { AXIS_NAME_COLUMNS } from '@dhis2/d2-ui-analytics';
+import { AXIS_NAME_COLUMNS } from '@dhis2/analytics';
 
 import UpdateButton from '../../../UpdateButton/UpdateButton';
 import Menu from './Menu';

--- a/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
@@ -17,7 +17,7 @@ import {
     DIMENSION_ID_PERIOD,
     DIMENSION_ID_ORGUNIT,
     FIXED_DIMENSIONS,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import HideButton from './HideButton';
 import AddToLayoutButton from './AddToLayoutButton/AddToLayoutButton';

--- a/packages/app/src/components/DimensionsPanel/Dialogs/__tests__/DialogManager.spec.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/__tests__/DialogManager.spec.js
@@ -4,7 +4,7 @@ import {
     DIMENSION_ID_DATA,
     DIMENSION_ID_PERIOD,
     DIMENSION_ID_ORGUNIT,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import { DialogManager } from '../DialogManager';
 
@@ -18,7 +18,7 @@ jest.mock('@material-ui/core/DialogActions', () => props => (
     <div id="mock-mui-dialog-actions">{props.children}</div>
 ));
 
-jest.mock('@dhis2/d2-ui-analytics', () => {
+jest.mock('@dhis2/analytics', () => {
     const dataId = 'dx';
     const periodId = 'pe';
     const ouId = 'ou';

--- a/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { DIMENSION_ID_PERIOD, DimensionsPanel } from '@dhis2/d2-ui-analytics';
+import { DIMENSION_ID_PERIOD, DimensionsPanel } from '@dhis2/analytics';
 
 import DialogManager from './Dialogs/DialogManager';
 import DimensionOptions from './DimensionOptions/DimensionOptions';

--- a/packages/app/src/components/DimensionsPanel/__tests__/DimensionsPanel.spec.js
+++ b/packages/app/src/components/DimensionsPanel/__tests__/DimensionsPanel.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { DimensionsPanel } from '@dhis2/d2-ui-analytics';
+import { DimensionsPanel } from '@dhis2/analytics';
 
 import { Dimensions } from '../DimensionsPanel';
 

--- a/packages/app/src/components/Layout/Chip.js
+++ b/packages/app/src/components/Layout/Chip.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import { FIXED_DIMENSIONS } from '@dhis2/d2-ui-analytics';
+import { FIXED_DIMENSIONS } from '@dhis2/analytics';
 
 import Menu from './Menu';
 import Tooltip from './Tooltip';

--- a/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -7,7 +7,7 @@ import {
     AXIS_NAME_COLUMNS,
     AXIS_NAMES,
     DIMENSION_ID_DATA,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import Chip from '../Chip';
 import { sGetUi } from '../../../reducers/ui';

--- a/packages/app/src/components/Layout/PieLayout/PieLayout.js
+++ b/packages/app/src/components/Layout/PieLayout/PieLayout.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AXIS_NAME_COLUMNS, AXIS_NAME_FILTERS } from '@dhis2/d2-ui-analytics';
+import { AXIS_NAME_COLUMNS, AXIS_NAME_FILTERS } from '@dhis2/analytics';
 
 import DefaultAxis from '../DefaultLayout/DefaultAxis';
 import defaultAxisStyles from '../DefaultLayout/styles/DefaultAxis.style';

--- a/packages/app/src/components/Layout/YearOverYearLayout/YearOverYearLayout.js
+++ b/packages/app/src/components/Layout/YearOverYearLayout/YearOverYearLayout.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { AXIS_NAME_FILTERS } from '@dhis2/d2-ui-analytics';
+import { AXIS_NAME_FILTERS } from '@dhis2/analytics';
 
 import DefaultAxis from '../DefaultLayout/DefaultAxis';
 import defaultLayoutStyles from '../DefaultLayout/styles/DefaultLayout.style';

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -58,7 +58,9 @@ const render = (location, baseUrl, d2, userSettings) => {
 const init = async () => {
     // log app info
     console.info(
-        `Data Visualizer app, v${manifest.version}, ${manifest.manifest_generated_at}`
+        `Data Visualizer app, v${manifest.version}, ${
+            manifest.manifest_generated_at
+        }`
     );
 
     // d2 config

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -58,9 +58,7 @@ const render = (location, baseUrl, d2, userSettings) => {
 const init = async () => {
     // log app info
     console.info(
-        `Data Visualizer app, v${manifest.version}, ${
-            manifest.manifest_generated_at
-        }`
+        `Data Visualizer app, v${manifest.version}, ${manifest.manifest_generated_at}`
     );
 
     // d2 config

--- a/packages/app/src/modules/__tests__/current.spec.js
+++ b/packages/app/src/modules/__tests__/current.spec.js
@@ -5,7 +5,7 @@ import {
     DIMENSION_ID_DATA,
     DIMENSION_ID_PERIOD,
     DIMENSION_ID_ORGUNIT,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import { getAxesFromUi } from '../current';
 

--- a/packages/app/src/modules/__tests__/layoutAdapters.spec.js
+++ b/packages/app/src/modules/__tests__/layoutAdapters.spec.js
@@ -5,7 +5,7 @@ import {
     DIMENSION_ID_DATA,
     DIMENSION_ID_PERIOD,
     DIMENSION_ID_ORGUNIT,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import { pieLayoutAdapter, yearOverYearLayoutAdapter } from '../layoutAdapters';
 

--- a/packages/app/src/modules/current.js
+++ b/packages/app/src/modules/current.js
@@ -6,7 +6,7 @@ import {
     DIMENSION_ID_DATA,
     DIMENSION_ID_PERIOD,
     dimensionCreate,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import options from './options';
 import {} from './layout';

--- a/packages/app/src/modules/currentAnalyticalObject.js
+++ b/packages/app/src/modules/currentAnalyticalObject.js
@@ -1,7 +1,7 @@
 import {
     DIMENSION_ID_ORGUNIT,
     layoutGetAxisNameDimensionIdsObject,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import { getInverseLayout } from './layout';
 

--- a/packages/app/src/modules/layout.js
+++ b/packages/app/src/modules/layout.js
@@ -3,7 +3,7 @@ import {
     AXIS_NAME_COLUMNS,
     AXIS_NAME_ROWS,
     AXIS_NAME_FILTERS,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 // Names for dnd sources
 export const SOURCE_DIMENSIONS = 'dimensions';

--- a/packages/app/src/modules/layoutAdapters.js
+++ b/packages/app/src/modules/layoutAdapters.js
@@ -3,7 +3,7 @@ import {
     AXIS_NAME_ROWS,
     AXIS_NAME_FILTERS,
     DIMENSION_ID_PERIOD,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 // Transform from ui.layout to pie layout format
 export const pieLayoutAdapter = layout => {

--- a/packages/app/src/modules/layoutValidation.js
+++ b/packages/app/src/modules/layoutValidation.js
@@ -6,7 +6,7 @@ import {
     FIXED_DIMENSIONS,
     dimensionIsValid,
     layoutGetDimension,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import {
     YEAR_OVER_YEAR_LINE,

--- a/packages/app/src/modules/ui.js
+++ b/packages/app/src/modules/ui.js
@@ -3,7 +3,7 @@ import {
     DIMENSION_ID_ORGUNIT,
     layoutGetAxisNameDimensionIdsObject,
     layoutGetDimensionIdItemIdsObject,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import {
     YEAR_OVER_YEAR_LINE,

--- a/packages/app/src/reducers/__tests__/current.spec.js
+++ b/packages/app/src/reducers/__tests__/current.spec.js
@@ -2,7 +2,7 @@ import {
     DIMENSION_ID_DATA,
     DIMENSION_ID_PERIOD,
     DIMENSION_ID_ORGUNIT,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import options from '../../modules/options';
 import reducer, {

--- a/packages/app/src/reducers/__tests__/dimensions.spec.js
+++ b/packages/app/src/reducers/__tests__/dimensions.spec.js
@@ -1,4 +1,4 @@
-import { FIXED_DIMENSIONS } from '@dhis2/d2-ui-analytics';
+import { FIXED_DIMENSIONS } from '@dhis2/analytics';
 
 import reducer, { SET_DIMENSIONS } from '../dimensions';
 

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -5,7 +5,7 @@ import {
     AXIS_NAME_COLUMNS,
     AXIS_NAME_ROWS,
     AXIS_NAME_FILTERS,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import * as ui from '../ui';
 import { BAR } from '../../modules/chartTypes';

--- a/packages/app/src/reducers/dimensions.js
+++ b/packages/app/src/reducers/dimensions.js
@@ -1,4 +1,4 @@
-import { FIXED_DIMENSIONS as DEFAULT_DIMENSIONS } from '@dhis2/d2-ui-analytics';
+import { FIXED_DIMENSIONS as DEFAULT_DIMENSIONS } from '@dhis2/analytics';
 
 export const SET_DIMENSIONS = 'SET_DIMENSIONS';
 export const SET_SELECTED_DIMENSION = 'SET_SELECTED_DIMENSION';

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -4,7 +4,7 @@ import {
     DIMENSION_ID_ORGUNIT,
     AXIS_NAME_COLUMNS,
     AXIS_NAME_ROWS,
-} from '@dhis2/d2-ui-analytics';
+} from '@dhis2/analytics';
 
 import { getFilteredLayout, getSwapModObj } from '../modules/layout';
 import { getOptionsForUi } from '../modules/options';

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "@material-ui/core": "^3.1.2",
-        "d2-charts-api": "33.0.1",
+        "@dhis2/analytics": "^2.0.0",
         "lodash-es": "^4.17.11",
         "react": "^16.6.0",
         "react-dom": "^16.6.0"

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -5,8 +5,8 @@
     "main": "./build/index.js",
     "license": "BSD-3-Clause",
     "dependencies": {
+        "@dhis2/analytics": "2.1.1",
         "@material-ui/core": "^3.1.2",
-        "@dhis2/analytics": "^2.0.0",
         "lodash-es": "^4.17.11",
         "react": "^16.6.0",
         "react-dom": "^16.6.0"

--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash-es/isEqual';
-import { createChart } from 'd2-charts-api';
+import { createVisualization } from '@dhis2/analytics';
 
 import { apiFetchVisualization } from './api/visualization';
 import {
@@ -20,7 +20,7 @@ class ChartPlugin extends Component {
 
         this.canvasRef = React.createRef();
 
-        this.recreateChart = Function.prototype;
+        this.recreateVisualization = Function.prototype;
 
         this.state = {
             isLoading: true,
@@ -43,8 +43,11 @@ class ChartPlugin extends Component {
         }
 
         // id set by DV app, style works in dashboards
-        if (this.props.id !== prevProps.id || !isEqual(this.props.style, prevProps.style)) {
-            this.recreateChart(0); // disable animation
+        if (
+            this.props.id !== prevProps.id ||
+            !isEqual(this.props.style, prevProps.style)
+        ) {
+            this.recreateVisualization(0); // disable animation
             return;
         }
     }
@@ -134,8 +137,8 @@ class ChartPlugin extends Component {
                 onResponsesReceived(responses);
             }
 
-            this.recreateChart = animation => {
-                const chartConfig = createChart(
+            this.recreateVisualization = animation => {
+                const visualizationConfig = createVisualization(
                     responses,
                     visualization,
                     this.canvasRef.current,
@@ -146,14 +149,14 @@ class ChartPlugin extends Component {
                 );
 
                 onChartGenerated(
-                    chartConfig.chart.getSVGForExport({
+                    visualizationConfig.visualization.getSVGForExport({
                         sourceHeight: 768,
                         sourceWidth: 1024,
                     })
                 );
             };
 
-            this.recreateChart();
+            this.recreateVisualization();
 
             this.setState({ isLoading: false });
         } catch (error) {

--- a/packages/plugin/src/__tests__/ChartPlugin.spec.js
+++ b/packages/plugin/src/__tests__/ChartPlugin.spec.js
@@ -2,13 +2,13 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import LoadingMask from '../widgets/LoadingMask';
 import ChartPlugin from '../ChartPlugin';
-import * as chartsApi from 'd2-charts-api';
+import * as analytics from '@dhis2/analytics';
 import * as api from '../api/analytics';
 import * as apiViz from '../api/visualization';
 import * as options from '../modules/options';
 import { YEAR_OVER_YEAR_LINE, COLUMN } from '../modules/chartTypes';
 
-jest.mock('d2-charts-api');
+jest.mock('@dhis2/analytics');
 
 const dxMock = {
     dimension: 'dx',
@@ -83,8 +83,8 @@ class MockYoYAnalyticsResponse {
     }
 }
 
-const createChartMock = {
-    chart: {
+const createVisualizationMock = {
+    visualization: {
         getSVGForExport: () => '<svg />',
     },
 };
@@ -135,9 +135,11 @@ describe('ChartPlugin', () => {
         ).toBeTruthy();
     });
 
-    describe('createChart success', () => {
+    describe('createVisualization success', () => {
         beforeEach(() => {
-            chartsApi.createChart = jest.fn().mockReturnValue(createChartMock);
+            analytics.createVisualization = jest
+                .fn()
+                .mockReturnValue(createVisualizationMock);
         });
 
         it('renders a div', done => {
@@ -154,11 +156,11 @@ describe('ChartPlugin', () => {
             done();
         });
 
-        it('calls createChart', done => {
+        it('calls createVisualization', done => {
             canvas();
 
             setTimeout(() => {
-                expect(chartsApi.createChart).toHaveBeenCalled();
+                expect(analytics.createVisualization).toHaveBeenCalled();
                 done();
             });
         });
@@ -220,7 +222,7 @@ describe('ChartPlugin', () => {
             setTimeout(() => {
                 expect(props.onChartGenerated).toHaveBeenCalled();
                 expect(props.onChartGenerated).toHaveBeenCalledWith(
-                    createChartMock.chart.getSVGForExport()
+                    createVisualizationMock.visualization.getSVGForExport()
                 );
                 done();
             });
@@ -284,18 +286,18 @@ describe('ChartPlugin', () => {
                 });
             });
 
-            it('provides extra options to createChart', done => {
+            it('provides extra options to createVisualization', done => {
                 canvas();
 
                 setTimeout(() => {
-                    expect(chartsApi.createChart).toHaveBeenCalled();
+                    expect(analytics.createVisualization).toHaveBeenCalled();
 
                     const expectedExtraOptions = {
                         yearlySeries: mockYoYSeriesLabels,
                         xAxisLabels: ['period 1', 'period 2'],
                     };
 
-                    expect(chartsApi.createChart.mock.calls[0][3]).toEqual({
+                    expect(analytics.createVisualization.mock.calls[0][3]).toEqual({
                         animation: undefined,
                         dashboard: false,
                         ...expectedExtraOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,10 +157,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.0.0.tgz#a5bf95adb62102c4969c5e8a21af36b646833441"
-  integrity sha512-mWRQOa7a6CU0Y2VFlpETl09FBbPuuK7dpxbtHd3bEFIfNeBdroRN+OS0EDkTnh1T61uhQJdGS4yavb9ACOjkgg==
+"@dhis2/analytics@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.1.1.tgz#9920356bc4f4cf81d9b03dcf58b8ac1e27c11958"
+  integrity sha512-3Sf+WjMCJPuraBCRmyLCkManFOyqiFjD+hjhKp3OIweWabu5ouBzBIzIgc44h9eQBathJpODm3ByHTONmT99Hg==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-org-unit-dialog" "^6.1.0"
@@ -168,6 +168,13 @@
     "@material-ui/core" "^3.9.3"
     "@material-ui/icons" "^3.0.2"
     classnames "^2.2.6"
+    d2-utilizr "^0.2.16"
+    d3-color "^1.2.3"
+    highcharts "^7.1.2"
+    highcharts-exporting "^0.1.7"
+    highcharts-more "^0.1.7"
+    highcharts-no-data-to-display "^0.1.7"
+    highcharts-solid-gauge "^0.1.7"
     lodash "^4.17.11"
     react-beautiful-dnd "^10.1.1"
     styled-jsx "^3.2.1"
@@ -193,11 +200,12 @@
     rimraf "^2.6.2"
 
 "@dhis2/d2-i18n@^1.0.3", "@dhis2/d2-i18n@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.4.tgz#8fbd113f56699b9832a401e1cb8f54d75bc36b9a"
-  integrity sha512-xI2j69q3bwlb374JOAs3wpo47V4BqDAz4h1PfGLVhdORPLAuz0CkKuwesfpW2eunDSHiKpMbOg7goTip/5ROew==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.5.tgz#9148af1bc95e9442bcae66136b8f80146406a43f"
+  integrity sha512-nz1JtDLNn6hOoSg84C1iYRBr11O/ljMdczEqq0/j/gQy9wRs80Z7lExwItclHgS7t6ESWCa6+OFkwgRCOKF2ew==
   dependencies:
     i18next "^10.3"
+    moment "^2.24.0"
 
 "@dhis2/d2-ui-analytics@^1.0.0":
   version "1.0.5"
@@ -218,6 +226,16 @@
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.1.0.tgz#3efe93fe0094dc968ecd938ed9e1c24fe186d71d"
   integrity sha512-4hgQu3t94B/XhPPFwuNW9SQ2VC+OEk4j4B/tPQMEyxrhCyUWfEN7D+MDxKkIu/P+cyKPTa0liMJF2tGOglyYsA==
+  dependencies:
+    babel-runtime "^6.26.0"
+    d2 "~31.7"
+    lodash "^4.17.10"
+    material-ui "^0.20.0"
+
+"@dhis2/d2-ui-core@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.1.1.tgz#c0ef84ff3267e4645989cf538ca3e4a8ab4a4c0e"
+  integrity sha512-+r8n07NXnolbFQyGKpxP02HBFP26/vueAEmAkiUYBSkZxj5IzuAmMlJB55kRTvkS2DO52mitGWaBPFfgrrAlHA==
   dependencies:
     babel-runtime "^6.26.0"
     d2 "~31.7"
@@ -283,30 +301,30 @@
     prop-types "^15.6.2"
 
 "@dhis2/d2-ui-org-unit-dialog@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-6.1.0.tgz#8f941129450097ba42fec19e2d65108368ccca49"
-  integrity sha512-/Rhxr22NU2l4Dto2dsn1+hfvH5z7/ORjp1bHi0J8haobODbWzW0xCq63xwsmb3qjyuG/cfY7cwVqpH7osD4Awg==
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-6.1.1.tgz#219d9aeb5daecdaa8008eaba8fa87cc6f861080b"
+  integrity sha512-DNTw2lJRcFWSl/TCzFbjV86gv2rSlJgWG41fxKwSOwG7XWXv7Vr8YdbSy11v8cwVHsc+307XloiGhk3JXAPNGg==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.3"
-    "@dhis2/d2-ui-org-unit-tree" "6.1.0"
+    "@dhis2/d2-ui-org-unit-tree" "6.1.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-org-unit-tree@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-6.1.0.tgz#6604cf93c9d11395e157bdee8ca44133e36673df"
-  integrity sha512-l4OnCkhzF8V/4GhS5gbFdsFyMBjmFyt2ECfbootafUh0jegMRE4vWLFdk88h6X3jwcRSD6d/gjnkB8Li1rGikQ==
+"@dhis2/d2-ui-org-unit-tree@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-6.1.1.tgz#e090b90fc452031d9e8aaa9c4d8bae7846dbd975"
+  integrity sha512-ys8br3vjbUaiOR0XjPfx6eZiMjU2DVFA5TnPsIX2rq9561MRU4nOyHNe21BdPvawUZO0L7nkrNy4xA8N8dwV2Q==
   dependencies:
-    "@dhis2/d2-ui-core" "6.1.0"
+    "@dhis2/d2-ui-core" "6.1.1"
     "@material-ui/core" "^3.3.1"
     babel-runtime "^6.26.0"
     prop-types "^15.5.10"
 
 "@dhis2/d2-ui-period-selector-dialog@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.1.0.tgz#c7b5b20b44923d9b6e180bb90e3ccd1889dc419d"
-  integrity sha512-JOKX/UgOgaINSL09tqVOy0l98W7koZh045c6H3iDxf6WE8u3i2/Gj1FEGIrV3/GfZ0hHov9+sdboTL4f85OnUA==
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.1.1.tgz#791924bafbad8dfb792c4691136b19e16ca6e41e"
+  integrity sha512-51MsNJbsKFPAAgs/msRtJnKo3iO1zO+aBue0mZJzsUi4RA2n82ZG/2GSWHROz4hGLdTcd0m0wArfDH1aOY31gA==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-analytics" "^1.0.0"
@@ -1309,9 +1327,9 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "16.8.19"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.19.tgz#629154ef05e2e1985cdde94477deefd823ad9be3"
-  integrity sha512-QzEzjrd1zFzY9cDlbIiFvdr+YUmefuuRYrPxmkwG0UQv5XF35gFIi7a95m1bNVcFU0VimxSZ5QVGSiBmlggQXQ==
+  version "16.8.22"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.22.tgz#7f18bf5ea0c1cad73c46b6b1c804a3ce0eec6d54"
+  integrity sha512-C3O1yVqk4sUXqWyx0wlys76eQfhrQhiDhDlHBrjER76lR2S2Agiid/KpOU9oCqj1dISStscz7xXz1Cg8+sCQeA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -4429,7 +4447,7 @@ d2-manifest@^1.0.0:
     minimist "^1.1.0"
     readline-sync "^1.4.1"
 
-d2-utilizr@^0.2.15:
+d2-utilizr@^0.2.15, d2-utilizr@^0.2.16:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/d2-utilizr/-/d2-utilizr-0.2.16.tgz#b71df7ca8c7ab5125ca8bdb4899611bc6782a754"
   integrity sha512-8Cqwe/3TIsHeLfRVsWFKYqRrY3ZzuHAJqkEMCPGW9gyNCAAnTPVjROFwBwonv0zodQhVntn1DlJCay/GTBPj1A==
@@ -4458,6 +4476,11 @@ d2@~31.7:
   integrity sha512-+ubKyPWKxUz90g5RHCYIt4KxKPzcCOBvDS7X0076XSycecfx4qvtkGBcKyFmXdz27iwTLUpNtruL9pUK9aTi/A==
   dependencies:
     isomorphic-fetch "^2.2.1"
+
+d3-color@^1.2.3:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.5.tgz#5810ea1808f2f993d04508cb2fad764f48134788"
+  integrity sha512-u4CaFaqQKRofuhr9uo/xLdaGvvzdsMX7MgP42XgQJHLBRWnn0C0T+48rvj80cN9KXAauHEMEfe7ehacIoxmP/g==
 
 d@1:
   version "1.0.0"
@@ -4597,7 +4620,7 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@3.2.0, deepmerge@^3.0.0:
+deepmerge@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
   integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
@@ -4606,6 +4629,11 @@ deepmerge@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
   integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
+deepmerge@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
+  integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -6630,6 +6658,31 @@ he@1.2.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highcharts-exporting@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/highcharts-exporting/-/highcharts-exporting-0.1.7.tgz#f38024b9ef78ce2ac3a39f853f83b55822ae1630"
+  integrity sha1-84Akue94zirDo5+FP4O1WCKuFjA=
+
+highcharts-more@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/highcharts-more/-/highcharts-more-0.1.7.tgz#43cd6274cccba443166c94d4536d904bbabf9c77"
+  integrity sha1-Q81idMzLpEMWbJTUU22QS7q/nHc=
+
+highcharts-no-data-to-display@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/highcharts-no-data-to-display/-/highcharts-no-data-to-display-0.1.7.tgz#a9eb8b28da3df299d0d8262b78437cfe7d81d877"
+  integrity sha1-qeuLKNo98pnQ2CYreEN8/n2B2Hc=
+
+highcharts-solid-gauge@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/highcharts-solid-gauge/-/highcharts-solid-gauge-0.1.7.tgz#4bf2dca76b5f559034b59d0c6d4755d1c71a6a5b"
+  integrity sha1-S/Lcp2tfVZA0tZ0MbUdV0ccaals=
+
+highcharts@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.1.2.tgz#f337e75cf0614f58f87fb28fbab48e1096265b5d"
+  integrity sha512-diSTVxWKefQzShi22gaV63pdrIFlQAsTGe3f328Ur7cqBoYFvHMtiMP+q+VOFdM2mdGVtlUR0QQSxj62LLsPpg==
 
 history@^4.7.2:
   version "4.9.0"
@@ -9291,7 +9344,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@2.24.0, moment@^2.22.1:
+moment@2.24.0, moment@^2.22.1, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,6 +157,21 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@dhis2/analytics@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.0.0.tgz#a5bf95adb62102c4969c5e8a21af36b646833441"
+  integrity sha512-mWRQOa7a6CU0Y2VFlpETl09FBbPuuK7dpxbtHd3bEFIfNeBdroRN+OS0EDkTnh1T61uhQJdGS4yavb9ACOjkgg==
+  dependencies:
+    "@dhis2/d2-i18n" "^1.0.4"
+    "@dhis2/d2-ui-org-unit-dialog" "^6.1.0"
+    "@dhis2/d2-ui-period-selector-dialog" "^6.1.0"
+    "@material-ui/core" "^3.9.3"
+    "@material-ui/icons" "^3.0.2"
+    classnames "^2.2.6"
+    lodash "^4.17.11"
+    react-beautiful-dnd "^10.1.1"
+    styled-jsx "^3.2.1"
+
 "@dhis2/d2-i18n-extract@^1.0.6", "@dhis2/d2-i18n-extract@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-extract/-/d2-i18n-extract-1.0.8.tgz#9d98690d522a51895c8ef3fe7136f026b0f8dacd"
@@ -184,7 +199,7 @@
   dependencies:
     i18next "^10.3"
 
-"@dhis2/d2-ui-analytics@^1.0.0", "@dhis2/d2-ui-analytics@^1.0.5":
+"@dhis2/d2-ui-analytics@^1.0.0":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-analytics/-/d2-ui-analytics-1.0.5.tgz#27dfdee86ea423e40381653e916f223928943a91"
   integrity sha512-NdXCe+i3en7ZGe3lZ32w3QtOEXzn3leOYuExNwnqsmlIqzHC8M3nYX9N3OlrRtCCpL4AcjUrDJXY09pD2POIGw==
@@ -4402,19 +4417,6 @@ cypress@^3.1.1:
     url "0.11.0"
     yauzl "2.10.0"
 
-d2-charts-api@33.0.1:
-  version "33.0.1"
-  resolved "https://registry.yarnpkg.com/d2-charts-api/-/d2-charts-api-33.0.1.tgz#51fcc00610cfb217e31b53c77fb9c9344f19e42f"
-  integrity sha512-DzyAnEZSzYspPGxkiHx4bqNEpdPNlrGms2Ct2ycFs5VmjoGUVJ1DQBet4q6B+6XoBn84Q98/VVddfRWYK8yOGw==
-  dependencies:
-    d2-utilizr "0.2.13"
-    d3-color "1.0.1"
-    highcharts "^6.2.0"
-    highcharts-exporting "^0.1.7"
-    highcharts-more "^0.1.7"
-    highcharts-no-data-to-display "^0.1.7"
-    highcharts-solid-gauge "^0.1.7"
-
 d2-manifest@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d2-manifest/-/d2-manifest-1.0.0.tgz#19d4a4c4e8151442ab730e932c9c2170be9ebcc9"
@@ -4426,19 +4428,6 @@ d2-manifest@^1.0.0:
     loglevel "^1.4.0"
     minimist "^1.1.0"
     readline-sync "^1.4.1"
-
-d2-utilizr@0.2.13:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/d2-utilizr/-/d2-utilizr-0.2.13.tgz#aff6dfb054f92e2c974cf69f38f4fdc13699a6d3"
-  integrity sha1-r/bfsFT5LiyXTPafOPT9wTaZptM=
-  dependencies:
-    lodash.isboolean "^3.0.3"
-    lodash.isfunction "^3.0.8"
-    lodash.ismap "^4.3.0"
-    lodash.isnumber "^3.0.3"
-    lodash.isobject "^3.0.2"
-    lodash.isset "^4.3.0"
-    lodash.isstring "^4.0.1"
 
 d2-utilizr@^0.2.15:
   version "0.2.16"
@@ -4469,11 +4458,6 @@ d2@~31.7:
   integrity sha512-+ubKyPWKxUz90g5RHCYIt4KxKPzcCOBvDS7X0076XSycecfx4qvtkGBcKyFmXdz27iwTLUpNtruL9pUK9aTi/A==
   dependencies:
     isomorphic-fetch "^2.2.1"
-
-d3-color@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.1.tgz#73cc91f4ee3f12e00ca06b1596a7c83cf104723a"
-  integrity sha1-c8yR9O4/EuAMoGsVlqfIPPEEcjo=
 
 d@1:
   version "1.0.0"
@@ -6646,31 +6630,6 @@ he@1.2.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-highcharts-exporting@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-exporting/-/highcharts-exporting-0.1.7.tgz#f38024b9ef78ce2ac3a39f853f83b55822ae1630"
-  integrity sha1-84Akue94zirDo5+FP4O1WCKuFjA=
-
-highcharts-more@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-more/-/highcharts-more-0.1.7.tgz#43cd6274cccba443166c94d4536d904bbabf9c77"
-  integrity sha1-Q81idMzLpEMWbJTUU22QS7q/nHc=
-
-highcharts-no-data-to-display@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-no-data-to-display/-/highcharts-no-data-to-display-0.1.7.tgz#a9eb8b28da3df299d0d8262b78437cfe7d81d877"
-  integrity sha1-qeuLKNo98pnQ2CYreEN8/n2B2Hc=
-
-highcharts-solid-gauge@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-solid-gauge/-/highcharts-solid-gauge-0.1.7.tgz#4bf2dca76b5f559034b59d0c6d4755d1c71a6a5b"
-  integrity sha1-S/Lcp2tfVZA0tZ0MbUdV0ccaals=
-
-highcharts@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-6.2.0.tgz#2a6d04652eb43c66f462ca7e2d2808f1f2782b61"
-  integrity sha512-A4E89MA+kto8giic7zyLU6ZxfXnVeCUlKOyzFsah3+n4BROx4bgonl92KIBtwLud/mIWir8ahqhuhe2by9LakQ==
 
 history@^4.7.2:
   version "4.9.0"


### PR DESCRIPTION
I left the `d2-utilizr` dependency for now, but we might want to replace that with lodash or other, since we are not using it in DV for similar purposes.