### PR TITLE
chore: fix GitHub Actions test workflow

### DIFF
--- a/.github/workflows/node-lint.yml
+++ b/.github/workflows/node-lint.yml
@@ -1,9 +1,6 @@
 name: 'DHIS2: Style'
 
 on:
-    push:
-        branches:
-            - master
     pull_request:
 
 jobs:

--- a/.github/workflows/node-lint.yml
+++ b/.github/workflows/node-lint.yml
@@ -1,7 +1,6 @@
 name: 'DHIS2: Style'
 
-on:
-    pull_request:
+on: pull_request
 
 jobs:
     pr:

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -22,11 +22,11 @@ jobs:
             - name: Lint
               run: yarn lint
 
-            - name: Test
-              run: yarn test
-
             - name: Build
               run: yarn build
+
+            - name: Test
+              run: yarn test
 
             - name: Publish to NPM
               run: npx @dhis2/cli-utils release --publish npm

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,7 +1,6 @@
 name: 'DHIS2: Tests'
 
-on:
-    pull_request:
+on: pull_request
 
 jobs:
     pr:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,9 +1,6 @@
 name: 'DHIS2: Tests'
 
 on:
-    push:
-        branches:
-            - master
     pull_request:
 
 jobs:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -20,6 +20,9 @@ jobs:
             - name: Install
               run: yarn install --frozen-lockfile
 
+            - name: Build
+              run: yarn build
+
             - name: Test
               run: yarn test
         env:

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,0 @@
-{
-    "lerna": "3.1.4",
-    "version": "independent",
-    "npmClient": "yarn",
-    "useWorkspaces": true
-}


### PR DESCRIPTION
We need to build the plugin before testing, otherwise the plugin's entrypoint (`build/es/lib.js`) doesn't exist and can't be resolved through the workspaces link.

This also removes the extraneous `lerna.json`