### PR TITLE
fix: prevent undefined in adapter

### DIFF
--- a/packages/app/src/modules/layoutAdapters.js
+++ b/packages/app/src/modules/layoutAdapters.js
@@ -12,8 +12,8 @@ export const defaultLayoutAdapter = layout => {
     const rows = layout[AXIS_ID_ROWS].slice()
 
     return {
-        [AXIS_ID_COLUMNS]: [columns.shift()],
-        [AXIS_ID_ROWS]: [rows.shift()],
+        [AXIS_ID_COLUMNS]: columns.length ? [columns.shift()] : [],
+        [AXIS_ID_ROWS]: rows.length ? [rows.shift()] : [],
         [AXIS_ID_FILTERS]: [...layout[AXIS_ID_FILTERS], ...columns, ...rows],
     }
 }
@@ -22,9 +22,11 @@ export const defaultLayoutAdapter = layout => {
 export const pieLayoutAdapter = layout => {
     const columns = layout[AXIS_ID_COLUMNS].slice()
     const rows = layout[AXIS_ID_ROWS].slice()
-
     return {
-        [AXIS_ID_COLUMNS]: [columns.shift() || rows.shift()],
+        [AXIS_ID_COLUMNS]:
+            columns.length || rows.length
+                ? [columns.shift() || rows.shift()]
+                : [],
         [AXIS_ID_ROWS]: [],
         [AXIS_ID_FILTERS]: [...layout[AXIS_ID_FILTERS], ...columns, ...rows],
     }


### PR DESCRIPTION
This fix prevents the ghost dimensions (screenshots) that were caused by the new layout adapters recently (https://github.com/dhis2/data-visualizer-app/pull/586/files). 

![ghost dimensions](https://user-images.githubusercontent.com/12590483/74031166-16df6680-49b1-11ea-9985-a94cf8c9ad52.png)
