### PR TITLE
fix: open modal for empty dims 

### DIFF
--- a/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
@@ -105,7 +105,7 @@ const mapDispatchToProps = dispatch => ({
     axisItemHandler: (dimensionId, axisId, numberOfDimensionItems) => {
         dispatch(acAddUiLayoutDimensions({ [dimensionId]: { axisId } }))
 
-        if (numberOfDimensionItems > 0) {
+        if (numberOfDimensionItems === 0) {
             dispatch(acSetUiActiveModalDialog(dimensionId))
         }
     },


### PR DESCRIPTION
When adding a dimension through the dimension panel context menu, the dimension modal should open if the dimension doesn't have any items selected. Previously, probably because of a typo, the modal would _only_ open for dimensions _with_ items 🤷‍♂ This has now been fixed. 