### PR TITLE
fix: single value legend (DHIS2-8348)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.1.1",
+        "@dhis2/analytics": "^4.1.3",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^6.5.5",

--- a/packages/app/src/components/VisualizationOptions/Options/Legend.js
+++ b/packages/app/src/components/VisualizationOptions/Options/Legend.js
@@ -25,7 +25,12 @@ import {
     tabSectionTitle,
 } from '../styles/VisualizationOptions.style.js'
 
-const Legend = ({ legendSet, legendDisplayStrategy, onChange }) => {
+const Legend = ({
+    legendSet,
+    legendDisplayStrategy,
+    onChange,
+    hideStyleOptions,
+}) => {
     const [legendEnabled, setLegendEnabled] = useState(
         !(legendDisplayStrategy === LEGEND_DISPLAY_STRATEGY_FIXED && !legendSet)
     )
@@ -56,19 +61,21 @@ const Legend = ({ legendSet, legendDisplayStrategy, onChange }) => {
             />
             {legendEnabled ? (
                 <div className={tabSectionOptionToggleable.className}>
-                    <FieldSet>
-                        <UiCoreLegend>
-                            <span
-                                className={tabSectionTitle.className}
-                                style={{ marginTop: 8 }}
-                            >
-                                {i18n.t('Legend style')}
-                            </span>
-                        </UiCoreLegend>
-                        <div className={tabSectionOption.className}>
-                            <LegendDisplayStyle />
-                        </div>
-                    </FieldSet>
+                    {!hideStyleOptions ? (
+                        <FieldSet>
+                            <UiCoreLegend>
+                                <span
+                                    className={tabSectionTitle.className}
+                                    style={{ marginTop: 8 }}
+                                >
+                                    {i18n.t('Legend style')}
+                                </span>
+                            </UiCoreLegend>
+                            <div className={tabSectionOption.className}>
+                                <LegendDisplayStyle />
+                            </div>
+                        </FieldSet>
+                    ) : null}
                     <FieldSet>
                         <UiCoreLegend>
                             <span className={tabSectionTitle.className}>
@@ -88,6 +95,7 @@ const Legend = ({ legendSet, legendDisplayStrategy, onChange }) => {
 Legend.propTypes = {
     legendDisplayStrategy: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    hideStyleOptions: PropTypes.bool,
     legendSet: PropTypes.object,
 }
 

--- a/packages/app/src/modules/options/config.js
+++ b/packages/app/src/modules/options/config.js
@@ -21,6 +21,7 @@ import lineConfig from './lineConfig'
 import areaConfig from './areaConfig'
 import pieConfig from './pieConfig'
 import gaugeConfig from './gaugeConfig'
+import singleValueConfig from './singleValueConfig'
 
 export const getOptionsByType = type => {
     switch (type) {
@@ -40,8 +41,9 @@ export const getOptionsByType = type => {
         case VIS_TYPE_GAUGE:
             return gaugeConfig
         case VIS_TYPE_PIE:
-        case VIS_TYPE_SINGLE_VALUE:
             return pieConfig
+        case VIS_TYPE_SINGLE_VALUE:
+            return singleValueConfig
         case VIS_TYPE_PIVOT_TABLE:
             return pivotTableConfig
         default:

--- a/packages/app/src/modules/options/singleValueConfig.js
+++ b/packages/app/src/modules/options/singleValueConfig.js
@@ -1,0 +1,48 @@
+/* eslint-disable react/jsx-key */
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+
+import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
+import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
+import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
+import Legend from '../../components/VisualizationOptions/Options/Legend'
+
+export default [
+    {
+        key: 'data-tab',
+        label: i18n.t('Data'),
+        content: [
+            {
+                key: 'data-advanced',
+                label: i18n.t('Advanced'),
+                content: React.Children.toArray([<AggregationType />]),
+            },
+        ],
+    },
+    {
+        key: 'legend-tab',
+        label: i18n.t('Legend'),
+        content: [
+            {
+                key: 'legend-section-1',
+                content: React.Children.toArray([
+                    <Legend hideStyleOptions={true} />,
+                ]),
+            },
+        ],
+    },
+    {
+        key: 'style-tab',
+        label: i18n.t('Style'),
+        content: [
+            {
+                key: 'style-titles',
+                label: i18n.t('Titles'),
+                content: React.Children.toArray([
+                    <HideTitle />,
+                    <HideSubtitle />,
+                ]),
+            },
+        ],
+    },
+]

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.1.1",
+        "@dhis2/analytics": "^4.1.3",
         "@material-ui/core": "^3.1.2",
         "d2-analysis": "33.2.11",
         "lodash-es": "^4.17.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,10 +1456,10 @@
     resize-observer-polyfill "^1.5.1"
     styled-jsx "^3.2.1"
 
-"@dhis2/analytics@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.1.1.tgz#b9cfc77a6d62c955e23083808290e3f0eab0d53c"
-  integrity sha512-ngjVEfA541vorEJy39RCnSyAtTGKQvyrIi4lPQqKQrrpg7tw9HSxA3Ctgr+vW9SrytzEJ5Mv7Sz7l7sFfejBWg==
+"@dhis2/analytics@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.1.3.tgz#9c00f7e76921284f1edaa6948c5831173604924e"
+  integrity sha512-+8koE+4bSklCm9m0oqLyOz4cUeFYdpEV5mj5FsHXwFAE2gA1xddXkd4f44H6aCsUbPZ7lP73dd6AGn8E4gxcOw==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-org-unit-dialog" "^6.5.6"


### PR DESCRIPTION
Adds Single Value legend options. Since SV can only change the text color, the "style" option thats present for other visualisation types has been hidden.
 https://jira.dhis2.org/browse/DHIS2-8348

![image](https://user-images.githubusercontent.com/12590483/75163714-fe48ad80-571f-11ea-942b-d64308509caa.png)

Depends on https://github.com/dhis2/analytics/pull/320