### PR TITLE
fix: fix default state for LegendSet option

### DIFF
--- a/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
@@ -18,11 +18,27 @@ import LegendDisplayStrategy from './LegendDisplayStrategy'
 import { sGetUiOptions } from '../../../reducers/ui'
 import { acSetUiOptions } from '../../../actions/ui'
 
+import { options } from '../../../modules/options'
+
 import {
     tabSection,
     tabSectionOption,
     tabSectionTitle,
 } from '../styles/VisualizationOptions.style.js'
+
+const optionName = 'legendSet'
+const defaultValue = options[optionName].defaultValue
+
+const query = {
+    legendSets: {
+        resource: 'legendSets.json',
+        params: {
+            fields:
+                'id,displayName~rename(name),legends[id,displayName~rename(name),startValue,endValue,color]',
+            paging: false,
+        },
+    },
+}
 
 const LegendSelect = ({ value, loading, options, onFocus, onChange }) => {
     const selected =
@@ -41,10 +57,8 @@ const LegendSelect = ({ value, loading, options, onFocus, onChange }) => {
             onFocus={onFocus}
             onChange={({ selected }) =>
                 onChange({
-                    legendSet: {
-                        id: selected.value,
-                        displayName: selected.label,
-                    },
+                    id: selected.value,
+                    displayName: selected.label,
                 })
             }
         >
@@ -80,17 +94,6 @@ const LegendSetup = ({ value, onChange }) => {
 
     const onSelectFocus = async () => {
         if (!isLoaded) {
-            const query = {
-                legendSets: {
-                    resource: 'legendSets.json',
-                    params: () => ({
-                        fields:
-                            'id,displayName~rename(name),legends[id,displayName~rename(name),startValue,endValue,color]',
-                        paging: false,
-                    }),
-                },
-            }
-
             const { legendSets } = await engine.query(query)
 
             if (legendSets) {
@@ -128,15 +131,8 @@ const LegendSet = ({ value, legendDisplayStrategy, onChange }) => {
     const onCheckboxChange = ({ checked }) => {
         setLegendSetEnabled(checked)
 
-        if (checked && !legendDisplayStrategy) {
-            onChange({
-                legendDisplayStrategy: 'FIXED',
-            })
-        } else {
-            onChange({
-                legendSet: undefined,
-                legendDisplayStrategy: undefined,
-            })
+        if (!checked) {
+            onChange(defaultValue)
         }
     }
 
@@ -193,12 +189,13 @@ LegendSet.propTypes = {
 }
 
 const mapStateToProps = state => ({
-    value: sGetUiOptions(state).legendSet || {},
+    value: sGetUiOptions(state)[optionName] || {},
     legendDisplayStrategy: sGetUiOptions(state).legendDisplayStrategy,
 })
 
 const mapDispatchToProps = dispatch => ({
-    onChange: legendSetOptions => dispatch(acSetUiOptions(legendSetOptions)),
+    onChange: ({ id, displayName }) =>
+        dispatch(acSetUiOptions({ [optionName]: { id, displayName } })),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(LegendSet)

--- a/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
@@ -26,15 +26,18 @@ import {
     tabSectionTitle,
 } from '../styles/VisualizationOptions.style.js'
 
-const optionName = 'legendSet'
-const defaultValue = options[optionName].defaultValue
+const LEGEND_SET_OPTION_NAME = 'legendSet'
+const defaultValue = options[LEGEND_SET_OPTION_NAME].defaultValue
 
 const query = {
     legendSets: {
-        resource: 'legendSets.json',
+        resource: 'legendSets',
         params: {
-            fields:
-                'id,displayName~rename(name),legends[id,displayName~rename(name),startValue,endValue,color]',
+            fields: [
+                'id',
+                'displayName~rename(name)',
+                'legends[id,displayName~rename(name),startValue,endValue,color]',
+            ],
             paging: false,
         },
     },
@@ -189,13 +192,15 @@ LegendSet.propTypes = {
 }
 
 const mapStateToProps = state => ({
-    value: sGetUiOptions(state)[optionName] || {},
+    value: sGetUiOptions(state)[LEGEND_SET_OPTION_NAME] || {},
     legendDisplayStrategy: sGetUiOptions(state).legendDisplayStrategy,
 })
 
 const mapDispatchToProps = dispatch => ({
     onChange: ({ id, displayName }) =>
-        dispatch(acSetUiOptions({ [optionName]: { id, displayName } })),
+        dispatch(
+            acSetUiOptions({ [LEGEND_SET_OPTION_NAME]: { id, displayName } })
+        ),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(LegendSet)

--- a/packages/app/src/modules/options.js
+++ b/packages/app/src/modules/options.js
@@ -39,7 +39,7 @@ export const options = {
     numberType: { defaultValue: 'VALUE', requestable: false },
     showHierarchy: { defaultValue: false, requestable: true },
     legendSet: { defaultValue: undefined, requestable: false },
-    legendDisplayStrategy: { defaultValue: undefined, requestable: false },
+    legendDisplayStrategy: { defaultValue: 'FIXED', requestable: false },
     legendDisplayStyle: { defaultValue: 'FILL', requestable: false },
     displayDensity: { defaultValue: 'NORMAL', requestable: false },
     fontSize: { defaultValue: 'NORMAL', requestable: false },


### PR DESCRIPTION
The selection for Legend type was lost when switching between tabs,
causing the app to crash.
The reason was that the radio group had no default value (which does not make sense for a radio group).
`FIXED` should be the default value for `legendDisplayStrategy`, which enables the dropdown for the selection of the legendSet.

Use a constant for the option name and get the default value from the
options list.
Moved also the query to the top.