### PR TITLE
fix: interpretations panel show for PT visualization type DHIS2-8300

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.3.1",
+        "@dhis2/analytics": "^4.3.2",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^6.5.5",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.3.1",
+        "@dhis2/analytics": "^4.3.2",
         "@material-ui/core": "^3.1.2",
         "d2-analysis": "33.2.11",
         "lodash-es": "^4.17.11"

--- a/packages/plugin/src/PivotPlugin.js
+++ b/packages/plugin/src/PivotPlugin.js
@@ -3,13 +3,20 @@ import PropTypes from 'prop-types'
 
 import { PivotTable } from '@dhis2/analytics'
 
-const PivotPlugin = ({ responses, legendSets, visualization, style }) => {
+const PivotPlugin = ({
+    responses,
+    legendSets,
+    visualization,
+    style,
+    id: renderCounter,
+}) => {
     return (
-        <div style={{ width: '100%', height: '100%', ...style }}>
+        <div style={style}>
             <PivotTable
                 visualization={visualization}
                 data={responses[0].response}
                 legendSets={legendSets}
+                renderCounter={renderCounter}
             />
         </div>
     )
@@ -23,6 +30,7 @@ PivotPlugin.propTypes = {
     legendSets: PropTypes.arrayOf(PropTypes.object).isRequired,
     responses: PropTypes.arrayOf(PropTypes.object).isRequired,
     visualization: PropTypes.object.isRequired,
+    id: PropTypes.number,
     style: PropTypes.object,
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,10 +1456,10 @@
     resize-observer-polyfill "^1.5.1"
     styled-jsx "^3.2.1"
 
-"@dhis2/analytics@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.3.1.tgz#66debe7a084cde829efa5df4916568e7a8f96066"
-  integrity sha512-9/+k7TwEwSMjpkTjBkDea93IuKy0OO/i8I3qE8FkrS8lOIuq9dNAd5J1CEaVGRwMJdeuaXbMY2d/Zkgcbjz1Sw==
+"@dhis2/analytics@^4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.3.2.tgz#8d8932cf1a36874b9133c2487e52fa8e6493a5c2"
+  integrity sha512-zkRLNe4nDByTaZe87sY+Q52NtR7Nn07h7bpk7AoGqLd5Ud+90vm0Xo4cHx52fEyBRk/M18iDIdrbH+bo4g0xcg==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-org-unit-dialog" "^6.5.6"


### PR DESCRIPTION
The actual fix is released in [`@dhis2/analytics@4.3.2`](https://github.com/dhis2/analytics/pull/332).

Basically when the interpretations button is toggled, the dimensions of the parent container of the pivot table are reset to 0.
This seems to allow the flow applied to the right section of the app to work and the interpretations panel is shown.
The observer attached on the pivot table plugin container then triggers and calculates and applies its correct dimensions.