### PR TITLE
fix: correctly set showDimensionLabels option

### DIFF
--- a/packages/app/src/components/VisualizationOptions/Options/ShowDimensionLabels.js
+++ b/packages/app/src/components/VisualizationOptions/Options/ShowDimensionLabels.js
@@ -8,7 +8,7 @@ const ShowDimensionLabels = () => (
     <CheckboxBaseOption
         label={i18n.t('Dimension labels')}
         option={{
-            name: 'showDimensionTotals',
+            name: 'showDimensionLabels',
         }}
     />
 )


### PR DESCRIPTION
This was probably a typo - the correct option is `showDimensionLabels`