### PR TITLE
fix: show names for levels and groups in dimension chip tooltip

### DIFF
--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -47,7 +47,7 @@ export class Tooltip extends React.Component {
         const groupIds = []
         const itemDisplayNames = []
 
-        !displayLimitedAmount &&
+        if (!displayLimitedAmount) {
             itemIds.forEach(id => {
                 if (ouIdHelper.hasLevelPrefix(id)) {
                     levelIds.push(ouIdHelper.removePrefix(id))
@@ -58,15 +58,16 @@ export class Tooltip extends React.Component {
                 }
             })
 
-        levelIds.length &&
-            itemDisplayNames.push(
-                this.getNameList(levelIds, 'Levels', metadata)
-            )
+            levelIds.length &&
+                itemDisplayNames.push(
+                    this.getNameList(levelIds, 'Levels', metadata)
+                )
 
-        groupIds.length &&
-            itemDisplayNames.push(
-                this.getNameList(groupIds, 'Groups', metadata)
-            )
+            groupIds.length &&
+                itemDisplayNames.push(
+                    this.getNameList(groupIds, 'Groups', metadata)
+                )
+        }
 
         return itemDisplayNames
     }

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -60,12 +60,12 @@ export class Tooltip extends React.Component {
 
             levelIds.length &&
                 itemDisplayNames.push(
-                    this.getNameList(levelIds, 'Levels', metadata)
+                    this.getNameList(levelIds, i18n.t('Levels'), metadata)
                 )
 
             groupIds.length &&
                 itemDisplayNames.push(
-                    this.getNameList(groupIds, 'Groups', metadata)
+                    this.getNameList(groupIds, i18n.t('Groups'), metadata)
                 )
         }
 

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import Popper from '@material-ui/core/Popper'
 import Paper from '@material-ui/core/Paper'
-import i18n from '@dhis2/d2-i18n'
 import LockIcon from '@material-ui/icons/Lock'
 import WarningIcon from '@material-ui/icons/Warning'
+import i18n from '@dhis2/d2-i18n'
+import { ouIdHelper } from '@dhis2/analytics'
 
 import { sGetMetadata } from '../../reducers/metadata'
 import { styles } from './styles/Tooltip.style'
@@ -30,11 +31,44 @@ export class Tooltip extends React.Component {
         return displayLimitedAmount ? warningLabel : null
     }
 
+    getNameList = (idList, label, metadata) =>
+        idList.reduce(
+            (levelString, levelId, index) =>
+                `${levelString}${index > 0 ? `, ` : ``}${
+                    metadata[levelId] ? metadata[levelId].name : levelId
+                }`,
+            `${label}: `
+        )
+
     getItemDisplayNames = () => {
         const { itemIds, metadata, displayLimitedAmount } = this.props
-        return itemIds.length && !displayLimitedAmount
-            ? itemIds.map(id => (metadata[id] ? metadata[id].name : id))
-            : []
+
+        const levelIds = []
+        const groupIds = []
+        const itemDisplayNames = []
+
+        !displayLimitedAmount &&
+            itemIds.forEach(id => {
+                if (ouIdHelper.hasLevelPrefix(id)) {
+                    levelIds.push(ouIdHelper.removePrefix(id))
+                } else if (ouIdHelper.hasGroupPrefix(id)) {
+                    groupIds.push(ouIdHelper.removePrefix(id))
+                } else {
+                    itemDisplayNames.push(metadata[id] ? metadata[id].name : id)
+                }
+            })
+
+        levelIds.length &&
+            itemDisplayNames.push(
+                this.getNameList(levelIds, 'Levels', metadata)
+            )
+
+        groupIds.length &&
+            itemDisplayNames.push(
+                this.getNameList(groupIds, 'Groups', metadata)
+            )
+
+        return itemDisplayNames
     }
 
     renderWarningLabel = warningLabel => (


### PR DESCRIPTION
Fixes proper display names for ou levels/groups in dimension chip tooltip.

Before:
![Screenshot from 2020-03-10 21-44-59](https://user-images.githubusercontent.com/1010094/76357770-95188b00-6318-11ea-8943-c1147028fc82.png)

After:
![Screenshot from 2020-03-10 21-43-57](https://user-images.githubusercontent.com/1010094/76357780-977ae500-6318-11ea-9299-15d54dfa161a.png)
