### PR TITLE
fix: completed only all vis types

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.1.4",
+        "@dhis2/analytics": "^4.1.5",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^6.5.5",

--- a/packages/app/src/modules/options/areaConfig.js
+++ b/packages/app/src/modules/options/areaConfig.js
@@ -22,6 +22,7 @@ import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import Title from '../../components/VisualizationOptions/Options/Title'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import Subtitle from '../../components/VisualizationOptions/Options/Subtitle'
+import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
     {
@@ -41,6 +42,11 @@ export default [
                     <SortOrder />,
                     <AggregationType />,
                 ]),
+            },
+            {
+                key: 'data-advanced',
+                label: i18n.t('Advanced'),
+                content: React.Children.toArray([<CompletedOnly />]),
             },
         ],
     },

--- a/packages/app/src/modules/options/columnConfig.js
+++ b/packages/app/src/modules/options/columnConfig.js
@@ -19,6 +19,7 @@ import NoSpaceBetweenColumns from '../../components/VisualizationOptions/Options
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
+import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
     {
@@ -46,7 +47,10 @@ export default [
             {
                 key: 'data-advanced',
                 label: i18n.t('Advanced'),
-                content: React.Children.toArray([<AggregationType />]),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
             },
         ],
     },

--- a/packages/app/src/modules/options/gaugeConfig.js
+++ b/packages/app/src/modules/options/gaugeConfig.js
@@ -9,6 +9,7 @@ import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import AxisRange from '../../components/VisualizationOptions/Options/AxisRange'
 import Legend from '../../components/VisualizationOptions/Options/Legend'
+import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
     {
@@ -23,7 +24,10 @@ export default [
             {
                 key: 'data-advanced',
                 label: i18n.t('Advanced'),
-                content: React.Children.toArray([<AggregationType />]),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
             },
         ],
     },

--- a/packages/app/src/modules/options/lineConfig.js
+++ b/packages/app/src/modules/options/lineConfig.js
@@ -21,6 +21,7 @@ import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import Title from '../../components/VisualizationOptions/Options/Title'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import Subtitle from '../../components/VisualizationOptions/Options/Subtitle'
+import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
     {
@@ -39,6 +40,11 @@ export default [
                     <SortOrder />,
                     <AggregationType />,
                 ]),
+            },
+            {
+                key: 'data-advanced',
+                label: i18n.t('Advanced'),
+                content: React.Children.toArray([<CompletedOnly />]),
             },
         ],
     },

--- a/packages/app/src/modules/options/pieConfig.js
+++ b/packages/app/src/modules/options/pieConfig.js
@@ -5,6 +5,7 @@ import i18n from '@dhis2/d2-i18n'
 import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
+import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
     {
@@ -14,7 +15,10 @@ export default [
             {
                 key: 'data-advanced',
                 label: i18n.t('Advanced'),
-                content: React.Children.toArray([<AggregationType />]),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
             },
         ],
     },

--- a/packages/app/src/modules/options/singleValueConfig.js
+++ b/packages/app/src/modules/options/singleValueConfig.js
@@ -6,6 +6,7 @@ import AggregationType from '../../components/VisualizationOptions/Options/Aggre
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import Legend from '../../components/VisualizationOptions/Options/Legend'
+import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
     {
@@ -15,7 +16,10 @@ export default [
             {
                 key: 'data-advanced',
                 label: i18n.t('Advanced'),
-                content: React.Children.toArray([<AggregationType />]),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
             },
         ],
     },

--- a/packages/app/src/modules/options/stackedColumnConfig.js
+++ b/packages/app/src/modules/options/stackedColumnConfig.js
@@ -20,6 +20,7 @@ import NoSpaceBetweenColumns from '../../components/VisualizationOptions/Options
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
+import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
     {
@@ -49,7 +50,10 @@ export default [
             {
                 key: 'data-advanced',
                 label: i18n.t('Advanced'),
-                content: React.Children.toArray([<AggregationType />]),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
             },
         ],
     },

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.1.4",
+        "@dhis2/analytics": "^4.1.5",
         "@material-ui/core": "^3.1.2",
         "d2-analysis": "33.2.11",
         "lodash-es": "^4.17.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,10 +1456,10 @@
     resize-observer-polyfill "^1.5.1"
     styled-jsx "^3.2.1"
 
-"@dhis2/analytics@^4.1.4":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.1.4.tgz#bcd6d4d99b41720dd99e895c874119881eebd58c"
-  integrity sha512-5sU7pNE2mj0/jVYjso2T+Ujd6dFtC6+hAOJAT4KjeOGbMhmT9TzhRA0ToasYLyu/jQGTLK5s1oTcVnxzk1pFvg==
+"@dhis2/analytics@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.1.5.tgz#c16f0c9de24c0635b950cbfd25a6fc42a08ff74a"
+  integrity sha512-pHUwZ9CFvCxNZmrS3tnkfZc+P26UulsxOXmxVxD9weDIeY5+5hnfOMqd+x6QKZSlfPz4HQXRZ2XBSKBtAQ7DWg==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-org-unit-dialog" "^6.5.6"


### PR DESCRIPTION
Adds the `completedOnly` option to all vis types

![image](https://user-images.githubusercontent.com/12590483/75343704-4f2fe180-5899-11ea-9f17-1a522f151490.png)
