### PR TITLE
fix: pass dimensionItemType in current AO (DHIS2-8577)

### DIFF
--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -82,6 +82,7 @@ export class Visualization extends Component {
                     id,
                     name: item.name || item.displayName,
                     displayName: item.displayName,
+                    dimensionItemType: item.dimensionItemType,
                 }
             })
         })

--- a/packages/app/src/modules/currentAnalyticalObject.js
+++ b/packages/app/src/modules/currentAnalyticalObject.js
@@ -68,6 +68,28 @@ export const appendDimensionItemNamesToAnalyticalObject = (
     }
 }
 
+export const appendDimensionItemTypeToAnalyticalObject = (
+    current,
+    metadata
+) => {
+    const appendDimensionType = dimension => ({
+        ...dimension,
+        items: dimension.items.map(item => ({
+            ...item,
+            dimensionItemType: metadata[item.id]
+                ? metadata[item.id].dimensionItemType
+                : undefined,
+        })),
+    })
+
+    return {
+        ...current,
+        columns: current.columns.map(appendDimensionType),
+        filters: current.filters.map(appendDimensionType),
+        rows: current.rows.map(appendDimensionType),
+    }
+}
+
 export const appendCompleteParentGraphMap = (current, { parentGraphMap }) => ({
     ...current,
     parentGraphMap: {
@@ -81,6 +103,7 @@ export const prepareCurrentAnalyticalObject = (current, metadata, ui) => {
 
     result = removeUnnecessaryAttributesFromAnalyticalObject(current)
     result = appendDimensionItemNamesToAnalyticalObject(result, metadata)
+    result = appendDimensionItemTypeToAnalyticalObject(result, metadata)
     result = appendPathsToOrgUnits(result, ui)
     result = appendCompleteParentGraphMap(result, ui)
 


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-8577

Maps app requires the `dataItemType` information for dimension items for correctly setting up the item type in the edit thematical layer dialog when switching from DV with a given AO

See screenshot from Maps app here:
<img width="647" alt="Screenshot 2020-04-06 at 12 08 35" src="https://user-images.githubusercontent.com/150978/78547419-5b478100-77ff-11ea-9ec9-0ff394bcc2b0.png">
