### PR TITLE
fix: saving incorrectly shows the confirmation 

### DIFF
--- a/packages/app/src/actions/__tests__/index.spec.js
+++ b/packages/app/src/actions/__tests__/index.spec.js
@@ -368,9 +368,10 @@ describe('index', () => {
                         expectedVis
                     )
                     expect(history.default.replace).toHaveBeenCalled()
-                    expect(history.default.replace).toHaveBeenCalledWith(
-                        `/${uid}`
-                    )
+                    expect(history.default.replace).toHaveBeenCalledWith({
+                        pathname: `/${uid}`,
+                        state: { isSaving: true },
+                    })
                 })
         })
 
@@ -392,7 +393,10 @@ describe('index', () => {
                         expectedVis
                     )
                     expect(history.default.push).toHaveBeenCalled()
-                    expect(history.default.push).toHaveBeenCalledWith(`/${uid}`)
+                    expect(history.default.push).toHaveBeenCalledWith({
+                        pathname: `/${uid}`,
+                        state: { isSaving: true },
+                    })
                 })
         })
     })

--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -156,9 +156,15 @@ export const tDoSaveVisualization = ({ name, description }, copy) => async (
     const onSuccess = res => {
         if (res.status === 'OK' && res.response.uid) {
             if (copy) {
-                history.push(`/${res.response.uid}`)
+                history.push({
+                    pathname: `/${res.response.uid}`,
+                    state: { isSaving: true },
+                }) // Save as
             } else {
-                history.replace(`/${res.response.uid}`)
+                history.replace({
+                    pathname: `/${res.response.uid}`,
+                    state: { isSaving: true },
+                }) // Save
             }
         }
     }

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -153,12 +153,14 @@ export class App extends Component {
         this.loadVisualization(this.props.location)
 
         this.unlisten = history.listen(location => {
+            const isSaving = location.state?.isSaving
             if (
                 getVisualizationState(
                     this.props.visualization,
                     this.props.current
                 ) === STATE_DIRTY &&
-                this.state.locationToConfirm !== location
+                this.state.locationToConfirm !== location &&
+                !isSaving
             ) {
                 this.setState({ locationToConfirm: location })
             } else {


### PR DESCRIPTION
Currently, when trying to Save or Save As on a "dirty" AO (i.e. a previously saved AO that has been updated), the _Discard unsaved changes?_ modal would incorrectly trigger when the save had been done. 
To recreate: Open a saved AO. Do any change and click Update. The AO is now "dirty". Click File -> Save or Save As. Just before the AO refreshes the modal will be shown (incorrect).

This PR prevents the modal from being displayed by passing a param on the `history` object called `isSaving`, which is used to prevent the modal. 

-------

_Discard unsaved changes?_ modal for reference

![image](https://user-images.githubusercontent.com/12590483/76333865-8323f180-62f2-11ea-865a-342b482fbc18.png)
