### PR TITLE
feat: drag 'n drop for reordering dimension items in layout

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -23,6 +23,7 @@
         "history": "^4.7.2",
         "lodash-es": "^4.17.11",
         "raf": "3.4.0",
+        "react-beautiful-dnd": "^12.2.0",
         "react-redux": "^5.1.0",
         "redux": "^4.0.0",
         "redux-actions": "^2.2.1",

--- a/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -138,7 +138,7 @@ class Axis extends React.Component {
                                                 {...provided.dragHandleProps}
                                             >
                                                 <Chip
-                                                    key={key}
+                                                    key={`${key}-chip`}
                                                     onClick={this.props.getOpenHandler(
                                                         dimensionId
                                                     )}

--- a/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -105,43 +105,57 @@ class Axis extends React.Component {
 
     render() {
         return (
-            <Droppable droppableId={this.props.axisId} direction="horizontal">
-                {provided => (
-                <div
-                    id={this.props.axisId}
-                    style={{ ...styles.axisContainer, ...this.props.style }}
-                    onDragOver={this.onDragOver}
-                    onDrop={this.onDrop}
-                    ref={provided.innerRef}
-                    {...provided.droppableProps}
+            <div
+                id={this.props.axisId}
+                style={{ ...styles.axisContainer, ...this.props.style }}
+                onDragOver={this.onDragOver}
+                onDrop={this.onDrop}
+            >
+                <div style={styles.label}>{getAxisName(this.props.axisId)}</div>
+                <Droppable
+                    droppableId={this.props.axisId}
+                    direction="horizontal"
                 >
-                    <div style={styles.label}>{getAxisName(this.props.axisId)}</div>
-                    <div style={styles.content}>
-                        {this.props.axis.map((dimensionId, index) => {
-                            const key = `${this.props.axisId}-${dimensionId}`;
+                    {provided => (
+                        <div
+                            style={styles.content}
+                            ref={provided.innerRef}
+                            {...provided.droppableProps}
+                        >
+                            {this.props.axis.map((dimensionId, index) => {
+                                const key = `${this.props.axisId}-${dimensionId}`
 
-                            return (
-                                <Draggable key={key} draggableId={key} index={index}>
-                                {provided => (
-                                    <div ref={provided.innerRef}
-                                    {...provided.draggableProps}
-                                    {...provided.dragHandleProps}
-                                    >
-                                    <Chip
+                                return (
+                                    <Draggable
                                         key={key}
-                                        onClick={this.props.getOpenHandler(dimensionId)}
-                                        axisId={this.props.axisId}
-                                        dimensionId={dimensionId}
-                                    />
-                                    </div>)}
-                                </Draggable>
-                            );
-                        })}
-                    </div>
-                    {provided.placeholder}
-                </div>)}
-            </Droppable>
-        );
+                                        draggableId={key}
+                                        index={index}
+                                    >
+                                        {provided => (
+                                            <div
+                                                ref={provided.innerRef}
+                                                {...provided.draggableProps}
+                                                {...provided.dragHandleProps}
+                                            >
+                                                <Chip
+                                                    key={key}
+                                                    onClick={this.props.getOpenHandler(
+                                                        dimensionId
+                                                    )}
+                                                    axisId={this.props.axisId}
+                                                    dimensionId={dimensionId}
+                                                />
+                                            </div>
+                                        )}
+                                    </Draggable>
+                                )
+                            })}
+                            {provided.placeholder}
+                        </div>
+                    )}
+                </Droppable>
+            </div>
+        )
     }
 }
 

--- a/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -1,8 +1,10 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import i18n from '@dhis2/d2-i18n'
-import MenuItem from '@material-ui/core/MenuItem'
-import Divider from '@material-ui/core/Divider'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Droppable, Draggable } from 'react-beautiful-dnd';
+import i18n from '@dhis2/d2-i18n';
+import MenuItem from '@material-ui/core/MenuItem';
+import Divider from '@material-ui/core/Divider';
 import {
     AXIS_ID_COLUMNS,
     DEFAULT_AXIS_IDS,
@@ -11,7 +13,6 @@ import {
     isDualAxisType,
     getAxisName,
 } from '@dhis2/analytics'
-import PropTypes from 'prop-types'
 
 import Chip from '../Chip'
 import { sGetUi } from '../../../reducers/ui'
@@ -104,25 +105,43 @@ class Axis extends React.Component {
 
     render() {
         return (
-            <div
-                id={this.props.axisId}
-                style={{ ...styles.axisContainer, ...this.props.style }}
-                onDragOver={this.onDragOver}
-                onDrop={this.onDrop}
-            >
-                <div style={styles.label}>{getAxisName(this.props.axisId)}</div>
-                <div style={styles.content}>
-                    {this.props.axis.map(dimensionId => (
-                        <Chip
-                            key={`${this.props.axisId}-${dimensionId}`}
-                            onClick={this.props.getOpenHandler(dimensionId)}
-                            axisId={this.props.axisId}
-                            dimensionId={dimensionId}
-                        />
-                    ))}
-                </div>
-            </div>
-        )
+            <Droppable droppableId={this.props.axisId} direction="horizontal">
+                {provided => (
+                <div
+                    id={this.props.axisId}
+                    style={{ ...styles.axisContainer, ...this.props.style }}
+                    onDragOver={this.onDragOver}
+                    onDrop={this.onDrop}
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                >
+                    <div style={styles.label}>{getAxisName(this.props.axisId)}</div>
+                    <div style={styles.content}>
+                        {this.props.axis.map((dimensionId, index) => {
+                            const key = `${this.props.axisId}-${dimensionId}`;
+
+                            return (
+                                <Draggable key={key} draggableId={key} index={index}>
+                                {provided => (
+                                    <div ref={provided.innerRef}
+                                    {...provided.draggableProps}
+                                    {...provided.dragHandleProps}
+                                    >
+                                    <Chip
+                                        key={key}
+                                        onClick={this.props.getOpenHandler(dimensionId)}
+                                        axisId={this.props.axisId}
+                                        dimensionId={dimensionId}
+                                    />
+                                    </div>)}
+                                </Draggable>
+                            );
+                        })}
+                    </div>
+                    {provided.placeholder}
+                </div>)}
+            </Droppable>
+        );
     }
 }
 
@@ -135,10 +154,11 @@ Axis.propTypes = {
     itemsByDimension: PropTypes.object,
     style: PropTypes.object,
     type: PropTypes.string,
+    ui: PropTypes.object,
     onAddDimension: PropTypes.func,
     onDropWithoutItems: PropTypes.func,
     onOpenAxisSetup: PropTypes.func,
-}
+};
 
 const mapStateToProps = state => ({
     ui: sGetUi(state),

--- a/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { Droppable, Draggable } from 'react-beautiful-dnd';
-import i18n from '@dhis2/d2-i18n';
-import MenuItem from '@material-ui/core/MenuItem';
-import Divider from '@material-ui/core/Divider';
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { Droppable, Draggable } from 'react-beautiful-dnd'
+import i18n from '@dhis2/d2-i18n'
+import MenuItem from '@material-ui/core/MenuItem'
+import Divider from '@material-ui/core/Divider'
 import {
     AXIS_ID_COLUMNS,
     DEFAULT_AXIS_IDS,
@@ -172,7 +172,7 @@ Axis.propTypes = {
     onAddDimension: PropTypes.func,
     onDropWithoutItems: PropTypes.func,
     onOpenAxisSetup: PropTypes.func,
-};
+}
 
 const mapStateToProps = state => ({
     ui: sGetUi(state),

--- a/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultAxis.js
@@ -138,7 +138,6 @@ class Axis extends React.Component {
                                                 {...provided.dragHandleProps}
                                             >
                                                 <Chip
-                                                    key={`${key}-chip`}
                                                     onClick={this.props.getOpenHandler(
                                                         dimensionId
                                                     )}

--- a/packages/app/src/components/Layout/DefaultLayout/styles/DefaultAxis.style.js
+++ b/packages/app/src/components/Layout/DefaultLayout/styles/DefaultAxis.style.js
@@ -25,6 +25,7 @@ export default {
         letterSpacing: '0.2px',
     },
     content: {
+        width: '100%',
         display: 'flex',
         alignItems: 'flex-start',
         alignContent: 'flex-start',

--- a/packages/app/src/components/Layout/Layout.js
+++ b/packages/app/src/components/Layout/Layout.js
@@ -1,5 +1,7 @@
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { DragDropContext } from 'react-beautiful-dnd';
 import {
     VIS_TYPE_COLUMN,
     VIS_TYPE_STACKED_COLUMN,
@@ -16,10 +18,11 @@ import {
     VIS_TYPE_PIVOT_TABLE,
 } from '@dhis2/analytics'
 
-import DefaultLayout from './DefaultLayout/DefaultLayout'
-import YearOverYearLayout from './YearOverYearLayout/YearOverYearLayout'
-import PieLayout from './PieLayout/PieLayout'
-import { sGetUiType } from '../../reducers/ui'
+import DefaultLayout from './DefaultLayout/DefaultLayout';
+import YearOverYearLayout from './YearOverYearLayout/YearOverYearLayout';
+import PieLayout from './PieLayout/PieLayout';
+import { sGetUiLayout, sGetUiType } from '../../reducers/ui';
+import { acSetUiLayout} from '../../actions/ui';
 
 const layoutMap = {
     [VIS_TYPE_COLUMN]: DefaultLayout,
@@ -42,10 +45,52 @@ const getLayoutByType = (type, props) => {
     return <Layout {...props} />
 }
 
-const Layout = props => getLayoutByType(props.type)
+const Layout = props => {
+     const onDragEnd = result => {
+        const { source, destination } = result;
+
+        if (!destination) {
+            return;
+        }
+
+        const sourceList = Array.from(props.layout[source.droppableId]);
+        const [moved] = sourceList.splice(source.index, 1);
+        const reorderedDimensions = {};
+
+        if (source.droppableId === destination.droppableId) {
+            sourceList.splice(destination.index, 0, moved);
+            reorderedDimensions[source.droppableId] = sourceList;
+        }
+        else {
+            const destList = Array.from(props.layout[destination.droppableId]);
+            destList.splice(destination.index, 0, moved);
+            reorderedDimensions[destination.droppableId] = destList;
+            reorderedDimensions[source.droppableId] = sourceList;
+        }
+
+        props.onReorderDimensions({ ...props.layout, ...reorderedDimensions });
+    };
+
+    return (
+        <DragDropContext onDragEnd={onDragEnd}>
+            {getLayoutByType(props.type)}
+        </DragDropContext>
+    );
+}
+
+Layout.propTypes = {
+    layout: PropTypes.object,
+    type: PropTypes.string,
+    onReorderDimensions: PropTypes.func,
+};
 
 const mapStateToProps = state => ({
+    layout: sGetUiLayout(state),
     type: sGetUiType(state),
 })
 
-export default connect(mapStateToProps)(Layout)
+const mapDispatchToProps = dispatch => ({
+    onReorderDimensions: layout => dispatch(acSetUiLayout(layout)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Layout);

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,6 +996,14 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime-corejs2@^7.6.3":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz#b9c2b1b5882762005785bc47740195a0ac780888"
+  integrity sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime-corejs3@^7.7.4":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.7.7.tgz#78fcbd472daec13abc42678bfc319e58a62235a3"
@@ -1004,7 +1012,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@7.7.4":
+"@babel/runtime@7.7.4", "@babel/runtime@^7.5.5":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.4.tgz#b23a856751e4bf099262f867767889c0e3fe175b"
   integrity sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==
@@ -4686,7 +4694,7 @@ css-blank-pseudo@^0.1.4:
   dependencies:
     postcss "^7.0.5"
 
-css-box-model@^1.1.1:
+css-box-model@^1.1.1, css-box-model@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.0.tgz#3a26377b4162b3200d2ede4b064ec5b6a75186d0"
   integrity sha512-lri0br+jSNV0kkkiGEp9y9y3Njq2PmpqbeGWRFQJuZteZzY9iC9GZhQ8Y4WpPwM/2YocjHePxy14igJY7YKzkA==
@@ -7392,6 +7400,13 @@ hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1:
   dependencies:
     react-is "^16.7.0"
 
+hoist-non-react-statics@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#101685d3aff3b23ea213163f6e8e12f4f111e19f"
+  integrity sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
@@ -9853,7 +9868,7 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^5.0.0, memoize-one@^5.0.1:
+memoize-one@^5.0.0, memoize-one@^5.0.1, memoize-one@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
@@ -12273,7 +12288,7 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
-raf-schd@^4.0.0:
+raf-schd@^4.0.0, raf-schd@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
   integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
@@ -12385,6 +12400,19 @@ react-beautiful-dnd@^10.1.1:
     redux "^4.0.1"
     tiny-invariant "^1.0.4"
 
+react-beautiful-dnd@^12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-12.2.0.tgz#e5f6222f9e7934c6ed4ee09024547f9e353ae423"
+  integrity sha512-s5UrOXNDgeEC+sx65IgbeFlqKKgK3c0UfbrJLWufP34WBheyu5kJ741DtJbsSgPKyNLkqfswpMYr0P8lRj42cA==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.6.3"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.1.1"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
+
 react-dev-utils@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-10.0.0.tgz#bd2d16426c7e4cbfed1b46fb9e2ac98ec06fcdfa"
@@ -12480,6 +12508,18 @@ react-redux@^5.0.7, react-redux@^5.1.0:
     prop-types "^15.6.1"
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
+
+react-redux@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.3.tgz#717a3d7bbe3a1b2d535c94885ce04cdc5a33fc79"
+  integrity sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-scripts@^3.3.0:
   version "3.3.0"
@@ -12799,7 +12839,7 @@ redux@^3.7.2:
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
 
-redux@^4.0.0, redux@^4.0.1:
+redux@^4.0.0, redux@^4.0.1, redux@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
   integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
@@ -15041,6 +15081,11 @@ url@0.11.0, url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
+  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This adds drag 'n drop capabilities to the dimension Chip components in
the Layout, allowing for reordering of the dimensions within an axis.
This is required for PT where the order is reflected in the generated
table.

DHIS2-7939.