### PR TITLE
fix: avoid React warning about required proptype

### DIFF
--- a/packages/app/src/reducers/index.js
+++ b/packages/app/src/reducers/index.js
@@ -44,7 +44,11 @@ export {
 };
 
 export const sGetAxisSetupItems = state =>
-    fromUi.sGetAxisSetup(state).map(obj => ({
-        ...obj,
-        name: (fromMetadata.sGetMetadata(state)[obj.id] || {}).name,
-    }));
+    fromUi.sGetAxisSetup(state).map(obj => {
+        const metadata = fromMetadata.sGetMetadata(state)[obj.id];
+
+        return {
+            ...obj,
+            name: metadata ? metadata.name : '',
+        };
+    });


### PR DESCRIPTION
> Warning: Failed prop type: The prop `items[0].name` is
marked as required in `AxisSetup`, but its value is `undefined`.
>    in AxisSetup (created by WithStyles(AxisSetup))

was sometimes popping up and it turned out sometimes there is no name
available in the metadata for the item object.
Changed the code to initialize the name to empty string when not
available instead of passing undefined.