### PR TITLE
fix: fix axes options for line and area vis types

### DIFF
--- a/packages/app/src/modules/options/areaConfig.js
+++ b/packages/app/src/modules/options/areaConfig.js
@@ -11,8 +11,7 @@ import TargetLine from '../../components/VisualizationOptions/Options/TargetLine
 import BaseLine from '../../components/VisualizationOptions/Options/BaseLine'
 import SortOrder from '../../components/VisualizationOptions/Options/SortOrder'
 import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
-import RangeAxisMinValue from '../../components/VisualizationOptions/Options/RangeAxisMinValue'
-import RangeAxisMaxValue from '../../components/VisualizationOptions/Options/RangeAxisMaxValue'
+import AxisRange from '../../components/VisualizationOptions/Options/AxisRange'
 import RangeAxisSteps from '../../components/VisualizationOptions/Options/RangeAxisSteps'
 import RangeAxisDecimals from '../../components/VisualizationOptions/Options/RangeAxisDecimals'
 import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeAxisLabel'
@@ -55,15 +54,19 @@ export default [
         label: i18n.t('Axes'),
         content: [
             {
-                key: 'axes-section-1',
+                key: 'axes-vertical-axis',
+                label: i18n.t('Vertical (y) axis'),
                 content: React.Children.toArray([
-                    <RangeAxisMinValue />,
-                    <RangeAxisMaxValue />,
+                    <RangeAxisLabel />,
+                    <AxisRange />,
                     <RangeAxisSteps />,
                     <RangeAxisDecimals />,
-                    <RangeAxisLabel />,
-                    <DomainAxisLabel />,
                 ]),
+            },
+            {
+                key: 'axes-horizontal-axis',
+                label: i18n.t('Horizontal (x) axis'),
+                content: React.Children.toArray([<DomainAxisLabel />]),
             },
         ],
     },

--- a/packages/app/src/modules/options/lineConfig.js
+++ b/packages/app/src/modules/options/lineConfig.js
@@ -10,8 +10,7 @@ import TargetLine from '../../components/VisualizationOptions/Options/TargetLine
 import BaseLine from '../../components/VisualizationOptions/Options/BaseLine'
 import SortOrder from '../../components/VisualizationOptions/Options/SortOrder'
 import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
-import RangeAxisMinValue from '../../components/VisualizationOptions/Options/RangeAxisMinValue'
-import RangeAxisMaxValue from '../../components/VisualizationOptions/Options/RangeAxisMaxValue'
+import AxisRange from '../../components/VisualizationOptions/Options/AxisRange'
 import RangeAxisSteps from '../../components/VisualizationOptions/Options/RangeAxisSteps'
 import RangeAxisDecimals from '../../components/VisualizationOptions/Options/RangeAxisDecimals'
 import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeAxisLabel'
@@ -53,15 +52,19 @@ export default [
         label: i18n.t('Axes'),
         content: [
             {
-                key: 'axes-section-1',
+                key: 'axes-vertical-axis',
+                label: i18n.t('Vertical (y) axis'),
                 content: React.Children.toArray([
-                    <RangeAxisMinValue />,
-                    <RangeAxisMaxValue />,
+                    <RangeAxisLabel />,
+                    <AxisRange />,
                     <RangeAxisSteps />,
                     <RangeAxisDecimals />,
-                    <RangeAxisLabel />,
-                    <DomainAxisLabel />,
                 ]),
+            },
+            {
+                key: 'axes-horizontal-axis',
+                label: i18n.t('Horizontal (x) axis'),
+                content: React.Children.toArray([<DomainAxisLabel />]),
             },
         ],
     },


### PR DESCRIPTION
While working on the documentation for DV, I noticed "broken" options in the Axes tab for `Line` and `Area` vis types.

Before:
<img width="403" alt="Screenshot 2020-04-03 at 11 24 12" src="https://user-images.githubusercontent.com/150978/78345408-ea555e80-759d-11ea-825a-a5b1131a79d2.png">

After:
<img width="369" alt="Screenshot 2020-04-03 at 11 26 38" src="https://user-images.githubusercontent.com/150978/78345508-fe995b80-759d-11ea-8993-5d8444ca6758.png">
