### PR TITLE
fix: error handling in DV app/plugin

### DIFF
--- a/packages/app/src/components/Visualization/BlankCanvas.js
+++ b/packages/app/src/components/Visualization/BlankCanvas.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import styles from './styles/BlankCanvas.style';
-import { sGetLoadError } from '../../reducers/loader';
 import chartErrorImg from '../../assets/chart-error-graphic.png';
 
 export const defaultCanvasMessage = i18n.t(
@@ -28,8 +26,4 @@ export const BlankCanvas = ({ error }) => {
     );
 };
 
-const mapStateToProps = state => ({
-    error: sGetLoadError(state),
-});
-
-export default connect(mapStateToProps)(BlankCanvas);
+export default BlankCanvas;

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -14,7 +14,6 @@ import {
     sGetUiRightSidebarOpen,
     sGetUiInterpretation,
 } from '../../reducers/ui';
-import { sGetLoadError } from '../../reducers/loader';
 
 import { acAddMetadata } from '../../actions/metadata';
 import { acSetChart } from '../../actions/chart';
@@ -24,10 +23,6 @@ import {
     acClearLoadError,
 } from '../../actions/loader';
 
-import { validateLayout } from '../../modules/layoutValidation';
-
-import BlankCanvas from './BlankCanvas';
-
 export class Visualization extends Component {
     constructor(props) {
         super(props);
@@ -35,21 +30,7 @@ export class Visualization extends Component {
         this.state = {
             renderId: null,
         };
-
-        if (props.chartConfig) {
-            this.validate(props.chartConfig);
-        }
     }
-
-    validate = visualization => {
-        try {
-            validateLayout(visualization);
-
-            this.props.acClearLoadError();
-        } catch (err) {
-            this.onError(err);
-        }
-    };
 
     onError = err => {
         const error =
@@ -99,11 +80,6 @@ export class Visualization extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.chartConfig !== prevProps.chartConfig) {
-            this.validate(this.props.chartConfig);
-            return;
-        }
-
         // open sidebar
         if (this.props.rightSidebarOpen !== prevProps.rightSidebarOpen) {
             this.getNewRenderId();
@@ -111,12 +87,9 @@ export class Visualization extends Component {
     }
 
     render() {
-        const { chartConfig, chartFilters, error } = this.props;
+        const { chartConfig, chartFilters } = this.props;
         const { renderId } = this.state;
-
-        return error ? (
-            <BlankCanvas />
-        ) : (
+        return (
             <ChartPlugin
                 id={renderId}
                 d2={this.context.d2}
@@ -153,7 +126,6 @@ const mapStateToProps = state => ({
     chartConfig: chartConfigSelector(state),
     chartFilters: chartFiltersSelector(state),
     rightSidebarOpen: sGetUiRightSidebarOpen(state),
-    error: sGetLoadError(state),
 });
 
 export default connect(

--- a/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
+++ b/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
@@ -6,8 +6,6 @@ import {
     chartConfigSelector,
     chartFiltersSelector,
 } from '../Visualization';
-import BlankCanvas from '../BlankCanvas';
-import * as validator from '../../../modules/layoutValidation';
 
 jest.mock('@dhis2/data-visualizer-plugin', () => () => <div />);
 
@@ -35,12 +33,6 @@ describe('Visualization', () => {
             };
 
             shallowVisualization = undefined;
-        });
-
-        it('renders a BlankCanvas when error', () => {
-            props.error = 'there was a catastrophic error';
-
-            expect(vis().find(BlankCanvas).length).toEqual(1);
         });
 
         it('renders a ChartPlugin when no error', () => {
@@ -78,23 +70,6 @@ describe('Visualization', () => {
             expect(props.acSetLoadError).toHaveBeenCalledWith(errorMsg);
         });
 
-        it('triggers clearLoadError when chart config has valid layout', () => {
-            props.chartConfig = { name: 'rainbowDash' };
-            validator.validateLayout = () => 'valid';
-            vis();
-            expect(props.acClearLoadError).toHaveBeenCalled();
-        });
-
-        it('triggers setLoadError when chart config has invalid layout', () => {
-            props.chartConfig = { name: 'non-valid rainbowDash' };
-            validator.validateLayout = () => {
-                throw new Error('not valid');
-            };
-            vis();
-
-            expect(props.acSetLoadError).toHaveBeenCalled();
-        });
-
         it('renders chart with new id when rightSidebarOpen prop changes', () => {
             const wrapper = vis();
 
@@ -103,18 +78,6 @@ describe('Visualization', () => {
             const updatedId = wrapper.find(ChartPlugin).prop('id');
 
             expect(initialId).not.toEqual(updatedId);
-        });
-
-        it('triggers clearLoadError when chart changed to a different, valid chart', () => {
-            validator.validateLayout = () => 'valid';
-            const wrapper = vis();
-
-            wrapper.setProps({
-                ...props,
-                chartConfig: { name: 'rainbowDash' },
-            });
-
-            expect(props.acClearLoadError).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -111,7 +111,7 @@ class ChartPlugin extends Component {
 
             const extraOptions = {
                 dashboard: forDashboard,
-                noData: { text: i18n.t('No data') }
+                noData: { text: i18n.t('No data') },
             };
 
             let responses = [];


### PR DESCRIPTION
Problem was that when changing visualization type and the layout validation failed, the plugin code was still running (due to async) and generated errors due to incompatible data passed in the object.
For example, switching from a gauge/sv AO to column, the layout
validation fails because of missing dimension in category. The error was
correctly raised, but the async code in the plugin was also raising an
error which was overriding the layout error.
The solution is to run the validation before we render the Visualization
component, in App.js. In this way the error is passed directly to the
BlankCanvas component and the Visualization component is never rendered.
Also, the Visualization component does not need to check for errors and
decide if render the plugin or the BlankCanvas component.