### PR TITLE
refactor: consolidated various generic error titles to one const (NOJIRA)

### DIFF
--- a/packages/app/src/components/ErrorBoundaries/FatalErrorBoundary.js
+++ b/packages/app/src/components/ErrorBoundaries/FatalErrorBoundary.js
@@ -4,6 +4,7 @@ import i18n from '@dhis2/d2-i18n'
 import { withStyles } from '@material-ui/core/styles'
 import InfoIcon from '@material-ui/icons/InfoOutlined'
 import styles from './styles/FatalErrorBoundary.style'
+import { genericErrorTitle } from '../../modules/error'
 
 const translatedErrorHeading = i18n.t(
     'An error occurred in the DHIS2 Data Visualizer application.'
@@ -45,7 +46,7 @@ export class FatalErrorBoundary extends Component {
                     <div className={classes.container}>
                         <InfoIcon className={classes.icon} />
                         <div className={classes.message}>
-                            {i18n.t('Something went wrong')}
+                            {genericErrorTitle}
                         </div>
                         <div
                             className={classes.link}

--- a/packages/app/src/components/Visualization/StartScreen.js
+++ b/packages/app/src/components/Visualization/StartScreen.js
@@ -8,7 +8,7 @@ import { apiFetchMostViewedVisualizations } from '../../api/mostViewedVisualizat
 import history from '../../modules/history'
 import { withStyles } from '@material-ui/core/styles'
 import { useDataEngine } from '@dhis2/app-runtime'
-import { VisualizationError } from '../../modules/error'
+import { VisualizationError, genericErrorTitle } from '../../modules/error'
 import { GenericError } from '../../assets/ErrorIcons'
 import { apiFetchVisualizations } from '../../api/visualization'
 import { visTypeIcons } from '@dhis2/analytics'
@@ -101,9 +101,7 @@ const StartScreen = ({ error, classes }) => {
         ) : (
             <div style={styles.errorContainer}>
                 <div style={styles.errorIcon}>{GenericError()}</div>
-                <p style={styles.errorTitle}>
-                    {i18n.t('Something went wrong')}
-                </p>
+                <p style={styles.errorTitle}>{genericErrorTitle}</p>
                 <p style={styles.errorDescription}>{error.message || error}</p>
             </div>
         )

--- a/packages/app/src/modules/error.js
+++ b/packages/app/src/modules/error.js
@@ -187,7 +187,7 @@ export class CombinationDEGSRRError extends VisualizationError {
     constructor() {
         super(
             DataError,
-            genericTitle,
+            genericErrorTitle,
             i18n.t(
                 'Data Element Group Sets and Reporting Rates cannot be used together.'
             )
@@ -199,7 +199,7 @@ export class GenericClientError extends VisualizationError {
     constructor(visType) {
         super(
             GenericError,
-            genericTitle,
+            genericErrorTitle,
             i18n.t(
                 'There is a problem with this {{visualizationType}} visualization.',
                 {
@@ -214,7 +214,7 @@ export class GenericServerError extends VisualizationError {
     constructor() {
         super(
             GenericError,
-            genericTitle,
+            genericErrorTitle,
             i18n.t('There was a problem getting the data from the server.')
         )
     }
@@ -244,7 +244,7 @@ export class AssignedCategoriesAsFilterError extends VisualizationError {
     }
 }
 
-const genericTitle = i18n.t('Something went wrong')
+export const genericErrorTitle = i18n.t('Something went wrong')
 
 const getAvailableAxesDescription = visType => {
     const axes = getAvailableAxes(visType)


### PR DESCRIPTION
Noticed that there was three identical copies of a generic error title "something went wrong", so I consolidated all three to a const that already existed in the error file, to be used by all: https://github.com/dhis2/data-visualizer-app/blob/ea7c1cc9550e43fbe41319ca7672758c7db25f37/packages/app/src/modules/error.js#L247

(NOJIRA) because I just found it ad-hoc and can't really be tested 🤷‍♂ 
No screenshots since its not a visual change 🙂 