### PR TITLE
fix: remove api.baseUrl duplicate

### DIFF
--- a/packages/app/src/api/dataStatistics.js
+++ b/packages/app/src/api/dataStatistics.js
@@ -6,9 +6,7 @@ export const apiPostDataStatistics = async id => {
     const d2 = await getInstance();
     const api = d2.Api.getApi();
 
-    const url = `${
-        api.baseUrl
-    }/dataStatistics?eventType=${EVENT_TYPE_CHART_VIEW}&favorite=${id}`;
+    const url = `/dataStatistics?eventType=${EVENT_TYPE_CHART_VIEW}&favorite=${id}`;
 
     return api.post(url);
 };


### PR DESCRIPTION
It worked on localhost, but not in production. Removing the base url.