### PR TITLE
fix: legend option text to suit all vis types

### DIFF
--- a/packages/app/src/components/VisualizationOptions/Options/LegendDisplayStrategy.js
+++ b/packages/app/src/components/VisualizationOptions/Options/LegendDisplayStrategy.js
@@ -32,7 +32,9 @@ const LegendDisplayStrategy = ({ value, onChange }) => (
             />
             <Radio
                 key={LEGEND_DISPLAY_STRATEGY_FIXED}
-                label={i18n.t('Select a single legend for entire table')}
+                label={i18n.t(
+                    'Select a single legend for the entire visualization'
+                )}
                 value={LEGEND_DISPLAY_STRATEGY_FIXED}
             />
         </RadioGroup>


### PR DESCRIPTION
Tiny text change to make a legend option suit all vis types (not just "table"). Verified by @cooper-joe 

Before
![image](https://user-images.githubusercontent.com/12590483/79566344-afc9e680-80b2-11ea-86fe-df8969480c9f.png)

After
![image](https://user-images.githubusercontent.com/12590483/79566431-d556f000-80b2-11ea-836d-f3aa18c6717f.png)
