### PR TITLE
refactor: components for legendSet and legendDisplayStrategy options

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-12-10T08:39:00.095Z\n"
-"PO-Revision-Date: 2019-12-10T08:39:00.095Z\n"
+"POT-Creation-Date: 2020-01-13T08:35:33.076Z\n"
+"PO-Revision-Date: 2020-01-13T08:35:33.076Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -35,16 +35,13 @@ msgid "Update"
 msgstr ""
 
 msgid ""
-"'{{visualiationType}}' is intended to show a single data item. Only the "
+"'{{visualizationType}}' is intended to show a single data item. Only the "
 "first item will be used and saved."
 msgstr ""
 
 msgid ""
 "'{{visualiationType}}' is intended to show maximum {{maxNumber}} number of "
 "items. Only the first {{maxNumber}} items will be used and saved."
-msgstr ""
-
-msgid "Hide"
 msgstr ""
 
 msgid "Download"
@@ -92,6 +89,9 @@ msgstr ""
 msgid "The following information may be requested by technical support."
 msgstr ""
 
+msgid "Hide"
+msgstr ""
+
 msgid "Interpretations"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "Only '{{number}}' in use"
 msgstr ""
 
-msgid "Unsaved chart"
+msgid "Unsaved visualization"
 msgstr ""
 
 msgid "Edited"
@@ -296,10 +296,34 @@ msgstr ""
 msgid "Auto generated"
 msgstr ""
 
+msgid "Apply a legend to entire table"
+msgstr ""
+
+msgid "Assign a unique legend to data elements"
+msgstr ""
+
 msgid "Legend changes background color"
 msgstr ""
 
 msgid "Legend changes text color"
+msgstr ""
+
+msgid "Select a legend"
+msgstr ""
+
+msgid "Select from predefined legends"
+msgstr ""
+
+msgid "Loading legend sets"
+msgstr ""
+
+msgid "Display legend"
+msgstr ""
+
+msgid "Legend type"
+msgstr ""
+
+msgid "Legend setup"
 msgstr ""
 
 msgid ""
@@ -674,12 +698,6 @@ msgid "Display empty data"
 msgstr ""
 
 msgid "Legend"
-msgstr ""
-
-msgid "Legend type"
-msgstr ""
-
-msgid "Legend setup"
 msgstr ""
 
 msgid "Limit values"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,7 +6,7 @@
     "private": true,
     "homepage": ".",
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^3.1.0",
+        "@dhis2/cli-app-scripts": "^3.1.1",
         "cypress": "^3.6.1",
         "eslint-plugin-cypress": "^2.7.0",
         "redux-mock-store": "^1.5.3"

--- a/packages/app/src/components/VisualizationOptions/Options/LegendDisplayStrategy.js
+++ b/packages/app/src/components/VisualizationOptions/Options/LegendDisplayStrategy.js
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import i18n from '@dhis2/d2-i18n'
+
+import RadioBaseOption from './RadioBaseOption'
+
+const LegendDisplayStrategy = () => (
+    <RadioBaseOption
+        option={{
+            name: 'legendDisplayStrategy',
+            items: [
+                {
+                    id: 'FIXED',
+                    label: i18n.t('Apply a legend to entire table'),
+                },
+                {
+                    id: 'BY_DATA_ITEM',
+                    label: i18n.t('Assign a unique legend to data elements'),
+                },
+            ],
+        }}
+    />
+)
+
+export default LegendDisplayStrategy

--- a/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
@@ -24,10 +24,9 @@ import {
     tabSectionTitle,
 } from '../styles/VisualizationOptions.style.js'
 
-const LegendSelect = ({ value, options, onFocus, onChange }) => {
+const LegendSelect = ({ value, loading, options, onFocus, onChange }) => {
     const selected = value ? { value: value.id, label: value.displayName } : {}
 
-    // TODO add loading/loadingText
     return (
         <SingleSelectField
             name="legendSet-legendSelect"
@@ -35,6 +34,8 @@ const LegendSelect = ({ value, options, onFocus, onChange }) => {
             selected={selected}
             inputWidth="280px"
             placeholder={i18n.t('Select from predefined legends')}
+            loadingText={i18n.t('Loading legends')}
+            loading={loading}
             dense
             onFocus={onFocus}
             onChange={({ selected }) =>
@@ -54,6 +55,7 @@ const LegendSelect = ({ value, options, onFocus, onChange }) => {
 }
 
 LegendSelect.propTypes = {
+    loading: PropTypes.bool,
     options: PropTypes.array,
     value: PropTypes.object,
     onChange: PropTypes.func,
@@ -102,6 +104,7 @@ const LegendSetup = ({ value, onChange }) => {
 
     return (
         <LegendSelect
+            loading={!isLoaded}
             value={value}
             options={options}
             onChange={onChange}

--- a/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
@@ -1,0 +1,205 @@
+import React, { Fragment, useState } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+import i18n from '@dhis2/d2-i18n'
+import {
+    Checkbox,
+    FieldSet,
+    Legend,
+    SingleSelectField,
+    SingleSelectOption,
+} from '@dhis2/ui-core'
+import { useDataEngine } from '@dhis2/app-runtime'
+
+import LegendDisplayStyle from './LegendDisplayStyle'
+import LegendDisplayStrategy from './LegendDisplayStrategy'
+
+import { sGetUiOptions } from '../../../reducers/ui'
+import { acSetUiOptions } from '../../../actions/ui'
+
+import {
+    tabSection,
+    tabSectionOption,
+    tabSectionTitle,
+} from '../styles/VisualizationOptions.style.js'
+
+const LegendSelect = ({ value, options, onFocus, onChange }) => {
+    const selected = value ? { value: value.id, label: value.displayName } : {}
+
+    // TODO add loading/loadingText
+    return (
+        <SingleSelectField
+            name="legendSet-legendSelect"
+            label={i18n.t('Select a legend')}
+            selected={selected}
+            inputWidth="280px"
+            placeholder={i18n.t('Select from predefined legends')}
+            dense
+            onFocus={onFocus}
+            onChange={({ selected }) =>
+                onChange({
+                    legendSet: {
+                        id: selected.value,
+                        displayName: selected.label,
+                    },
+                })
+            }
+        >
+            {options.map(({ id, label }) => (
+                <SingleSelectOption key={id} value={String(id)} label={label} />
+            ))}
+        </SingleSelectField>
+    )
+}
+
+LegendSelect.propTypes = {
+    options: PropTypes.array,
+    value: PropTypes.string,
+    onChange: PropTypes.func,
+    onFocus: PropTypes.func,
+}
+
+const LegendSetup = ({ value, onChange }) => {
+    console.log('legendSetup value', value)
+    const engine = useDataEngine()
+
+    const [options, setOptions] = useState([])
+    const [isLoaded, setIsLoaded] = useState(false)
+
+    if (value) {
+        if (!options.find(option => option.id === value.id)) {
+            setOptions([...options, { id: value.id, label: value.displayName }])
+        }
+    }
+
+    const onSelectFocus = async () => {
+        console.log('select focus')
+
+        if (!isLoaded) {
+            const query = {
+                legendSets: {
+                    resource: 'legendSets.json',
+                    params: () => ({
+                        fields:
+                            'id,displayName~rename(name),legends[id,displayName~rename(name),startValue,endValue,color]',
+                        paging: false,
+                    }),
+                },
+            }
+
+            const { legendSets } = await engine.query(query)
+
+            if (legendSets) {
+                console.log('legendSets', legendSets)
+
+                const options = legendSets.legendSets.map(legendSet => ({
+                    id: legendSet.id,
+                    label: legendSet.name,
+                }))
+
+                console.log('set option', options)
+
+                setOptions(options)
+            }
+
+            setIsLoaded(true)
+        }
+    }
+
+    return (
+        <LegendSelect
+            value={value}
+            options={options}
+            onChange={onChange}
+            onFocus={onSelectFocus}
+        />
+    )
+}
+
+LegendSetup.propTypes = {
+    value: PropTypes.string,
+    onChange: PropTypes.func,
+}
+
+const LegendSet = ({ value, legendDisplayStrategy, onChange }) => {
+    const [legendSetEnabled, setLegendSetEnabled] = useState(Boolean(value))
+
+    const onCheckboxChange = ({ checked }) => {
+        setLegendSetEnabled(checked)
+
+        if (checked && !legendDisplayStrategy) {
+            onChange({
+                legendDisplayStrategy: 'FIXED',
+            })
+        } else {
+            // XXX reset
+            onChange({
+                legendSet: undefined,
+                legendDisplayStrategy: undefined,
+            })
+        }
+    }
+
+    return (
+        <Fragment>
+            <Checkbox
+                checked={legendSetEnabled}
+                label={i18n.t('Display legend')}
+                onChange={onCheckboxChange}
+                dense
+            />
+            {legendSetEnabled ? (
+                <Fragment>
+                    <div className={tabSection.className}>
+                        <FieldSet>
+                            <Legend>
+                                <span className={tabSectionTitle.className}>
+                                    {i18n.t('Legend type')}
+                                </span>
+                            </Legend>
+                            <div className={tabSectionOption.className}>
+                                <LegendDisplayStrategy />
+                            </div>
+                        </FieldSet>
+                    </div>
+                    <div className={tabSection.className}>
+                        <FieldSet>
+                            <Legend>
+                                <span className={tabSectionTitle.className}>
+                                    {i18n.t('Legend setup')}
+                                </span>
+                            </Legend>
+                            {legendDisplayStrategy === 'FIXED' ? (
+                                <div className={tabSectionOption.className}>
+                                    <LegendSetup
+                                        value={value}
+                                        onChange={onChange}
+                                    />
+                                </div>
+                            ) : null}
+                            <LegendDisplayStyle />
+                        </FieldSet>
+                    </div>
+                </Fragment>
+            ) : null}
+        </Fragment>
+    )
+}
+
+LegendSet.propTypes = {
+    value: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
+    legendDisplayStrategy: PropTypes.string,
+}
+
+const mapStateToProps = state => ({
+    value: sGetUiOptions(state).legendSet,
+    legendDisplayStrategy: sGetUiOptions(state).legendDisplayStrategy,
+})
+
+const mapDispatchToProps = dispatch => ({
+    onChange: legendSetOptions => dispatch(acSetUiOptions(legendSetOptions)),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(LegendSet)

--- a/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
@@ -55,13 +55,12 @@ const LegendSelect = ({ value, options, onFocus, onChange }) => {
 
 LegendSelect.propTypes = {
     options: PropTypes.array,
-    value: PropTypes.string,
+    value: PropTypes.object,
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
 }
 
 const LegendSetup = ({ value, onChange }) => {
-    console.log('legendSetup value', value)
     const engine = useDataEngine()
 
     const [options, setOptions] = useState([])
@@ -74,8 +73,6 @@ const LegendSetup = ({ value, onChange }) => {
     }
 
     const onSelectFocus = async () => {
-        console.log('select focus')
-
         if (!isLoaded) {
             const query = {
                 legendSets: {
@@ -91,14 +88,10 @@ const LegendSetup = ({ value, onChange }) => {
             const { legendSets } = await engine.query(query)
 
             if (legendSets) {
-                console.log('legendSets', legendSets)
-
                 const options = legendSets.legendSets.map(legendSet => ({
                     id: legendSet.id,
                     label: legendSet.name,
                 }))
-
-                console.log('set option', options)
 
                 setOptions(options)
             }
@@ -118,7 +111,7 @@ const LegendSetup = ({ value, onChange }) => {
 }
 
 LegendSetup.propTypes = {
-    value: PropTypes.string,
+    value: PropTypes.object,
     onChange: PropTypes.func,
 }
 
@@ -133,7 +126,6 @@ const LegendSet = ({ value, legendDisplayStrategy, onChange }) => {
                 legendDisplayStrategy: 'FIXED',
             })
         } else {
-            // XXX reset
             onChange({
                 legendSet: undefined,
                 legendDisplayStrategy: undefined,

--- a/packages/app/src/modules/fields/nestedFields.js
+++ b/packages/app/src/modules/fields/nestedFields.js
@@ -4,13 +4,12 @@ const ID = 'id'
 const NAME = 'name,displayName,displayShortName'
 
 const DIMENSION_ITEM = `dimensionItem~rename(${ID})`
-const LEGEND_SET = `legendSet[${ID},${NAME}]`
-const USER = `user[${NAME},userCredentials[username]]`
+const LEGEND_SET = `${ID},${NAME}`
+const USER = `${NAME},userCredentials[username]`
 
-const ITEMS = `items[${DIMENSION_ITEM},${NAME},dimensionItemType]`
-const COMMENTS = `comments[${ID},${USER},lastUpdated,text`
+const ITEMS = `${DIMENSION_ITEM},${NAME},dimensionItemType`
 
-const AXIS = `dimension,filter,${LEGEND_SET},${ITEMS}`
+const AXIS = `dimension,filter,legendSet[${LEGEND_SET}],items[${ITEMS}]`
 const INTERPRETATIONS = 'id,created'
 
 // nested fields map
@@ -19,8 +18,8 @@ export const nestedFields = {
     rows: AXIS,
     filters: AXIS,
     user: USER,
-    comments: COMMENTS,
     interpretations: INTERPRETATIONS,
+    legendSet: LEGEND_SET,
 }
 
 export const extendFields = field =>

--- a/packages/app/src/modules/options.js
+++ b/packages/app/src/modules/options.js
@@ -19,7 +19,6 @@ export const options = {
     showData: { defaultValue: true, requestable: false },
     targetLineLabel: { defaultValue: undefined, requestable: false },
     targetLineValue: { defaultValue: undefined, requestable: false },
-    // legendDisplayStrategy
     aggregationType: { defaultValue: 'DEFAULT', requestable: true },
     completedOnly: { defaultValue: false, requestable: true },
     hideSubtitle: { defaultValue: false, requestable: false },
@@ -40,6 +39,7 @@ export const options = {
     numberType: { defaultValue: 'VALUE', requestable: false },
     showHierarchy: { defaultValue: false, requestable: true },
     legendSet: { defaultValue: undefined, requestable: false },
+    legendDisplayStrategy: { defaultValue: undefined, requestable: false },
     legendDisplayStyle: { defaultValue: 'FILL', requestable: false },
     displayDensity: { defaultValue: 'NORMAL', requestable: false },
     fontSize: { defaultValue: 'NORMAL', requestable: false },

--- a/packages/app/src/modules/options/pivotTableConfig.js
+++ b/packages/app/src/modules/options/pivotTableConfig.js
@@ -12,7 +12,7 @@ import RowSubTotals from '../../components/VisualizationOptions/Options/RowSubTo
 import HideEmptyColumns from '../../components/VisualizationOptions/Options/HideEmptyColumns'
 import HideEmptyRows from '../../components/VisualizationOptions/Options/HideEmptyRows'
 import NumberType from '../../components/VisualizationOptions/Options/NumberType'
-import LegendDisplayStyle from '../../components/VisualizationOptions/Options/LegendDisplayStyle'
+import LegendSet from '../../components/VisualizationOptions/Options/LegendSet'
 import Title from '../../components/VisualizationOptions/Options/Title'
 import DisplayDensity from '../../components/VisualizationOptions/Options/DisplayDensity'
 import FontSize from '../../components/VisualizationOptions/Options/FontSize'
@@ -71,14 +71,8 @@ export default [
         label: i18n.t('Legend'),
         content: [
             {
-                key: 'legend-legend-type',
-                label: i18n.t('Legend type'),
-                content: React.Children.toArray([]),
-            },
-            {
-                key: 'legend-legend-setup',
-                label: i18n.t('Legend setup'),
-                content: React.Children.toArray([<LegendDisplayStyle />]),
+                key: 'legend-section-1',
+                content: React.Children.toArray([<LegendSet />]),
             },
         ],
     },

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "react-dom": "^16.8"
     },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^3.1.0"
+        "@dhis2/cli-app-scripts": "^3.1.1"
     },
     "scripts": {
         "clean": "rm -rf ./build/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,10 +1281,10 @@
     react-beautiful-dnd "^10.1.1"
     styled-jsx "^3.2.1"
 
-"@dhis2/app-adapter@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-3.1.0.tgz#d082a14c5c31d55e82750b09e6413cbf82a008dc"
-  integrity sha512-PB0Dg0sFvOHEI7wPAyNVq6xh4jhuNuWTcGOM4EbHmYTCBacvSR0h5zNp0kD+4x6r+4g8Dk3BhIDe7FORIipMVw==
+"@dhis2/app-adapter@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-3.1.1.tgz#8b910f30cf8f06245eeaa39390d3a4f0a143ed3b"
+  integrity sha512-LyoXlGgpG51zHyO0D3vMnGxZlV4SK3C1qN1pjFYHZBhLSwCOmE0vxF3JxO4j5Dy9IMeUIGsAStbZiIQItXF1dQ==
   dependencies:
     "@dhis2/ui-widgets" "^2.0.4"
     moment "^2.24.0"
@@ -1294,15 +1294,15 @@
   resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.0.4.tgz#9ae202fef3313094aef33a3e38d2c6c5d799c808"
   integrity sha512-w5+C/fHSsuF0am5Tpvz53+tigEZzfz9ahkjXH3BiWxGVxwZGtdHjWfso1T5bJRiKhDTgf76TxIsQiC11W20WyA==
 
-"@dhis2/app-shell@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-3.1.0.tgz#17318f7f48fd5c6bd9abd91787148f5a6802dd2f"
-  integrity sha512-EKhzMavZwFx/WFpgXNL+yYLOQU3eKVNzjZbmkFQz401kT5OeZVklt4igz/55DfKX0OhXgl72hcKKyCfZr1EUSQ==
+"@dhis2/app-shell@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-3.1.1.tgz#0a0aee79e61cd4ad4520c52c02de963a929c704c"
+  integrity sha512-S9/69mTRUNeOyQ6wy1QZ87bB4LFIi5vYDeN8zQfcnm8KU/hTIDUzUVSPyJbzYmf4E3Yz6vSaM0B1NB6PypwITw==
   dependencies:
-    "@dhis2/app-adapter" "3.1.0"
+    "@dhis2/app-adapter" "3.1.1"
     "@dhis2/app-runtime" "^2.0.4"
     "@dhis2/d2-i18n" "^1.0.5"
-    "@dhis2/ui-core" "^4.1.1"
+    "@dhis2/ui-core" "^4.6.1"
     classnames "^2.2.6"
     moment "^2.24.0"
     prop-types "^15.7.2"
@@ -1314,10 +1314,10 @@
     typeface-roboto "^0.0.75"
     typescript "^3.6.3"
 
-"@dhis2/cli-app-scripts@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-3.1.0.tgz#2bfd583a9d87c02a658485f9ed4d1cfbc69a37d3"
-  integrity sha512-NAEidyIjqIOWx1YyEa3Kp8zsumXfNafJezzo/xcb89XVsOxjLNshzSXfQoE1byH8ONOSdthpKJqwGzkZH6f+YA==
+"@dhis2/cli-app-scripts@3.1.1", "@dhis2/cli-app-scripts@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-3.1.1.tgz#9a311e67ae61dfb5320c84eaf2bdf8cf7a394285"
+  integrity sha512-Hki8K5xbWZC/Dk6+tx2K3mHmhm3k3qwjceRYGiSD6IF2alP4FD6zx3cgtt9stESOH/i4VTQaFo0NwDbbblHFjw==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.4.4"
@@ -1325,7 +1325,7 @@
     "@babel/preset-env" "^7.6.2"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "3.1.0"
+    "@dhis2/app-shell" "3.1.1"
     "@dhis2/cli-helpers-engine" "^1.5.0"
     archiver "^3.1.1"
     babel-jest "^24.9.0"
@@ -1628,7 +1628,7 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/prop-types@^1.5":
+"@dhis2/prop-types@^1.5", "@dhis2/prop-types@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.5.0.tgz#7e69919f66698be373dd21940a8a770234ded6a1"
   integrity sha512-dueFkkAMOIMbXiU7Mhr3Y+DBRyOd/rHA+5/IDiYWN1xttlUTSuGZLQ5AnJ7osBicEhx+qElaGbTdRYQj3SMBtA==
@@ -1652,6 +1652,14 @@
     "@dhis2/prop-types" "^1.4.0"
     classnames "^2.2.6"
     styled-jsx "^3.2.4"
+
+"@dhis2/ui-core@^4.6.1":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.6.1.tgz#62677590b3b32322dfa014b006e6226b637f0162"
+  integrity sha512-85ubddhmSRjDFPZqtSoTOZiPnfzHU1CyFyTXYmar/3lr8zl4mzY7aKScsEsTtJRWpN8ie86LWRqdGpbrV98VcQ==
+  dependencies:
+    "@dhis2/prop-types" "^1.5.0"
+    classnames "^2.2.6"
 
 "@dhis2/ui-widgets@^2.0.4":
   version "2.0.6"


### PR DESCRIPTION
It seems backend support for having multiple legends by data element in a visualization object is not in place.
The implementation in this PR is then the same as the current one used in PT app.
I guess we can merge this version to start with, while the backend support is added.
I'm not sure if that feature/improvement for legendSet is supposed to be in place for 2.34.

Labelling as WIP until I tested it a bit more and I figure out what's the plan for the multiple legend by data element feature/improvement.

Cfr. Joe's sketch: https://sketch.cloud/s/boZO0/a/zOyWPy/play (click Options -> Legend -> Assign a unique legend to data elements).