### PR TITLE
chore(github-actions): add workflows for lint and publish

### DIFF
--- a/.github/workflows/node-lint.yml
+++ b/.github/workflows/node-lint.yml
@@ -1,0 +1,26 @@
+name: 'DHIS2: Style'
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+
+jobs:
+    pr:
+        name: Lint
+        runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+
+            - name: Install
+              run: yarn install --frozen-lockfile
+
+            - name: Run linters
+              run: yarn lint
+        env:
+            CI: true

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -1,0 +1,41 @@
+name: 'DHIS2: Release'
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    process:
+        name: Publish
+        runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+
+            - name: Install
+              run: yarn install --frozen-lockfile
+
+            - name: Lint
+              run: yarn lint
+
+            - name: Test
+              run: yarn test
+
+            - name: Build
+              run: yarn build
+
+            - name: Publish to NPM
+              run: npx @dhis2/cli-utils release --publish npm
+              env:
+                  GIT_AUTHOR_NAME: '@dhis2-bot'
+                  GIT_AUTHOR_EMAIL: 'apps@dhis2.org'
+                  GIT_COMMITTER_NAME: '@dhis2-bot'
+                  GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
+                  NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+                  GH_TOKEN: ${{secrets.GH_TOKEN}}
+        env:
+            CI: true

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,0 +1,26 @@
+name: 'DHIS2: Tests'
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+
+jobs:
+    pr:
+        name: Unit
+        runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+
+            - name: Install
+              run: yarn install --frozen-lockfile
+
+            - name: Test
+              run: yarn test
+        env:
+            CI: true

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-visualizer-app",
-    "version": "32.0.2",
+    "version": "34.0.0",
     "description": "DHIS2 Data Visualizer app",
     "license": "BSD-3-Clause",
     "private": true,

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -6,6 +6,9 @@
     "module": "./build/es/lib.js",
     "license": "BSD-3-Clause",
     "private": false,
+    "publishConfig": {
+        "access": "public"
+    },
     "dependencies": {
         "@dhis2/analytics": "^3.1.3",
         "@material-ui/core": "^3.1.2",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,10 +1,11 @@
 {
     "name": "@dhis2/data-visualizer-plugin",
-    "version": "33.1.6",
+    "version": "34.0.0",
     "description": "DHIS2 Data Visualizer plugin",
     "main": "./build/cjs/lib.js",
     "module": "./build/es/lib.js",
     "license": "BSD-3-Clause",
+    "private": false,
     "dependencies": {
         "@dhis2/analytics": "^3.1.3",
         "@material-ui/core": "^3.1.2",


### PR DESCRIPTION
We will use Travis for running the deploy-build script to d2-ci ([more information on why](https://developers.dhis2.org/2019/02/the-build-system/#d2-ci-organisation)) and our more _modern_ tooling for NPM until we've ported the deploy-build script.