### PR TITLE
fix: avoid casting undefined to Number -> NaN

### DIFF
--- a/packages/app/src/modules/current.js
+++ b/packages/app/src/modules/current.js
@@ -84,7 +84,9 @@ export const getOptionsFromUi = ui => {
         'rangeAxisMaxValue',
     ].forEach(option => {
         if (Object.prototype.hasOwnProperty.call(optionsFromUi, option)) {
-            optionsFromUi[option] = Number(optionsFromUi[option])
+            if (optionsFromUi[option] !== undefined) {
+                optionsFromUi[option] = Number(optionsFromUi[option])
+            }
         }
     })
 


### PR DESCRIPTION
Only cast the value for numeric options if it's defined.
This prevents those options to passed around with NaN as value.
undefined is the default value, and is now passed around as is.