### PR TITLE
fix: vertical scaling with >= 3 filter rows (DHIS2-7802)

### DIFF
--- a/packages/app/src/components/Layout/DefaultLayout/styles/DefaultLayout.style.js
+++ b/packages/app/src/components/Layout/DefaultLayout/styles/DefaultLayout.style.js
@@ -10,7 +10,7 @@ export const DIMENSION_AXIS_WIDTH = `${100 - parseInt(FILTER_AXIS_WIDTH, 10)}%`;
 export default {
     ct: {
         display: 'flex',
-        height: LAYOUT_HEIGHT,
+        minHeight: LAYOUT_HEIGHT,
     },
     axisGroup: {
         display: 'flex',


### PR DESCRIPTION
When adding multiple filter dimensions that creates three or more filter rows the vertical scaling breaks the layout, causing the name of the chart to overflow into the axes area.