### PR TITLE
chore: update @dhis2/analytics to enable epi weekly periods

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -5,7 +5,7 @@
     "main": "./build/index.js",
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "2.1.1",
+        "@dhis2/analytics": "2.3.0",
         "@material-ui/core": "^3.1.2",
         "lodash-es": "^4.17.11",
         "react": "^16.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,6 +179,25 @@
     react-beautiful-dnd "^10.1.1"
     styled-jsx "^3.2.1"
 
+"@dhis2/analytics@2.3.0", "@dhis2/analytics@^2.1.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.3.0.tgz#b8f0b4827b2944a78d6297658e9ca31497f61601"
+  integrity sha512-hZd/1X3OBwyz8nQksaaHL5eVAW5bARMTQ6Vu5xCNm5IB5pHpo6MXH9CFFi1UJsyuwx7tQLCUV663nM/Ta6OTgQ==
+  dependencies:
+    "@dhis2/d2-i18n" "^1.0.4"
+    "@dhis2/d2-ui-org-unit-dialog" "^6.1.0"
+    "@dhis2/d2-ui-period-selector-dialog" "^6.2.0"
+    "@dhis2/ui-core" "^3.4.0"
+    "@material-ui/core" "^3.9.3"
+    "@material-ui/icons" "^3.0.2"
+    classnames "^2.2.6"
+    d2-utilizr "^0.2.16"
+    d3-color "^1.2.3"
+    highcharts "^7.1.2"
+    lodash "^4.17.11"
+    react-beautiful-dnd "^10.1.1"
+    styled-jsx "^3.2.1"
+
 "@dhis2/d2-i18n-extract@^1.0.6", "@dhis2/d2-i18n-extract@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-extract/-/d2-i18n-extract-1.0.8.tgz#9d98690d522a51895c8ef3fe7136f026b0f8dacd"
@@ -328,6 +347,18 @@
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-analytics" "^1.0.0"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    babel-runtime "^6.26.0"
+    prop-types "^15.6.0"
+
+"@dhis2/d2-ui-period-selector-dialog@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.2.0.tgz#7c27654b846775faa014f67ac7ea0178e40f8066"
+  integrity sha512-NaCeAuwXgHX1Gle6kjFMI5hdtQqeQlBfHtFCa9IPZNvDoN3yn4pDSGx5XW9DPNESEoBg3KVhkdm8NDmcyglbqg==
+  dependencies:
+    "@dhis2/analytics" "^2.1.0"
+    "@dhis2/d2-i18n" "^1.0.4"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
Relates to [DHIS2-6983](https://jira.dhis2.org/browse/DHIS2-6983).

Changes include:
- Updating `@dhis2/analytics` dependency to v2.3.0 to enable epi weekly periods.