### PR TITLE
feat: WIP pivot table type

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-09-16T07:28:39.022Z\n"
-"PO-Revision-Date: 2019-09-16T07:28:39.022Z\n"
+"POT-Creation-Date: 2019-10-15T11:53:22.928Z\n"
+"PO-Revision-Date: 2019-10-15T11:53:22.928Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -295,6 +295,9 @@ msgid "Options"
 msgstr ""
 
 msgid "Chart options"
+msgstr ""
+
+msgid "Pivot table"
 msgstr ""
 
 msgid "Column"

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import HeaderBar from '@dhis2/ui/widgets/HeaderBar';
@@ -14,9 +15,11 @@ import Interpretations from './Interpretations/Interpretations';
 import Visualization from './Visualization/Visualization';
 import Layout from './Layout/Layout';
 import * as fromReducers from '../reducers';
+import { sGetUiType } from '../reducers/ui';
 import * as fromActions from '../actions';
 import history from '../modules/history';
 import defaultMetadata from '../modules/metadata';
+import { PIVOT_TABLE } from '../modules/chartTypes';
 import {
     apiFetchAOFromUserDataStore,
     CURRENT_AO_KEY,
@@ -204,11 +207,17 @@ export class App extends Component {
     }
 }
 
+const apiObjectSelector = createSelector(
+    [sGetUiType],
+    type => (type === PIVOT_TABLE ? 'reportTable' : 'chart')
+);
+
 const mapStateToProps = state => ({
     settings: fromReducers.fromSettings.sGetSettings(state),
     current: fromReducers.fromCurrent.sGetCurrent(state),
     interpretations: fromReducers.fromVisualization.sGetInterpretations(state),
     ui: fromReducers.fromUi.sGetUi(state),
+    apiObjectName: apiObjectSelector(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/app/src/components/Layout/Layout.js
+++ b/packages/app/src/components/Layout/Layout.js
@@ -18,6 +18,7 @@ import {
     YEAR_OVER_YEAR_LINE,
     YEAR_OVER_YEAR_COLUMN,
     SINGLE_VALUE,
+    PIVOT_TABLE,
 } from '../../modules/chartTypes';
 import { sGetUiType } from '../../reducers/ui';
 
@@ -34,6 +35,7 @@ const layoutMap = {
     [YEAR_OVER_YEAR_LINE]: YearOverYearLayout,
     [YEAR_OVER_YEAR_COLUMN]: YearOverYearLayout,
     [SINGLE_VALUE]: SingleValueLayout,
+    [PIVOT_TABLE]: DefaultLayout,
 };
 
 const getLayoutByType = (type, props) => {

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -6,8 +6,7 @@ import i18n from '@dhis2/d2-i18n';
 import debounce from 'lodash-es/debounce';
 
 import styles from './styles/Visualization.style';
-import ChartPlugin from '@dhis2/data-visualizer-plugin';
-
+import VisualizationPlugin from '@dhis2/data-visualizer-plugin';
 import { sGetVisualization } from '../../reducers/visualization';
 import { sGetCurrent } from '../../reducers/current';
 import {
@@ -86,17 +85,17 @@ export class Visualization extends Component {
     }
 
     render() {
-        const { chartConfig, chartFilters, error } = this.props;
+        const { visConfig, visFilters, error } = this.props;
         const { renderId } = this.state;
 
-        return Boolean(!chartConfig || error) ? (
+        return Boolean(!visConfig || error) ? (
             <BlankCanvas />
         ) : (
-            <ChartPlugin
+            <VisualizationPlugin
                 id={renderId}
                 d2={this.context.d2}
-                config={chartConfig}
-                filters={chartFilters}
+                config={visConfig}
+                filters={visFilters}
                 onChartGenerated={this.onChartGenerated}
                 onResponsesReceived={this.onResponsesReceived}
                 onError={this.onError}
@@ -110,13 +109,13 @@ Visualization.contextTypes = {
     d2: PropTypes.object,
 };
 
-export const chartConfigSelector = createSelector(
+export const visConfigSelector = createSelector(
     [sGetCurrent, sGetVisualization, sGetUiInterpretation],
     (current, visualization, interpretation) =>
         interpretation.id ? visualization : current
 );
 
-export const chartFiltersSelector = createSelector(
+export const visFiltersSelector = createSelector(
     [sGetUiInterpretation],
     interpretation =>
         interpretation.created
@@ -125,8 +124,8 @@ export const chartFiltersSelector = createSelector(
 );
 
 const mapStateToProps = state => ({
-    chartConfig: chartConfigSelector(state),
-    chartFilters: chartFiltersSelector(state),
+    visConfig: visConfigSelector(state),
+    visFilters: visFiltersSelector(state),
     rightSidebarOpen: sGetUiRightSidebarOpen(state),
     error: sGetLoadError(state),
 });

--- a/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
+++ b/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ChartPlugin from '@dhis2/data-visualizer-plugin';
+import VisualizationPlugin from '@dhis2/data-visualizer-plugin';
 import {
     Visualization,
-    chartConfigSelector,
-    chartFiltersSelector,
+    visConfigSelector,
+    visFiltersSelector,
 } from '../Visualization';
 import BlankCanvas from '../BlankCanvas';
 
@@ -23,8 +23,8 @@ describe('Visualization', () => {
 
         beforeEach(() => {
             props = {
-                chartConfig: {},
-                chartFilters: null,
+                visConfig: {},
+                visFilters: null,
                 error: null,
                 rightSidebarOpen: false,
                 acAddMetadata: jest.fn(),
@@ -42,8 +42,8 @@ describe('Visualization', () => {
             expect(vis().find(BlankCanvas).length).toEqual(1);
         });
 
-        it('renders a ChartPlugin when no error and chartConfig available', () => {
-            expect(vis().find(ChartPlugin).length).toEqual(1);
+        it('renders a VisualizationPlugin when no error and visConfig available', () => {
+            expect(vis().find(VisualizationPlugin).length).toEqual(1);
         });
 
         it('triggers addMetadata action when responses received from chart plugin', () => {
@@ -77,12 +77,12 @@ describe('Visualization', () => {
             expect(props.acSetLoadError).toHaveBeenCalledWith(errorMsg);
         });
 
-        it('renders chart with new id when rightSidebarOpen prop changes', () => {
+        it('renders visualization with new id when rightSidebarOpen prop changes', () => {
             const wrapper = vis();
 
-            const initialId = wrapper.find(ChartPlugin).prop('id');
+            const initialId = wrapper.find(VisualizationPlugin).prop('id');
             wrapper.setProps({ ...props, rightSidebarOpen: true });
-            const updatedId = wrapper.find(ChartPlugin).prop('id');
+            const updatedId = wrapper.find(VisualizationPlugin).prop('id');
 
             expect(initialId).not.toEqual(updatedId);
         });
@@ -97,23 +97,23 @@ describe('Visualization', () => {
             },
         };
 
-        describe('chartConfigSelector', () => {
+        describe('visConfigSelector', () => {
             it('equals the visualization if interpretation selected', () => {
                 const newState = Object.assign({}, state, {
                     ui: { interpretation: { id: 'rainbow dash' } },
                 });
 
-                const selector = chartConfigSelector(newState);
+                const selector = visConfigSelector(newState);
                 expect(selector).toEqual('vis');
             });
 
             it('equals the current if no interpretation selected', () => {
-                const selector = chartConfigSelector(state);
+                const selector = visConfigSelector(state);
                 expect(selector).toEqual('current');
             });
         });
 
-        describe('chartFiltersSelector', () => {
+        describe('visFiltersSelector', () => {
             it('equals object with interpretation date if interpretation selected', () => {
                 const created = 'the near future';
                 const newState = Object.assign({}, state, {
@@ -123,14 +123,14 @@ describe('Visualization', () => {
                         },
                     },
                 });
-                const selector = chartFiltersSelector(newState);
+                const selector = visFiltersSelector(newState);
                 expect(selector).toEqual({
                     relativePeriodDate: created,
                 });
             });
 
             it('equals empty object if no interpretation selected', () => {
-                const selector = chartFiltersSelector(state);
+                const selector = visFiltersSelector(state);
                 expect(selector).toEqual({});
             });
         });

--- a/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeIcon.js
+++ b/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeIcon.js
@@ -16,6 +16,7 @@ import SingleValueIcon from '../../assets/SingleValueIcon';
 import GlobeIcon from '../../assets/GlobeIcon';
 
 import {
+    PIVOT_TABLE,
     COLUMN,
     STACKED_COLUMN,
     BAR,
@@ -32,8 +33,10 @@ import {
     chartTypeDisplayNames,
 } from '../../modules/chartTypes';
 
-const VisualizationTypeIcon = ({ type = COLUMN, style }) => {
+const VisualizationTypeIcon = ({ type = PIVOT_TABLE, style }) => {
     switch (type) {
+        case COLUMN:
+            return <ColumnIcon style={style} />;
         case STACKED_COLUMN:
             return <StackedColumnIcon style={style} />;
         case BAR:
@@ -58,9 +61,9 @@ const VisualizationTypeIcon = ({ type = COLUMN, style }) => {
             return <SingleValueIcon style={style} />;
         case OPEN_AS_MAP:
             return <GlobeIcon style={style} />;
-        case COLUMN:
+        case PIVOT_TABLE:
         default:
-            return <ColumnIcon style={style} />;
+            return <LineIcon style={style} />;
     }
 };
 

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -18,8 +18,6 @@ import muiTheme from './modules/theme';
 import { extractUserSettings } from './modules/settings';
 import { apiFetchOrganisationUnitLevels } from './api/organisationUnits';
 
-const apiObjectName = 'chart';
-
 const configI18n = async userSettings => {
     const uiLocale = userSettings.uiLocale;
 
@@ -43,7 +41,7 @@ const render = props => {
     ReactDOM.render(
         <Provider store={store}>
             <MuiThemeProvider theme={muiTheme}>
-                <App apiObjectName={apiObjectName} {...props} />
+                <App {...props} />
             </MuiThemeProvider>
         </Provider>,
         document.getElementById('root')
@@ -63,7 +61,7 @@ const init = async () => {
         : DHIS_CONFIG.baseUrl;
 
     config.baseUrl = `${baseUrl}/api/${manifest.dhis2.apiVersion}`;
-    config.schemas = ['chart', 'organisationUnit', 'userGroup'];
+    config.schemas = ['chart', 'reportTable', 'organisationUnit', 'userGroup'];
 
     const userSettings = extractUserSettings(await getUserSettings());
 

--- a/packages/app/src/modules/chartTypes.js
+++ b/packages/app/src/modules/chartTypes.js
@@ -13,9 +13,11 @@ export const BUBBLE = 'BUBBLE';
 export const YEAR_OVER_YEAR_LINE = 'YEAR_OVER_YEAR_LINE';
 export const YEAR_OVER_YEAR_COLUMN = 'YEAR_OVER_YEAR_COLUMN';
 export const SINGLE_VALUE = 'SINGLE_VALUE';
+export const PIVOT_TABLE = 'PIVOT_TABLE';
 export const OPEN_AS_MAP = 'OPEN_AS_MAP';
 
 export const chartTypeDisplayNames = {
+    [PIVOT_TABLE]: i18n.t('Pivot table'),
     [COLUMN]: i18n.t('Column'),
     [STACKED_COLUMN]: i18n.t('Stacked column'),
     [BAR]: i18n.t('Bar'),
@@ -36,7 +38,7 @@ const yearOverYearTypes = [YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN];
 const openAsTypes = [OPEN_AS_MAP];
 const dualAxisTypes = [COLUMN, BAR, LINE, AREA];
 
-export const defaultChartType = COLUMN;
+export const defaultChartType = PIVOT_TABLE;
 export const isStacked = type => stackedTypes.includes(type);
 export const isYearOverYear = type => yearOverYearTypes.includes(type);
 export const isOpenAsType = type => openAsTypes.includes(type);

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -9,7 +9,7 @@ import {
 
 import { getFilteredLayout, getSwapModObj } from '../modules/layout';
 import { getOptionsForUi } from '../modules/options';
-import { COLUMN } from '../modules/chartTypes';
+import { PIVOT_TABLE } from '../modules/chartTypes';
 import { getUiFromVisualization } from '../modules/ui';
 
 export const SET_UI = 'SET_UI';
@@ -35,7 +35,7 @@ export const CLEAR_UI_INTERPRETATION = 'CLEAR_UI_INTERPRETATION';
 export const SET_AXES = 'SET_AXES';
 
 export const DEFAULT_UI = {
-    type: COLUMN,
+    type: PIVOT_TABLE,
     options: getOptionsForUi(),
     layout: {
         columns: [DIMENSION_ID_DATA],

--- a/packages/plugin/src/PivotPlugin.js
+++ b/packages/plugin/src/PivotPlugin.js
@@ -1,0 +1,213 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import isEqual from 'lodash-es/isEqual';
+import i18n from '@dhis2/d2-i18n';
+import { createVisualization } from '@dhis2/analytics';
+
+import { apiFetchVisualization } from './api/visualization';
+import {
+    apiFetchAnalytics,
+    apiFetchAnalyticsForYearOverYear,
+} from './api/analytics';
+import { isYearOverYear, isSingleValue } from './modules/chartTypes';
+import { getOptionsForRequest } from './modules/options';
+import { computeGenericPeriodNames } from './modules/analytics';
+import { BASE_FIELD_YEARLY_SERIES } from './modules/fields/baseFields';
+import LoadingMask from './widgets/LoadingMask';
+
+class PivotPlugin extends Component {
+    constructor(props) {
+        super(props);
+
+        this.canvasRef = React.createRef();
+
+        this.recreateVisualization = Function.prototype;
+
+        this.state = {
+            isLoading: true,
+        };
+    }
+
+    componentDidMount() {
+        this.renderChart();
+    }
+
+    componentDidUpdate(prevProps) {
+        if (!isEqual(this.props.config, prevProps.config)) {
+            this.renderChart();
+            return;
+        }
+
+        if (!isEqual(this.props.filters, prevProps.filters)) {
+            this.renderChart();
+            return;
+        }
+
+        // id set by DV app, style works in dashboards
+        if (
+            this.props.id !== prevProps.id ||
+            !isEqual(this.props.style, prevProps.style)
+        ) {
+            this.recreateVisualization(0); // disable animation
+            return;
+        }
+    }
+
+    getRequestOptions = (visualization, filters) => {
+        const options = getOptionsForRequest().reduce(
+            (map, [option, props]) => {
+                // only add parameter if value !== default
+                if (
+                    visualization[option] !== undefined &&
+                    visualization[option] !== props.defaultValue
+                ) {
+                    map[option] = visualization[option];
+                }
+
+                return map;
+            },
+            {}
+        );
+
+        // interpretation filter
+        if (filters.relativePeriodDate) {
+            options.relativePeriodDate = filters.relativePeriodDate;
+        }
+
+        // global filters
+        // userOrgUnit
+        if (filters.userOrgUnit && filters.userOrgUnit.length) {
+            const ouIds = filters.userOrgUnit.map(
+                ouPath => ouPath.split('/').slice(-1)[0]
+            );
+
+            options.userOrgUnit = ouIds.join(';');
+        }
+
+        return options;
+    };
+
+    getConfigById = id => {
+        return apiFetchVisualization(this.props.d2, 'chart', id);
+    };
+
+    renderChart = async () => {
+        const {
+            config,
+            filters,
+            forDashboard,
+            onResponsesReceived,
+            onChartGenerated,
+            onError,
+        } = this.props;
+
+        try {
+            const visualization =
+                Object.keys(config).length === 1 && config.id
+                    ? await this.getConfigById(config.id)
+                    : config;
+
+            const options = this.getRequestOptions(visualization, filters);
+
+            const extraOptions = {
+                dashboard: forDashboard,
+                noData: { text: i18n.t('No data') }
+            };
+
+            let responses = [];
+
+            if (isYearOverYear(visualization.type)) {
+                let yearlySeriesLabels = [];
+
+                ({
+                    responses,
+                    yearlySeriesLabels,
+                } = await apiFetchAnalyticsForYearOverYear(
+                    this.props.d2,
+                    visualization,
+                    options
+                ));
+
+                extraOptions[BASE_FIELD_YEARLY_SERIES] = yearlySeriesLabels;
+                extraOptions.xAxisLabels = computeGenericPeriodNames(responses);
+            } else {
+                responses = await apiFetchAnalytics(
+                    this.props.d2,
+                    visualization,
+                    options
+                );
+            }
+
+            if (responses.length) {
+                onResponsesReceived(responses);
+            }
+
+            this.recreateVisualization = animation => {
+                const visualizationConfig = createVisualization(
+                    responses,
+                    visualization,
+                    this.canvasRef.current,
+                    {
+                        ...extraOptions,
+                        animation,
+                    },
+                    undefined,
+                    undefined,
+                    isSingleValue(visualization.type) ? 'dhis' : 'highcharts' // output format
+                );
+
+                if (isSingleValue(visualization.type)) {
+                    onChartGenerated(visualizationConfig.visualization);
+                } else {
+                    onChartGenerated(
+                        visualizationConfig.visualization.getSVGForExport({
+                            sourceHeight: 768,
+                            sourceWidth: 1024,
+                        })
+                    );
+                }
+            };
+
+            this.recreateVisualization();
+
+            this.setState({ isLoading: false });
+        } catch (error) {
+            onError(error);
+        }
+    };
+
+    render() {
+        return (
+            <Fragment>
+                {this.state.isLoading ? <LoadingMask /> : null}
+                <div ref={this.canvasRef} style={this.props.style} />
+            </Fragment>
+        );
+    }
+}
+
+PivotPlugin.defaultProps = {
+    config: {},
+    filters: {},
+    forDashboard: false,
+    style: {},
+    animation: 200,
+    onError: Function.prototype,
+    onChartGenerated: Function.prototype,
+    onResponsesReceived: Function.prototype,
+};
+
+PivotPlugin.propTypes = {
+    id: PropTypes.number,
+    d2: PropTypes.object.isRequired,
+    animation: PropTypes.number,
+    config: PropTypes.object.isRequired,
+    filters: PropTypes.object,
+    forDashboard: PropTypes.bool,
+    style: PropTypes.object,
+    onError: PropTypes.func.isRequired,
+    onChartGenerated: PropTypes.func,
+    onResponsesReceived: PropTypes.func,
+};
+
+export default PivotPlugin;

--- a/packages/plugin/src/index.js
+++ b/packages/plugin/src/index.js
@@ -1,3 +1,16 @@
-import ChartPlugin from './ChartPlugin';
+import React from 'react';
 
-export default ChartPlugin;
+import ChartPlugin from './ChartPlugin';
+import PivotPlugin from './PivotPlugin';
+
+import { PIVOT_TABLE } from './modules/chartTypes';
+
+const VisualizationPlugin = props => {
+    if (!props.config.type || props.config.type === PIVOT_TABLE) {
+        return <PivotPlugin {...props} />;
+    } else {
+        return <ChartPlugin {...props} />;
+    }
+};
+
+export default VisualizationPlugin;

--- a/packages/plugin/src/modules/chartTypes.js
+++ b/packages/plugin/src/modules/chartTypes.js
@@ -1,6 +1,7 @@
 export const YEAR_OVER_YEAR_LINE = 'YEAR_OVER_YEAR_LINE';
 export const YEAR_OVER_YEAR_COLUMN = 'YEAR_OVER_YEAR_COLUMN';
 export const SINGLE_VALUE = 'SINGLE_VALUE';
+export const PIVOT_TABLE = 'PIVOT_TABLE';
 
 const yearOverYearTypes = [YEAR_OVER_YEAR_LINE, YEAR_OVER_YEAR_COLUMN];
 


### PR DESCRIPTION
- Adds a new visualization type for Pivot table.
- FileMenu lists `reportTable` AOs when the pivot type is selected (temporary solution for testing purposes when a proper plugin for pivot is available).
There is a problem with this in subsequent vis type changes as FileMenu does not refresh the list of files when the `fileType` passed changes (needs to be fixed in the d2-ui component)
- Currently the pivot plugin is just a copy of the chart one.
- The pivot type is now also the default vis type; this is to avoid problems due to the missing `type` in the reportTable AO.
This allows to open a pivot table directly via URL and have the correct type and plugin used.

DHIS2-7721.