### PR TITLE
fix: d2-ui-file-menu v6.5.10, improved open dialog organisation (DHIS2-8413)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,7 +16,7 @@
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^6.5.5",
-        "@dhis2/d2-ui-file-menu": "^6.5.5",
+        "@dhis2/d2-ui-file-menu": "^6.5.10",
         "@dhis2/d2-ui-interpretations": "^6.5.5",
         "@dhis2/data-visualizer-plugin": "34.3.17",
         "@dhis2/ui-core": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,6 +1593,17 @@
     i18next "^10.3"
     moment "^2.24.0"
 
+"@dhis2/d2-ui-core@6.5.10":
+  version "6.5.10"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.5.10.tgz#cbe1f1a9edcfa1e7cc7c482b1f2197280e545bac"
+  integrity sha512-mAsO91UjW0zdSOntz0/YnbjmUlHSAhwJMqMoKZMhsKDsJeeeZly18NYLjqztQH6uBRgBFFaHcMROsPAlSI0XUQ==
+  dependencies:
+    babel-runtime "^6.26.0"
+    d2 "~31.7"
+    lodash "^4.17.10"
+    material-ui "^0.20.0"
+    rxjs "^5.5.7"
+
 "@dhis2/d2-ui-core@6.5.5", "@dhis2/d2-ui-core@^6.5.5":
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.5.5.tgz#d75455a8388ef2c63a79824652a62f920441dfc6"
@@ -1614,13 +1625,13 @@
     material-ui "^0.20.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-favorites-dialog@6.5.5":
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-6.5.5.tgz#554bf5008ea257e03c4298c79f3bd2349cf71b56"
-  integrity sha512-Ly8jVYxGFp+ZOH0+e6ARRVeYNkGE2gLDh+2mNPSMbm/WTinD8gC/4sM/2+4GPvicKlpkU02jVxzzUbpOqpwSNA==
+"@dhis2/d2-ui-favorites-dialog@6.5.10":
+  version "6.5.10"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-6.5.10.tgz#e5f56d85016c003c4abc8c7fbe77d60ebe7b0fde"
+  integrity sha512-1RTSt7+KvuF7T/xNfEDeyhVkTN7o86WNm+50rEhm9kajLQbHTgiDDUFY6aOitqQmuE6vXqjoY7OOQKO0svOoNQ==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.6"
-    "@dhis2/d2-ui-sharing-dialog" "6.5.5"
+    "@dhis2/d2-ui-sharing-dialog" "6.5.10"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -1630,15 +1641,15 @@
     redux-logger "^3.0.6"
     redux-thunk "^2.2.0"
 
-"@dhis2/d2-ui-file-menu@^6.5.5":
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-file-menu/-/d2-ui-file-menu-6.5.5.tgz#21539a7095033107c9b34e3e178b64ba1c242d2d"
-  integrity sha512-oQxmMbtsfJiJfYAON/FKfPQfPwkqu4a0CK25Dl5ZZuIpww56Z0MD9Is3iYQiuTSNe/e6VmJoAP9o6Mqsq1wP6Q==
+"@dhis2/d2-ui-file-menu@^6.5.10":
+  version "6.5.10"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-file-menu/-/d2-ui-file-menu-6.5.10.tgz#6f399a11d616c54cfcae6e50e16a809e7f9803cc"
+  integrity sha512-5Rph/RrdGn5MB3nzH9UMSJIoUdd2XKLmO2+2FaLwJlcXZQYCk3Bd9rMwxojOz565BSZH7E8l477AAwDIcXlcVQ==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.3"
-    "@dhis2/d2-ui-favorites-dialog" "6.5.5"
-    "@dhis2/d2-ui-sharing-dialog" "6.5.5"
-    "@dhis2/d2-ui-translation-dialog" "6.5.5"
+    "@dhis2/d2-ui-favorites-dialog" "6.5.10"
+    "@dhis2/d2-ui-sharing-dialog" "6.5.10"
+    "@dhis2/d2-ui-translation-dialog" "6.5.10"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.6.0"
@@ -1724,6 +1735,20 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
+"@dhis2/d2-ui-sharing-dialog@6.5.10":
+  version "6.5.10"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-6.5.10.tgz#836095669abb65e44cc0401b36e8fda4906879d8"
+  integrity sha512-WBrVwgRRU8H3nMrU8Vs//l7LEqUAaCImccVbmRlGUBY5GjauDhMrBUct1hPNl9tUW9hPjEWjQSbI62BYgs2Erw==
+  dependencies:
+    "@dhis2/d2-ui-core" "6.5.10"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    babel-runtime "^6.26.0"
+    downshift "^2.2.2"
+    prop-types "^15.5.10"
+    recompose "^0.26.0"
+    rxjs "^5.5.7"
+
 "@dhis2/d2-ui-sharing-dialog@6.5.5":
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-6.5.5.tgz#ee975a062bc9264c51ad1f57fe7a3bdf65ba7f67"
@@ -1738,12 +1763,12 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-translation-dialog@6.5.5":
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-6.5.5.tgz#ff189db25cf2c66a0c9e27cba3f492bc64e45f56"
-  integrity sha512-0TTvMB1UZ/VxXCHGbn8FizhQXTgEXnupE7e2i944p4P98lZGZr5scyaYE+Zb7qlj1gH4n2PSm0rOc6wBO9v0xQ==
+"@dhis2/d2-ui-translation-dialog@6.5.10":
+  version "6.5.10"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-6.5.10.tgz#e2bedebc5450e2bdc9d33a0d26c43649ae598d35"
+  integrity sha512-2f9YgZJHkzLg8hrUhrUKs8Ki00X4gCbcHxjYftGXA/RRYr1gohYdAZbQOGtCvv1yxlnQY41nDTsK0Ej3DIL0sA==
   dependencies:
-    "@dhis2/d2-ui-core" "6.5.5"
+    "@dhis2/d2-ui-core" "6.5.10"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
Upgrades `d2-ui-file-menu` to v6.5.10 (https://github.com/dhis2/d2-ui/pull/574).

Implement the new design for the filter by visualization type in the File Open dialog.

- "Chart" and "Pivot Table" are at the top of the list.
- "Chart" comprises of all chart types, basically all the types listed except "Pivot Table".

![image](https://user-images.githubusercontent.com/12590483/76088125-c95a1780-5fb7-11ea-924c-5bb4e6479d42.png)
