### PR TITLE
fix: remove data dimension validation

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-02-24T13:53:01.461Z\n"
-"PO-Revision-Date: 2020-02-24T13:53:01.461Z\n"
+"POT-Creation-Date: 2020-02-27T10:29:24.823Z\n"
+"PO-Revision-Date: 2020-02-27T10:29:24.823Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -513,6 +513,11 @@ msgid "{{visualizationType}} must have at least one period set in {{axes}}."
 msgstr ""
 
 msgid "No data set"
+msgstr ""
+
+msgid ""
+"{{visualizationType}} must have at least one data item or data element "
+"group set item in {{axes}}."
 msgstr ""
 
 msgid "{{visualizationType}} must have at least one data item in {{axes}}."

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -22,6 +22,7 @@ import {
     EmptyResponseError,
     AssignedCategoriesAsFilterError,
     MultipleIndicatorAsFilterError,
+    NoDataError,
 } from '../../modules/error'
 import LoadingMask from './LoadingMask'
 
@@ -46,6 +47,9 @@ export class Visualization extends Component {
                     break
                 case 'E7108':
                     error = new MultipleIndicatorAsFilterError()
+                    break
+                case 'E7102':
+                    error = new NoDataError(this.props.visualization.type)
                     break
                 default:
                     error = response

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -22,7 +22,7 @@ import {
     EmptyResponseError,
     AssignedCategoriesAsFilterError,
     MultipleIndicatorAsFilterError,
-    NoDataError,
+    NoDataOrDataElementGroupSetError,
 } from '../../modules/error'
 import LoadingMask from './LoadingMask'
 
@@ -49,7 +49,9 @@ export class Visualization extends Component {
                     error = new MultipleIndicatorAsFilterError()
                     break
                 case 'E7102':
-                    error = new NoDataError(this.props.visualization.type)
+                    error = new NoDataOrDataElementGroupSetError(
+                        this.props.visualization.type
+                    )
                     break
                 default:
                     error = response

--- a/packages/app/src/modules/error.js
+++ b/packages/app/src/modules/error.js
@@ -95,7 +95,7 @@ export class NoPeriodError extends VisualizationError {
     }
 }
 
-export class NoDataError extends VisualizationError {
+export class NoDataOrDataElementGroupSetError extends VisualizationError {
     constructor(visType) {
         const lockedAxis = getAxisPerLockedDimension(visType, DIMENSION_ID_DATA)
         super(
@@ -103,6 +103,28 @@ export class NoDataError extends VisualizationError {
             i18n.t('No data set'),
             i18n.t(
                 '{{visualizationType}} must have at least one data item or data element group set item in {{axes}}.',
+                {
+                    visualizationType: getDisplayNameByVisType(visType),
+                    axes: lockedAxis
+                        ? getAxisNameByLayoutType(
+                              lockedAxis,
+                              getLayoutTypeByVisType(visType)
+                          )
+                        : getAvailableAxesDescription(visType),
+                }
+            )
+        )
+    }
+}
+
+export class NoDataError extends VisualizationError {
+    constructor(visType) {
+        const lockedAxis = getAxisPerLockedDimension(visType, DIMENSION_ID_DATA)
+        super(
+            DataError,
+            i18n.t('No data set'),
+            i18n.t(
+                '{{visualizationType}} must have at least one data item in {{axes}}.',
                 {
                     visualizationType: getDisplayNameByVisType(visType),
                     axes: lockedAxis

--- a/packages/app/src/modules/error.js
+++ b/packages/app/src/modules/error.js
@@ -102,7 +102,7 @@ export class NoDataError extends VisualizationError {
             DataError,
             i18n.t('No data set'),
             i18n.t(
-                '{{visualizationType}} must have at least one data item in {{axes}}.',
+                '{{visualizationType}} must have at least one data item or data element group set item in {{axes}}.',
                 {
                     visualizationType: getDisplayNameByVisType(visType),
                     axes: lockedAxis

--- a/packages/app/src/modules/layoutValidation.js
+++ b/packages/app/src/modules/layoutValidation.js
@@ -10,10 +10,16 @@ import {
     dimensionIsValid,
     layoutGetDimension,
     DIMENSION_PROP_NO_ITEMS,
+    DIMENSION_ID_DATA,
 } from '@dhis2/analytics'
 
 import { BASE_FIELD_YEARLY_SERIES } from './fields/baseFields'
-import { NoSeriesError, NoCategoryError, NoPeriodError } from './error'
+import {
+    NoSeriesError,
+    NoCategoryError,
+    NoPeriodError,
+    NoDataError,
+} from './error'
 
 // Layout validation helper functions
 const isAxisValid = axis =>
@@ -50,6 +56,11 @@ const validateDefaultLayout = layout => {
 }
 
 const validateYearOverYearLayout = layout => {
+    validateDimension(
+        layoutGetDimension(layout, DIMENSION_ID_DATA),
+        new NoDataError(layout.type)
+    )
+
     if (
         !(
             Array.isArray(layout[BASE_FIELD_YEARLY_SERIES]) &&
@@ -71,6 +82,11 @@ const validatePieLayout = layout => {
 }
 
 const validateSingleValueLayout = layout => {
+    validateDimension(
+        layoutGetDimension(layout, DIMENSION_ID_DATA),
+        new NoDataError(layout.type)
+    )
+
     validateDimension(
         layoutGetDimension(layout, DIMENSION_ID_PERIOD),
         new NoPeriodError(layout.type)

--- a/packages/app/src/modules/layoutValidation.js
+++ b/packages/app/src/modules/layoutValidation.js
@@ -9,17 +9,11 @@ import {
     getPredefinedDimensionProp,
     dimensionIsValid,
     layoutGetDimension,
-    DIMENSION_ID_DATA,
     DIMENSION_PROP_NO_ITEMS,
 } from '@dhis2/analytics'
 
 import { BASE_FIELD_YEARLY_SERIES } from './fields/baseFields'
-import {
-    NoSeriesError,
-    NoCategoryError,
-    NoPeriodError,
-    NoDataError,
-} from './error'
+import { NoSeriesError, NoCategoryError, NoPeriodError } from './error'
 
 // Layout validation helper functions
 const isAxisValid = axis =>
@@ -86,11 +80,6 @@ const validateSingleValueLayout = layout => {
 // TODO: Add validatePivotLayout
 
 export const validateLayout = layout => {
-    validateDimension(
-        layoutGetDimension(layout, DIMENSION_ID_DATA),
-        new NoDataError(layout.type)
-    )
-
     switch (layout.type) {
         case VIS_TYPE_PIE:
             return validatePieLayout(layout)


### PR DESCRIPTION
Data element group set dimension items should be allowed to be used without a data dimension item. Solution: 

* Removes the data dimension validation from layout validation (front end) and catches the old api error (screenshot) to display the new data dimension error again.

* Updates the error message to include info about data element group sets (verified with @cooper-joe )

* YearOverYear, Gauge and Single Value still requires Data

Affects the testing of https://jira.dhis2.org/browse/DHIS2-5029, but the end result for the user should be unaffected.

Old error
![image](https://user-images.githubusercontent.com/12590483/75356897-d6d51a80-58b0-11ea-9e8a-36839afde84b.png)

New error
![image](https://user-images.githubusercontent.com/12590483/75424787-aa1d1380-5941-11ea-8649-9eea965fab4c.png)
