### PR TITLE
fix: do not use options intended for download request DHIS2-8401

### DIFF
--- a/packages/app/src/modules/options.js
+++ b/packages/app/src/modules/options.js
@@ -87,7 +87,7 @@ export const options = {
     subtitle: { defaultValue: undefined, requestable: false, savable: true },
     title: { defaultValue: undefined, requestable: false, savable: true },
 
-    // only for PT XXX
+    // only for PT
     colTotals: { defaultValue: false, requestable: false, savable: true },
     colSubTotals: { defaultValue: false, requestable: false, savable: true },
     rowTotals: { defaultValue: false, requestable: false, savable: true },
@@ -97,8 +97,12 @@ export const options = {
         requestable: false,
         savable: true,
     },
-    hideEmptyColumns: { defaultValue: false, requestable: true, savable: true },
-    hideEmptyRows: { defaultValue: false, requestable: true, savable: true },
+    hideEmptyColumns: {
+        defaultValue: false,
+        requestable: false,
+        savable: true,
+    },
+    hideEmptyRows: { defaultValue: false, requestable: false, savable: true },
     skipRounding: { defaultValue: false, requestable: true, savable: true },
     numberType: { defaultValue: 'VALUE', requestable: false, savable: true },
     showHierarchy: { defaultValue: false, requestable: true, savable: true },

--- a/packages/plugin/src/modules/options.js
+++ b/packages/plugin/src/modules/options.js
@@ -87,7 +87,7 @@ export const options = {
     subtitle: { defaultValue: undefined, requestable: false, savable: true },
     title: { defaultValue: undefined, requestable: false, savable: true },
 
-    // only for PT XXX
+    // only for PT
     colTotals: { defaultValue: false, requestable: false, savable: true },
     colSubTotals: { defaultValue: false, requestable: false, savable: true },
     rowTotals: { defaultValue: false, requestable: false, savable: true },
@@ -97,14 +97,18 @@ export const options = {
         requestable: false,
         savable: true,
     },
-    hideEmptyColumns: { defaultValue: false, requestable: true, savable: true },
-    hideEmptyRows: { defaultValue: false, requestable: true, savable: true },
+    hideEmptyColumns: {
+        defaultValue: false,
+        requestable: false,
+        savable: true,
+    },
+    hideEmptyRows: { defaultValue: false, requestable: false, savable: true },
     skipRounding: { defaultValue: false, requestable: true, savable: true },
     numberType: { defaultValue: 'VALUE', requestable: false, savable: true },
     showHierarchy: { defaultValue: false, requestable: true, savable: true },
     legendSet: { defaultValue: undefined, requestable: false, savable: true },
     legendDisplayStrategy: {
-        defaultValue: undefined,
+        defaultValue: 'FIXED',
         requestable: false,
         savable: true,
     },
@@ -162,6 +166,7 @@ export const computedOptions = {
     baseLine: { defaultValue: false, requestable: false, savable: false },
     targetLine: { defaultValue: false, requestable: false, savable: false },
     axisRange: { defaultValue: undefined, requestable: false, savable: false },
+    legend: { defaultValue: undefined, requestable: false, savable: false },
 }
 
 export default options


### PR DESCRIPTION
`hideEmptyRows` and `hideEmptyColumns` options are only intended for the
analytics download request when `tableLayout` is passed (download .xls, .csv and .html+css for PT), not for the normal request used to render the table.

Passing them does not affect the response payload, but does negatively affect caching, both client and server side, because the options are passed in the query string.

Solution is to mark them as non-requestable in the options list config file.

The URLs used in the download menu do not look at this flag, but rely only on the options been set in the visualization object (`current` in the app's Redux store).

Fixes: https://jira.dhis2.org/browse/DHIS2-8401.

Note: the changes in `options.js` for plugin related to `legendDisplayStrategy` and `legend` are there just to keep the file aligned with the one in the app package.
This file should be shared, but for now it's just copied and we should keep them in sync to avoid confusion about which one is the "correct" one.