### PR TITLE
fix: legends for gauge

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-02-18T14:35:56.019Z\n"
-"PO-Revision-Date: 2020-02-18T14:35:56.019Z\n"
+"POT-Creation-Date: 2020-02-21T11:16:30.247Z\n"
+"PO-Revision-Date: 2020-02-21T11:16:30.247Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -334,10 +334,19 @@ msgstr ""
 msgid "Chart title"
 msgstr ""
 
-msgid "Apply a legend to entire table"
+msgid "Display legend"
 msgstr ""
 
-msgid "Assign a unique legend to data elements"
+msgid "Legend style"
+msgstr ""
+
+msgid "Legend type"
+msgstr ""
+
+msgid "Use pre-defined legends set per data item"
+msgstr ""
+
+msgid "Select a single legend for entire table"
 msgstr ""
 
 msgid "Legend changes background color"
@@ -346,22 +355,13 @@ msgstr ""
 msgid "Legend changes text color"
 msgstr ""
 
-msgid "Select a legend"
+msgid "Legend"
 msgstr ""
 
-msgid "Select from predefined legends"
+msgid "Select from legends"
 msgstr ""
 
 msgid "Loading legends"
-msgstr ""
-
-msgid "Display legend"
-msgstr ""
-
-msgid "Legend type"
-msgstr ""
-
-msgid "Legend setup"
 msgstr ""
 
 msgid ""
@@ -689,9 +689,6 @@ msgid "Display totals"
 msgstr ""
 
 msgid "Display empty data"
-msgstr ""
-
-msgid "Legend"
 msgstr ""
 
 msgid "Labels"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.1.0",
+        "@dhis2/analytics": "^4.1.1",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^6.5.5",

--- a/packages/app/src/modules/options/gaugeConfig.js
+++ b/packages/app/src/modules/options/gaugeConfig.js
@@ -8,7 +8,7 @@ import AggregationType from '../../components/VisualizationOptions/Options/Aggre
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import AxisRange from '../../components/VisualizationOptions/Options/AxisRange'
-import LegendSet from '../../components/VisualizationOptions/Options/LegendSet'
+import Legend from '../../components/VisualizationOptions/Options/Legend'
 
 export default [
     {
@@ -33,7 +33,7 @@ export default [
         content: [
             {
                 key: 'legend-section-1',
-                content: React.Children.toArray([<LegendSet />]),
+                content: React.Children.toArray([<Legend />]),
             },
         ],
     },

--- a/packages/app/src/modules/options/gaugeConfig.js
+++ b/packages/app/src/modules/options/gaugeConfig.js
@@ -8,6 +8,7 @@ import AggregationType from '../../components/VisualizationOptions/Options/Aggre
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import AxisRange from '../../components/VisualizationOptions/Options/AxisRange'
+import LegendSet from '../../components/VisualizationOptions/Options/LegendSet'
 
 export default [
     {
@@ -23,6 +24,16 @@ export default [
                 key: 'data-advanced',
                 label: i18n.t('Advanced'),
                 content: React.Children.toArray([<AggregationType />]),
+            },
+        ],
+    },
+    {
+        key: 'legend-tab',
+        label: i18n.t('Legend'),
+        content: [
+            {
+                key: 'legend-section-1',
+                content: React.Children.toArray([<LegendSet />]),
             },
         ],
     },

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.1.0",
+        "@dhis2/analytics": "^4.1.1",
         "@material-ui/core": "^3.1.2",
         "d2-analysis": "33.2.11",
         "lodash-es": "^4.17.11"

--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -6,7 +6,7 @@ const ChartPlugin = ({
     visualization,
     responses,
     extraOptions,
-    // legendSets,
+    legendSets,
     id: renderCounter,
     style,
     onChartGenerated,
@@ -23,6 +23,7 @@ const ChartPlugin = ({
                 {
                     ...extraOptions,
                     animation,
+                    legendSets,
                 },
                 undefined,
                 undefined,
@@ -40,7 +41,14 @@ const ChartPlugin = ({
                 )
             }
         },
-        [canvasRef, visualization, onChartGenerated, responses, extraOptions]
+        [
+            canvasRef,
+            visualization,
+            onChartGenerated,
+            responses,
+            extraOptions,
+            legendSets,
+        ]
     )
 
     useEffect(() => {
@@ -68,7 +76,7 @@ ChartPlugin.defaultProps = {
 
 ChartPlugin.propTypes = {
     extraOptions: PropTypes.object.isRequired,
-    // legendSets: PropTypes.arrayOf(PropTypes.object).isRequired,
+    legendSets: PropTypes.arrayOf(PropTypes.object).isRequired,
     responses: PropTypes.arrayOf(PropTypes.object).isRequired,
     visualization: PropTypes.object.isRequired,
     animation: PropTypes.number,

--- a/packages/plugin/src/__tests__/ChartPlugin.spec.js
+++ b/packages/plugin/src/__tests__/ChartPlugin.spec.js
@@ -109,6 +109,7 @@ describe('ChartPlugin', () => {
             onChartGenerated: jest.fn(),
             responses: [],
             extraOptions: mockExtraOptions,
+            legendSets: [],
         }
         chartPlugin = undefined
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,10 +1456,10 @@
     resize-observer-polyfill "^1.5.1"
     styled-jsx "^3.2.1"
 
-"@dhis2/analytics@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.1.0.tgz#7296350c3b35192ddf9912ee6a619a95ae786cd2"
-  integrity sha512-+S0fW+jLQtoNwqlVes8dnePr0MIoSgh0sqW2wMK+lPBu9cAmKkI8MFf6DGfxjVBidZ9bE+fWS8SMVYIk1Ve5Yw==
+"@dhis2/analytics@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.1.1.tgz#b9cfc77a6d62c955e23083808290e3f0eab0d53c"
+  integrity sha512-ngjVEfA541vorEJy39RCnSyAtTGKQvyrIi4lPQqKQrrpg7tw9HSxA3Ctgr+vW9SrytzEJ5Mv7Sz7l7sFfejBWg==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-org-unit-dialog" "^6.5.6"


### PR DESCRIPTION
1. Adds legends to Gauge options
![image](https://user-images.githubusercontent.com/12590483/74947946-e6111f80-53fb-11ea-88b7-f5e7e6211fe8.png)

2. Sends through `legendSets` to Analytics for the visualization generation.

3. Updates the Analytics dep

Depends on https://github.com/dhis2/analytics/pull/315/