### PR TITLE
fix: viewport layout with visible interpretations panel

### DIFF
--- a/packages/app/src/components/App.css
+++ b/packages/app/src/components/App.css
@@ -63,7 +63,7 @@ body {
 .main-right {
     flex: 1 1 0%;
     max-width: 380px;
-    background-color: #f4f6f8;
+    background-color: #f0f2f4;
     overflow-y: auto;
     overflow-x: hidden;
 }

--- a/packages/app/src/components/App.css
+++ b/packages/app/src/components/App.css
@@ -27,6 +27,10 @@ body {
     flex-grow: 1;
 }
 
+.flex-basis-0 {
+    flex-basis: 0%;
+}
+
 /* Headerbar */
 
 .section-headerbar {

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -177,7 +177,7 @@ export class App extends Component {
                         <div className="main-left">
                             <DimensionsPanel />
                         </div>
-                        <div className="main-center flex-grow-1 flex-ct flex-dir-col">
+                        <div className="main-center flex-grow-1 flex-basis-0 flex-ct flex-dir-col">
                             <div className="main-center-layout">
                                 <Layout />
                             </div>


### PR DESCRIPTION
There was a missing flexbox rule that messed up the layout when interpretations panel was shown.

Also changing the main-right (interpretation panel area) background color slightly because there was no visible separation vs main-center (chart area) for SV charts when interpretations panel was shown.