### PR TITLE
fix: correctly specify runtime and peer dependencies

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -30,9 +30,7 @@
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.2.0",
         "reselect": "^4.0.0",
-        "whatwg-fetch": "^3.0.0"
-    },
-    "peerDependencies": {
+        "whatwg-fetch": "^3.0.0",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/ui-core": "*",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -13,7 +13,9 @@
         "@dhis2/analytics": "^3.2.0",
         "@material-ui/core": "^3.1.2",
         "d2-analysis": "33.2.11",
-        "lodash-es": "^4.17.11",
+        "lodash-es": "^4.17.11"
+    },
+    "peerDependencies": {
         "react": "^16.8",
         "react-dom": "^16.8"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,7 +1456,7 @@
     "@dhis2/ui-widgets" "^2.0.4"
     moment "^2.24.0"
 
-"@dhis2/app-runtime@^2.0.4":
+"@dhis2/app-runtime@*", "@dhis2/app-runtime@^2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.0.4.tgz#9ae202fef3313094aef33a3e38d2c6c5d799c808"
   integrity sha512-w5+C/fHSsuF0am5Tpvz53+tigEZzfz9ahkjXH3BiWxGVxwZGtdHjWfso1T5bJRiKhDTgf76TxIsQiC11W20WyA==
@@ -1577,18 +1577,18 @@
     moment "^2.22.1"
     rimraf "^2.6.2"
 
-"@dhis2/d2-i18n@^1.0.3", "@dhis2/d2-i18n@^1.0.4":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.5.tgz#9148af1bc95e9442bcae66136b8f80146406a43f"
-  integrity sha512-nz1JtDLNn6hOoSg84C1iYRBr11O/ljMdczEqq0/j/gQy9wRs80Z7lExwItclHgS7t6ESWCa6+OFkwgRCOKF2ew==
+"@dhis2/d2-i18n@*", "@dhis2/d2-i18n@^1.0.5", "@dhis2/d2-i18n@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.6.tgz#2914be8acf296f3a6bf7b51c76c46da6a120b0ff"
+  integrity sha512-7YdA4ppFosjuyf7ZMm47BrdsA5TWLM9lmS0lUPgjcCVeeWfUgagqzf4W5JGB9XQ3w1vzK+yy5zH2Ij8IgRAGhA==
   dependencies:
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/d2-i18n@^1.0.5", "@dhis2/d2-i18n@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.6.tgz#2914be8acf296f3a6bf7b51c76c46da6a120b0ff"
-  integrity sha512-7YdA4ppFosjuyf7ZMm47BrdsA5TWLM9lmS0lUPgjcCVeeWfUgagqzf4W5JGB9XQ3w1vzK+yy5zH2Ij8IgRAGhA==
+"@dhis2/d2-i18n@^1.0.3", "@dhis2/d2-i18n@^1.0.4":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.5.tgz#9148af1bc95e9442bcae66136b8f80146406a43f"
+  integrity sha512-nz1JtDLNn6hOoSg84C1iYRBr11O/ljMdczEqq0/j/gQy9wRs80Z7lExwItclHgS7t6ESWCa6+OFkwgRCOKF2ew==
   dependencies:
     i18next "^10.3"
     moment "^2.24.0"
@@ -1758,7 +1758,7 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-core@^4.1.1":
+"@dhis2/ui-core@*", "@dhis2/ui-core@^4.1.1":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.9.0.tgz#d2af15cee87a7873741e8698ac2923c423f671c1"
   integrity sha512-9Cf7Tv4JQ+2TX9CCoy3xGMn0P5FWvA1KNx9qzWFccHorEwlvbDYUbeAJaZ2LMnHUBeS5llmBbDByYzAH4K5SmA==


### PR DESCRIPTION
This moves plugin `react` and `react-dom` deps to Peer, and moves app deps from `peer` to `runtime` (technically they could be omitted, but we're going for explicit here).  While it shouldn't technically be required to specify `react` as a peer dep in the plugin (`yarn` should de-duplicate if the major version matches) it makes sense to ensure that there can only be one copy.  This will also cut version 34.0.0.

BREAKING CHANGE: The Data Visualizer Plugin now requires `react` and `react-dom` to be provided by the consumer.