### PR TITLE
chore: let webpack compile @dhis2 scoped packages to es5 to satisfy u…

### DIFF
--- a/packages/app/config/webpack.config.dev.js
+++ b/packages/app/config/webpack.config.dev.js
@@ -168,6 +168,13 @@ module.exports = {
                     },
                     // Process JS with Babel.
                     {
+                        test: /@dhis2\/.*\.(js|jsx|mjs)$/,
+                        loader: require.resolve('babel-loader'),
+                        options: {
+                            cacheDirectory: true,
+                        },
+                    },
+                    {
                         test: /\.(js|jsx|mjs)$/,
                         include: paths.appSrc,
                         loader: require.resolve('babel-loader'),

--- a/packages/app/config/webpack.config.prod.js
+++ b/packages/app/config/webpack.config.prod.js
@@ -158,6 +158,13 @@ module.exports = {
                     },
                     // Process JS with Babel.
                     {
+                        test: /@dhis2\/.*\.(js|jsx|mjs)$/,
+                        loader: require.resolve('babel-loader'),
+                        options: {
+                            cacheDirectory: true,
+                        },
+                    },
+                    {
                         test: /\.(js|jsx|mjs)$/,
                         include: paths.appSrc,
                         loader: require.resolve('babel-loader'),


### PR DESCRIPTION
…glifyjs

To allow DV to use the ui-core components (which are shipped as ES6 code),
the App is responsible to compile the ui-core components into the target
of the App.

The problem is that UglifyJS does not support ES6, so we need to compile
the ES6 code to ES5 code before shipping it to the html-webpack-plugin[1] minifier,
which uses html-minifier[2] which finally runs the uglifyjs library[3] which crashes.

> uglify-js only supports JavaScript (ECMAScript 5).

To solve this we need to allow webpack to run babel on @dhis2-scope packages in
node_modules.

[1] https://github.com/jantimon/html-webpack-plugin#minification
[2] https://github.com/kangax/html-minifier
[3] https://github.com/mishoo/UglifyJS2