### PR TITLE
fix: properly set layout on vis type change for all vis types

### DIFF
--- a/packages/app/src/modules/__tests__/layoutAdapters.spec.js
+++ b/packages/app/src/modules/__tests__/layoutAdapters.spec.js
@@ -7,10 +7,34 @@ import {
     DIMENSION_ID_ORGUNIT,
 } from '@dhis2/analytics'
 
-import { pieLayoutAdapter, yearOverYearLayoutAdapter } from '../layoutAdapters'
+import {
+    defaultLayoutAdapter,
+    pieLayoutAdapter,
+    yearOverYearLayoutAdapter,
+} from '../layoutAdapters'
 
 const someId = 'someId'
 const otherId = 'otherId'
+
+describe('defaultLayoutAdapter', () => {
+    it('should move all extra dimensions in columns and rows to filters', () => {
+        const initialState = {
+            [AXIS_ID_COLUMNS]: [DIMENSION_ID_DATA, someId],
+            [AXIS_ID_ROWS]: [DIMENSION_ID_PERIOD, otherId],
+            [AXIS_ID_FILTERS]: [DIMENSION_ID_ORGUNIT],
+        }
+
+        const actualState = defaultLayoutAdapter(initialState)
+
+        const expectedState = {
+            [AXIS_ID_COLUMNS]: [DIMENSION_ID_DATA],
+            [AXIS_ID_ROWS]: [DIMENSION_ID_PERIOD],
+            [AXIS_ID_FILTERS]: [DIMENSION_ID_ORGUNIT, someId, otherId],
+        }
+
+        expect(actualState).toEqual(expectedState)
+    })
+})
 
 describe('pieLayoutAdapter', () => {
     it('should move all column and row dimensions to filter except the first column dimension', () => {

--- a/packages/app/src/modules/layoutAdapters.js
+++ b/packages/app/src/modules/layoutAdapters.js
@@ -6,6 +6,18 @@ import {
     DIMENSION_ID_PERIOD,
 } from '@dhis2/analytics'
 
+// Transform from ui.layout to default layout format
+export const defaultLayoutAdapter = layout => {
+    const columns = layout[AXIS_ID_COLUMNS].slice()
+    const rows = layout[AXIS_ID_ROWS].slice()
+
+    return {
+        [AXIS_ID_COLUMNS]: [columns.shift()],
+        [AXIS_ID_ROWS]: [rows.shift()],
+        [AXIS_ID_FILTERS]: [...layout[AXIS_ID_FILTERS], ...columns, ...rows],
+    }
+}
+
 // Transform from ui.layout to pie layout format
 export const pieLayoutAdapter = layout => {
     const columns = layout[AXIS_ID_COLUMNS].slice()

--- a/packages/app/src/modules/ui.js
+++ b/packages/app/src/modules/ui.js
@@ -16,6 +16,7 @@ import { getInverseLayout } from './layout'
 import { getOptionsFromVisualization } from './options'
 import { BASE_FIELD_YEARLY_SERIES } from './fields/baseFields'
 import {
+    defaultLayoutAdapter,
     pieLayoutAdapter,
     yearOverYearLayoutAdapter,
     singleValueLayoutAdapter,
@@ -42,6 +43,12 @@ export const getUiFromVisualization = (vis, currentState = {}) => ({
         ? vis.rows[0].items.map(item => item.id)
         : currentState.yearOverYearCategory,
     axes: getIdAxisMap(vis.optionalAxes),
+})
+
+// Transform from store.ui to default format
+export const defaultUiAdapter = ui => ({
+    ...ui,
+    layout: defaultLayoutAdapter(ui.layout),
 })
 
 // Transform from store.ui to pie format
@@ -83,7 +90,7 @@ export const getAdaptedUiByType = ui => {
             return singleValueUiAdapter(ui)
         }
         default:
-            return ui
+            return defaultUiAdapter(ui)
     }
 }
 


### PR DESCRIPTION
The adapted layout should be used always when changing vis type, also
for the "default" vis types.