### PR TITLE
fix: added completedOnly to all vis types

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-09-16T07:28:39.022Z\n"
-"PO-Revision-Date: 2019-09-16T07:28:39.022Z\n"
+"POT-Creation-Date: 2020-02-26T13:21:17.550Z\n"
+"PO-Revision-Date: 2020-02-26T13:21:17.550Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -184,6 +184,9 @@ msgid "Base line title"
 msgstr ""
 
 msgid "Base line value"
+msgstr ""
+
+msgid "Only include completed events"
 msgstr ""
 
 msgid "Use cumulative values"

--- a/packages/app/src/api/analytics.js
+++ b/packages/app/src/api/analytics.js
@@ -22,6 +22,7 @@ export const apiDownloadData = async (current, format, idScheme, path) => {
 
     let req = new d2.analytics.request()
         .fromModel(current, path === 'dataValueSet')
+        .withParameters({ completedOnly: current.completedOnly })
         .withFormat(format);
 
     if (path) {

--- a/packages/app/src/components/VisualizationOptions/DataTab.js
+++ b/packages/app/src/components/VisualizationOptions/DataTab.js
@@ -12,6 +12,7 @@ import TargetLine from './Options/TargetLine';
 import BaseLine from './Options/BaseLine';
 import SortOrder from './Options/SortOrder';
 import AggregationType from './Options/AggregationType';
+import CompletedOnly from './Options/CompletedOnly';
 import styles from './styles/VisualizationOptions.style';
 
 export const DataTab = ({ classes }) => (
@@ -19,6 +20,7 @@ export const DataTab = ({ classes }) => (
         <ShowData />
         <PercentStackedValues />
         <CumulativeValues />
+        <CompletedOnly />
         <HideEmptyRowItems />
         <RegressionType />
         <TargetLine />

--- a/packages/app/src/components/VisualizationOptions/Options/CompletedOnly.js
+++ b/packages/app/src/components/VisualizationOptions/Options/CompletedOnly.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import i18n from '@dhis2/d2-i18n';
+import { withStyles } from '@material-ui/core/styles';
+import CheckboxBaseOption from './CheckboxBaseOption';
+import styles from '../styles/VisualizationOptions.style';
+
+const CompletedOnly = ({ classes }) => (
+    <CheckboxBaseOption
+        className={classes.dataTabCheckbox}
+        option={{
+            name: 'completedOnly',
+            label: i18n.t('Only include completed events'),
+        }}
+    />
+);
+
+CompletedOnly.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(CompletedOnly);

--- a/packages/app/src/components/VisualizationOptions/__tests__/DataTab.spec.js
+++ b/packages/app/src/components/VisualizationOptions/__tests__/DataTab.spec.js
@@ -33,7 +33,7 @@ describe('The DataTab component', () => {
         const wrappingDiv = dataTab()
             .find(FormGroup)
             .first();
-        expect(wrappingDiv.children()).toHaveLength(9);
+        expect(wrappingDiv.children()).toHaveLength(10);
     });
 
     [


### PR DESCRIPTION
* Adds the `completedOnly` option to the option modal, api requests and data download

![image](https://user-images.githubusercontent.com/12590483/75348840-d5e9bc00-58a3-11ea-91f0-ae6afbc92bcf.png)

