### PR TITLE
fix: chart plugin infinite loading when no change has been made

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -31,21 +31,15 @@ class ChartPlugin extends Component {
     componentDidUpdate(prevProps) {
         if (!isEqual(this.props.config, prevProps.config)) {
             this.renderChart()
-            return
-        }
-
-        if (!isEqual(this.props.filters, prevProps.filters)) {
+        } else if (!isEqual(this.props.filters, prevProps.filters)) {
             this.renderChart()
-            return
-        }
-
-        // id set by DV app, style works in dashboards
-        if (
+        } else if (
             this.props.id !== prevProps.id ||
             !isEqual(this.props.style, prevProps.style)
         ) {
             this.recreateVisualization(0) // disable animation
-            return
+        } else {
+            this.props.onLoadingComplete()
         }
     }
 


### PR DESCRIPTION
There's currently a bug with the chart plugin, where it's spinning indefinitely if no change has been made and the Update button is clicked.