### PR TITLE
refactor: rename visConfig and config

### DIFF
--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -100,10 +100,10 @@ export class Visualization extends Component {
     }
 
     render() {
-        const { visConfig, visFilters, error } = this.props
+        const { visualization, visFilters, error } = this.props
         const { renderId } = this.state
 
-        return !visConfig || error ? (
+        return !visualization || error ? (
             <StartScreen />
         ) : (
             <Fragment>
@@ -115,7 +115,7 @@ export class Visualization extends Component {
                 <VisualizationPlugin
                     id={renderId}
                     d2={this.context.d2}
-                    config={visConfig}
+                    visualization={visualization}
                     filters={visFilters}
                     onChartGenerated={this.onChartGenerated}
                     onLoadingComplete={this.props.onLoadingComplete}
@@ -139,12 +139,12 @@ Visualization.propTypes = {
     rightSidebarOpen: PropTypes.bool,
     setChart: PropTypes.func,
     setLoadError: PropTypes.func,
-    visConfig: PropTypes.object,
     visFilters: PropTypes.object,
+    visualization: PropTypes.object,
     onLoadingComplete: PropTypes.func,
 }
 
-export const visConfigSelector = createSelector(
+export const visualizationSelector = createSelector(
     [sGetCurrent, sGetVisualization, sGetUiInterpretation],
     (current, visualization, interpretation) =>
         interpretation.id ? visualization : current
@@ -159,7 +159,7 @@ export const visFiltersSelector = createSelector(
 )
 
 const mapStateToProps = state => ({
-    visConfig: visConfigSelector(state),
+    visualization: visualizationSelector(state),
     visFilters: visFiltersSelector(state),
     rightSidebarOpen: sGetUiRightSidebarOpen(state),
     error: sGetLoadError(state),

--- a/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
+++ b/packages/app/src/components/Visualization/__tests__/Visualization.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import VisualizationPlugin from '@dhis2/data-visualizer-plugin'
 import {
     Visualization,
-    visConfigSelector,
+    visualizationSelector,
     visFiltersSelector,
 } from '../Visualization'
 import StartScreen from '../StartScreen'
@@ -25,7 +25,7 @@ describe('Visualization', () => {
 
         beforeEach(() => {
             props = {
-                visConfig: {},
+                visualization: {},
                 visFilters: null,
                 error: null,
                 rightSidebarOpen: false,
@@ -63,7 +63,7 @@ describe('Visualization', () => {
             ).toBeFalsy()
         })
 
-        it('renders a VisualizationPlugin when no error and visConfig available', () => {
+        it('renders a VisualizationPlugin when no error and visualization available', () => {
             expect(vis().find(VisualizationPlugin).length).toEqual(1)
         })
 
@@ -113,18 +113,18 @@ describe('Visualization', () => {
             },
         }
 
-        describe('visConfigSelector', () => {
+        describe('visualizationSelector', () => {
             it('equals the visualization if interpretation selected', () => {
                 const newState = Object.assign({}, state, {
                     ui: { interpretation: { id: 'rainbow dash' } },
                 })
 
-                const selector = visConfigSelector(newState)
+                const selector = visualizationSelector(newState)
                 expect(selector).toEqual('vis')
             })
 
             it('equals the current if no interpretation selected', () => {
-                const selector = visConfigSelector(state)
+                const selector = visualizationSelector(state)
                 expect(selector).toEqual('current')
             })
         })

--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -29,7 +29,7 @@ class ChartPlugin extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (!isEqual(this.props.config, prevProps.config)) {
+        if (!isEqual(this.props.visualization, prevProps.visualization)) {
             this.renderChart()
             return
         }
@@ -85,7 +85,7 @@ class ChartPlugin extends Component {
 
     renderChart = async () => {
         const {
-            config: visualization,
+            visualization,
             filters,
             forDashboard,
             onResponsesReceived,
@@ -170,7 +170,7 @@ class ChartPlugin extends Component {
 }
 
 ChartPlugin.defaultProps = {
-    config: {},
+    visualization: {},
     filters: {},
     forDashboard: false,
     style: {},
@@ -182,8 +182,8 @@ ChartPlugin.defaultProps = {
 }
 
 ChartPlugin.propTypes = {
-    config: PropTypes.object.isRequired,
     d2: PropTypes.object.isRequired,
+    visualization: PropTypes.object.isRequired,
     onError: PropTypes.func.isRequired,
     animation: PropTypes.number,
     filters: PropTypes.object,

--- a/packages/plugin/src/PivotPlugin.js
+++ b/packages/plugin/src/PivotPlugin.js
@@ -37,7 +37,7 @@ const getRequestOptions = (visualization, filters) => {
 }
 
 const PivotPlugin = ({
-    config,
+    visualization,
     filters,
     style,
     onError,
@@ -48,8 +48,8 @@ const PivotPlugin = ({
     const [data, setData] = useState(null)
 
     useEffect(() => {
-        const options = getRequestOptions(config, filters)
-        apiFetchAnalytics(d2, config, options)
+        const options = getRequestOptions(visualization, filters)
+        apiFetchAnalytics(d2, visualization, options)
             .then(responses => {
                 if (!responses.length) {
                     return
@@ -65,17 +65,26 @@ const PivotPlugin = ({
             })
 
         // TODO: cancellation
-    }, [config, filters, onResponsesReceived, onError, d2, onLoadingComplete])
+    }, [
+        visualization,
+        filters,
+        onResponsesReceived,
+        onError,
+        d2,
+        onLoadingComplete,
+    ])
 
     return (
         <div style={{ width: '100%', height: '100%', ...style }}>
-            {!data ? null : <PivotTable visualization={config} data={data} />}
+            {!data ? null : (
+                <PivotTable visualization={visualization} data={data} />
+            )}
         </div>
     )
 }
 
 PivotPlugin.defaultProps = {
-    config: {},
+    visualization: {},
     filters: {},
     style: {},
     onError: Function.prototype,
@@ -84,8 +93,8 @@ PivotPlugin.defaultProps = {
 }
 
 PivotPlugin.propTypes = {
-    config: PropTypes.object.isRequired,
     d2: PropTypes.object.isRequired,
+    visualization: PropTypes.object.isRequired,
     onError: PropTypes.func.isRequired,
     filters: PropTypes.object,
     style: PropTypes.object,

--- a/packages/plugin/src/__tests__/ChartPlugin.spec.js
+++ b/packages/plugin/src/__tests__/ChartPlugin.spec.js
@@ -118,7 +118,7 @@ describe('ChartPlugin', () => {
 
     beforeEach(() => {
         props = {
-            config: {},
+            visualization: {},
             filters: {},
             style: { height: 100 },
             id: 1,
@@ -166,7 +166,7 @@ describe('ChartPlugin', () => {
         })
 
         it('includes only options that do not have default value in request', done => {
-            props.config = {
+            props.visualization = {
                 ...defaultCurrentMock,
                 option1: 'def',
                 option2: null,
@@ -238,7 +238,7 @@ describe('ChartPlugin', () => {
 
         describe('Year-on-year chart', () => {
             beforeEach(() => {
-                props.config = {
+                props.visualization = {
                     ...yearOverYearCurrentMock,
                     option1: 'def',
                 }
@@ -250,7 +250,7 @@ describe('ChartPlugin', () => {
                 analytics.isYearOverYear = jest
                     .fn()
                     .mockReturnValue(
-                        isYearOverYearMockResponse(props.config.type)
+                        isYearOverYearMockResponse(props.visualization.type)
                     )
             })
 
@@ -299,14 +299,14 @@ describe('ChartPlugin', () => {
 
         describe('Single value visualization', () => {
             beforeEach(() => {
-                props.config = {
+                props.visualization = {
                     ...singleValueCurrentMock,
                 }
 
                 analytics.isSingleValue = jest
                     .fn()
                     .mockReturnValue(
-                        isSingleValueMockResponse(props.config.type)
+                        isSingleValueMockResponse(props.visualization.type)
                     )
             })
 

--- a/packages/plugin/src/index.js
+++ b/packages/plugin/src/index.js
@@ -5,7 +5,10 @@ import ChartPlugin from './ChartPlugin'
 import PivotPlugin from './PivotPlugin'
 
 const VisualizationPlugin = props => {
-    if (!props.config.type || props.config.type === VIS_TYPE_PIVOT_TABLE) {
+    if (
+        !props.visualization.type ||
+        props.visualization.type === VIS_TYPE_PIVOT_TABLE
+    ) {
         return <PivotPlugin {...props} />
     } else {
         return <ChartPlugin {...props} />


### PR DESCRIPTION
Currently there's a prop on `Visualization.js` called `visConfig`, which is passed to the plugins as `config`. This name is a legacy from https://github.com/dhis2/data-visualizer-app/commit/af1d0124b0338f0114b9a59fbbc2e500175ba227#diff-e4a1f1987c1f3a83a3ed17722cecb3a4 but has later evolved to contain either `state.visualization` or `state.current`. This PR renames the prop to a more understandable name (currently `visualization`, but that's open for suggestions).