### PR TITLE
fix: updated the error and start page texts based on user feedback

### DIFF
--- a/packages/app/src/components/Visualization/StartScreen.js
+++ b/packages/app/src/components/Visualization/StartScreen.js
@@ -61,9 +61,7 @@ const StartScreen = ({ error, classes }) => {
                             {i18n.t('Add dimensions to the layout above')}
                         </li>
                         <li style={styles.guideItem}>
-                            {i18n.t(
-                                'Double click a dimension to add or remove items'
-                            )}
+                            {i18n.t('Click a dimension to add or remove items')}
                         </li>
                     </ul>
                 </div>

--- a/packages/app/src/modules/error.js
+++ b/packages/app/src/modules/error.js
@@ -83,9 +83,9 @@ export class NoPeriodError extends VisualizationError {
     constructor(visType) {
         super(
             PeriodError,
-            i18n.t('No period set'),
+            i18n.t('No period selected'),
             i18n.t(
-                '{{visualizationType}} must have at least one period set in {{axes}}.',
+                '{{visualizationType}} must have at least one period selected in {{axes}}.',
                 {
                     visualizationType: getDisplayNameByVisType(visType),
                     axes: getAvailableAxesDescription(visType),
@@ -100,7 +100,7 @@ export class NoDataOrDataElementGroupSetError extends VisualizationError {
         const lockedAxis = getAxisPerLockedDimension(visType, DIMENSION_ID_DATA)
         super(
             DataError,
-            i18n.t('No data set'),
+            i18n.t('No data selected'),
             i18n.t(
                 '{{visualizationType}} must have at least one data item or data element group set item in {{axes}}.',
                 {
@@ -122,7 +122,7 @@ export class NoDataError extends VisualizationError {
         const lockedAxis = getAxisPerLockedDimension(visType, DIMENSION_ID_DATA)
         super(
             DataError,
-            i18n.t('No data set'),
+            i18n.t('No data selected'),
             i18n.t(
                 '{{visualizationType}} must have at least one data item in {{axes}}.',
                 {


### PR DESCRIPTION
During the 2.34 dev demo @larshelge collected user-feedback regarding the text for the "No data" and "No period" messages. It was also noted that the start message incorrectly told the user to "double click" a dimension. These messages have now been updated.

--------------

Original feedback:

> "No data set": This is a bit confusing, i thought it referred to a "dataset". We could say "No data items selected".
Replace "set" with "selected", so "No period set" -> "No periods selected".

--------------
Updated "No data" message:

![image](https://user-images.githubusercontent.com/12590483/75890086-2924b700-5e2e-11ea-8a45-5a67e3b5a8a3.png)
--------------
Updated "No period" message

![image](https://user-images.githubusercontent.com/12590483/75890129-39d52d00-5e2e-11ea-92ed-2fd29305dc65.png)

--------------
Updated start page message:

![image](https://user-images.githubusercontent.com/12590483/75890063-1f9b4f00-5e2e-11ea-8f98-448d78f36172.png)