### PR TITLE
fix: cli-style commit hooks

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,13 +1,10 @@
 const { config } = require('@dhis2/cli-style')
-
-const tasks = arr => arr.join(' && ')
+const husky = require(config.husky)
 
 module.exports = {
     hooks: {
-        ...config.husky.hooks,
-        'pre-commit': tasks([
-            // 'd2-style js check --staged',
-            // 'd2-style text check --staged',
-        ]),
+        ...husky.hooks,
+        'pre-commit': 'yarn validate-commit',
+        'pre-push': 'yarn validate-push',
     },
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+/node_modules/*
+/packages/app/node_modules/*
+/packages/plugin/node_modules/*
+/packages/app/build/*
+/packages/plugin/build/*
+/coverage/*

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
         "test-plugin": "cd packages/plugin && yarn test",
         "test-app": "cd packages/app && yarn test",
         "test": "yarn test-plugin && yarn test-app",
-        "coverage": "yarn test-plugin --coverage && yarn test-app --coverage"
+        "coverage": "yarn test-plugin --coverage && yarn test-app --coverage",
+        "validate-commit": "d2-style js check --staged && d2-style text check --staged",
+        "validate-push": "yarn test"
     },
     "workspaces": [
         "packages/*"


### PR DESCRIPTION
↔️ Follows the [pattern from Dashboards](https://github.com/dhis2/dashboards-app/pull/520)

🎉 Adds commit hooks using [cli-style](https://github.com/dhis2/cli-style) and Husky 💻 🚀 

🔨 Before commit, the following will be run and validated:
1. JS code using `d2-style js check --staged`
1. Text using `d2-style text check --staged`
1. Commit message

🔨 Before push, the following will be run and validated:
1. Test suite

💡  A _dry run_ of the commit validation can be run using `yarn validate-commit`.
💡  A _dry run_ of the push validation can be run using `yarn validate-push`.
