### PR TITLE
fix: YoY displays "no data" when some years actually have data (but some don't)

### DIFF
--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -61,11 +61,12 @@ export class Visualization extends Component {
 
     onResponsesReceived = responses => {
         const forMetadata = {}
-
+        if (
+            !responses.some(response => response.rows && response.rows.length)
+        ) {
+            throw new EmptyResponseError()
+        }
         responses.forEach(response => {
-            if (!response.rows || !response.rows.length) {
-                throw new EmptyResponseError()
-            }
             Object.entries(response.metaData.items).forEach(([id, item]) => {
                 forMetadata[id] = {
                     id,


### PR DESCRIPTION
There's a bug which causes YearOverYear vis types to incorrectly display "no data" when one year is missing data but other years have data that can still be shown.

The bug was introduced in https://github.com/dhis2/data-visualizer-app/pull/552 by https://github.com/dhis2/data-visualizer-app/blob/14644ad38fdd50c533bda2c512db289d28b08d3e/packages/app/src/components/Visualization/Visualization.js#L66

**Previously**: "This year" has data but "2011" doesn't, incorrectly displays "No data" for the whole visualisation
![image](https://user-images.githubusercontent.com/12590483/74910800-a1fe2a80-53bb-11ea-985e-aecf43788da1.png)

**Fix**: "This year" has data but "2011" doesn't, correctly displays the data for "This year" and disregards the missing data for "2011" 
![image](https://user-images.githubusercontent.com/12590483/74910953-ec7fa700-53bb-11ea-8572-64b03127ed4c.png)
