### PR TITLE
refactor: rewrite Chip and TooltipContent components (TECH-322)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,7 +19,7 @@
         "@dhis2/d2-ui-file-menu": "^6.5.11",
         "@dhis2/d2-ui-interpretations": "^6.5.11",
         "@dhis2/data-visualizer-plugin": "34.3.46",
-        "@dhis2/ui-core": "^4.16.0",
+        "@dhis2/ui-core": "^4.18.0",
         "@material-ui/core": "^3.1.2",
         "@material-ui/icons": "^3.0.1",
         "d2": "31.8.1",

--- a/packages/app/src/components/Layout/Chip.js
+++ b/packages/app/src/components/Layout/Chip.js
@@ -1,5 +1,5 @@
 // TODO: Refactor chip to contain less logic
-import React, { createRef } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
@@ -22,15 +22,13 @@ import {
 } from '@dhis2/analytics'
 
 import Menu from './Menu'
-import { Tooltip as TooltipContent } from './Tooltip'
+import TooltipContent from './TooltipContent'
 import { setDataTransfer } from '../../modules/dnd'
 import { sGetDimensions } from '../../reducers/dimensions'
 import { sGetUiItemsByDimension, sGetUiType } from '../../reducers/ui'
 import DynamicDimensionIcon from '../../assets/DynamicDimensionIcon'
 import { styles } from './styles/Chip.style'
 import { acSetUiActiveModalDialog } from '../../actions/ui'
-
-const TOOLTIP_ENTER_DELAY = 500
 
 const LockIconWrapper = (
     <div style={styles.lockIconWrapper}>
@@ -53,49 +51,24 @@ const Chip = ({
     getOpenHandler,
 }) => {
     const id = Math.random().toString(36)
-    const ref = createRef()
-//    let timeout = null
     const isLocked = () => isDimensionLocked(type, dimensionId)
 
-    const getMaxNumberOfItems = () =>
-        getAxisMaxNumberOfItems(type, axisId)
-/*
-    const handleMouseOut = () => {
-        if (typeof timeout === 'number') {
-            console.log('mouse out hide tooltip')
-            clearTimeout(timeout)
-            timeout = null
-            setTooltipIsOpen(false)
-        }
-    }
-*/
+    const getMaxNumberOfItems = () => getAxisMaxNumberOfItems(type, axisId)
+
     const handleClick = () => {
-        if (
-            !getPredefinedDimensionProp(
-                dimensionId,
-                DIMENSION_PROP_NO_ITEMS
-            )
-        ) {
+        if (!getPredefinedDimensionProp(dimensionId, DIMENSION_PROP_NO_ITEMS)) {
             getOpenHandler(dimensionId)
         }
-
-        /// XXX close the tooltip ?!
-        //handleMouseOut()
     }
 
     const getDragStartHandler = () => event => {
-        // XXX close the tooltip ?!
-        //handleMouseOut()
-
         setDataTransfer(event, axisId)
     }
 
     const getWrapperStyles = () => ({
         ...styles.chipWrapper,
-        ...(!getPredefinedDimensionProp(
-            dimensionId,
-            DIMENSION_PROP_NO_ITEMS
-        ) && !items.length
+        ...(!getPredefinedDimensionProp(dimensionId, DIMENSION_PROP_NO_ITEMS) &&
+        !items.length
             ? styles.chipEmpty
             : {}),
     })
@@ -104,8 +77,7 @@ const Chip = ({
         const numberOfItems = items.length
 
         const getItemsLabel =
-            !!getMaxNumberOfItems() &&
-            numberOfItems > getMaxNumberOfItems()
+            !!getMaxNumberOfItems() && numberOfItems > getMaxNumberOfItems()
                 ? i18n.t(`{{total}} of {{axisMaxNumberOfItems}} selected`, {
                       total: numberOfItems,
                       axisMaxNumberOfItems: getMaxNumberOfItems(),
@@ -162,21 +134,14 @@ const Chip = ({
                     dimensionId={dimensionId}
                     itemIds={activeItemIds}
                     lockedLabel={lockedLabel}
-                    displayLimitedAmount={
-                        items.length > activeItemIds.length
-                    }
-                    open={tooltipIsOpen}
-                    anchorEl={ref}
+                    displayLimitedAmount={items.length > activeItemIds.length}
                 />
             )
         }
     }
 
     return (
-        <Tooltip
-            content={renderTooltipContent()}
-            ref={ref}
-        >
+        <Tooltip content={renderTooltipContent()} placement="bottom">
             {({ ref, onMouseOver, onMouseOut }) => (
                 <div
                     style={getWrapperStyles()}
@@ -184,20 +149,15 @@ const Chip = ({
                     draggable={!isLocked()}
                     onDragStart={getDragStartHandler()}
                     ref={ref}
+                    onMouseOver={onMouseOver}
+                    onMouseOut={onMouseOut}
                 >
-                    <div
-                        id={id}
-                        style={styles.chipLeft}
-                        onClick={handleClick}
-                    >
+                    <div id={id} style={styles.chipLeft} onClick={handleClick}>
                         <div style={styles.iconWrapper}>{renderChipIcon()}</div>
                         <span style={styles.label}>{dimensionName}</span>
                         <span>{renderChipLabelSuffix()}</span>
-                        {hasAxisTooManyItems(
-                            type,
-                            axisId,
-                            items.length
-                        ) && WarningIconWrapper}
+                        {hasAxisTooManyItems(type, axisId, items.length) &&
+                            WarningIconWrapper}
                         {isLocked() && LockIconWrapper}
                     </div>
                     {!isLocked() && renderMenu()}

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -1,10 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import Popper from '@material-ui/core/Popper'
-import Paper from '@material-ui/core/Paper'
+//import Popper from '@material-ui/core/Popper'
+//import Paper from '@material-ui/core/Paper'
 import LockIcon from '@material-ui/icons/Lock'
 import WarningIcon from '@material-ui/icons/Warning'
+
+//import { Popover } from '@dhis2/ui-core'
+
 import i18n from '@dhis2/d2-i18n'
 import { ouIdHelper } from '@dhis2/analytics'
 
@@ -138,6 +141,17 @@ export class Tooltip extends React.Component {
         const hasNoItemsLabel = !itemDisplayNames.length && !warningLabel
 
         return (
+            <ul style={styles.list}>
+                {warningLabel &&
+                    this.renderWarningLabel(warningLabel)}
+                {this.props.lockedLabel && this.renderLockedLabel()}
+                {itemDisplayNames &&
+                    this.renderItems(itemDisplayNames)}
+                {hasNoItemsLabel && this.renderNoItemsLabel()}
+            </ul>
+        )
+        /*
+        return (
             <Popper
                 anchorEl={this.props.anchorEl}
                 open={this.props.open}
@@ -157,6 +171,7 @@ export class Tooltip extends React.Component {
                 </Paper>
             </Popper>
         )
+            */
     }
 }
 

--- a/packages/app/src/components/Layout/TooltipContent.js
+++ b/packages/app/src/components/Layout/TooltipContent.js
@@ -17,9 +17,15 @@ const labels = {
     onlyLimitedNumberInUse: number =>
         i18n.t("Only '{{number}}' in use", { number }),
 }
-export class TooltipContent extends React.Component {
-    getWarningLabel = () => {
-        const { itemIds, metadata, displayLimitedAmount } = this.props
+
+export const TooltipContent = ({
+    dimensionId,
+    itemIds,
+    metadata,
+    displayLimitedAmount,
+    lockedLabel,
+}) => {
+    const getWarningLabel = () => {
         const warningLabel =
             itemIds.length === 1
                 ? labels.onlyOneInUse(
@@ -31,7 +37,7 @@ export class TooltipContent extends React.Component {
         return displayLimitedAmount ? warningLabel : null
     }
 
-    getNameList = (idList, label, metadata) =>
+    const getNameList = (idList, label, metadata) =>
         idList.reduce(
             (levelString, levelId, index) =>
                 `${levelString}${index > 0 ? `, ` : ``}${
@@ -40,8 +46,7 @@ export class TooltipContent extends React.Component {
             `${label}: `
         )
 
-    getItemDisplayNames = () => {
-        const { itemIds, metadata, displayLimitedAmount } = this.props
+    const getItemDisplayNames = () => {
         const levelIds = []
         const groupIds = []
         const itemDisplayNames = []
@@ -59,19 +64,19 @@ export class TooltipContent extends React.Component {
 
             levelIds.length &&
                 itemDisplayNames.push(
-                    this.getNameList(levelIds, i18n.t('Levels'), metadata)
+                    getNameList(levelIds, i18n.t('Levels'), metadata)
                 )
 
             groupIds.length &&
                 itemDisplayNames.push(
-                    this.getNameList(groupIds, i18n.t('Groups'), metadata)
+                    getNameList(groupIds, i18n.t('Groups'), metadata)
                 )
         }
 
         return itemDisplayNames
     }
 
-    renderWarningLabel = warningLabel => (
+    const renderWarningLabel = warningLabel => (
         <li style={styles.item}>
             <div style={styles.iconWrapper}>
                 <WarningIcon style={styles.icon} />
@@ -80,14 +85,14 @@ export class TooltipContent extends React.Component {
         </li>
     )
 
-    renderItems = itemDisplayNames => {
+    const renderItems = itemDisplayNames => {
         const renderLimit = 5
 
         const itemsToRender = itemDisplayNames
             .slice(0, renderLimit)
             .map(name => (
                 <li
-                    key={`${this.props.dimensionId}-${name}`}
+                    key={`${dimensionId}-${name}`}
                     style={styles.item}
                 >
                     {name}
@@ -97,7 +102,7 @@ export class TooltipContent extends React.Component {
         if (itemDisplayNames.length > renderLimit) {
             itemsToRender.push(
                 <li
-                    key={`${this.props.dimensionId}-render-limit`}
+                    key={`${dimensionId}-render-limit`}
                     style={styles.item}
                 >
                     {itemDisplayNames.length - renderLimit === 1
@@ -113,38 +118,33 @@ export class TooltipContent extends React.Component {
         return itemsToRender
     }
 
-    renderLockedLabel = () => (
+    const renderLockedLabel = () => (
         <li style={styles.item}>
             <div style={styles.iconWrapper}>
                 <LockIcon style={styles.icon} />
-                <span>{this.props.lockedLabel}</span>
+                <span>{lockedLabel}</span>
             </div>
         </li>
     )
 
-    renderNoItemsLabel = () => (
-        <li
-            key={`${this.props.dimensionId}-${labels.noneSelected}`}
-            style={styles.item}
-        >
+    const renderNoItemsLabel = () => (
+        <li key={`${dimensionId}-${labels.noneSelected}`} style={styles.item}>
             {labels.noneSelected}
         </li>
     )
 
-    render() {
-        const itemDisplayNames = this.getItemDisplayNames()
-        const warningLabel = this.getWarningLabel()
-        const hasNoItemsLabel = !itemDisplayNames.length && !warningLabel
+    const itemDisplayNames = getItemDisplayNames()
+    const warningLabel = getWarningLabel()
+    const hasNoItemsLabel = !itemDisplayNames.length && !warningLabel
 
-        return (
-            <ul style={styles.list}>
-                {warningLabel && this.renderWarningLabel(warningLabel)}
-                {this.props.lockedLabel && this.renderLockedLabel()}
-                {itemDisplayNames && this.renderItems(itemDisplayNames)}
-                {hasNoItemsLabel && this.renderNoItemsLabel()}
-            </ul>
-        )
-    }
+    return (
+        <ul style={styles.list}>
+            {warningLabel && renderWarningLabel(warningLabel)}
+            {lockedLabel && renderLockedLabel()}
+            {itemDisplayNames && renderItems(itemDisplayNames)}
+            {hasNoItemsLabel && renderNoItemsLabel()}
+        </ul>
+    )
 }
 
 TooltipContent.propTypes = {

--- a/packages/app/src/components/Layout/TooltipContent.js
+++ b/packages/app/src/components/Layout/TooltipContent.js
@@ -1,12 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-//import Popper from '@material-ui/core/Popper'
-//import Paper from '@material-ui/core/Paper'
+
 import LockIcon from '@material-ui/icons/Lock'
 import WarningIcon from '@material-ui/icons/Warning'
-
-//import { Popover } from '@dhis2/ui-core'
 
 import i18n from '@dhis2/d2-i18n'
 import { ouIdHelper } from '@dhis2/analytics'
@@ -20,7 +17,7 @@ const labels = {
     onlyLimitedNumberInUse: number =>
         i18n.t("Only '{{number}}' in use", { number }),
 }
-export class Tooltip extends React.Component {
+export class TooltipContent extends React.Component {
     getWarningLabel = () => {
         const { itemIds, metadata, displayLimitedAmount } = this.props
         const warningLabel =
@@ -45,7 +42,6 @@ export class Tooltip extends React.Component {
 
     getItemDisplayNames = () => {
         const { itemIds, metadata, displayLimitedAmount } = this.props
-
         const levelIds = []
         const groupIds = []
         const itemDisplayNames = []
@@ -142,44 +138,18 @@ export class Tooltip extends React.Component {
 
         return (
             <ul style={styles.list}>
-                {warningLabel &&
-                    this.renderWarningLabel(warningLabel)}
+                {warningLabel && this.renderWarningLabel(warningLabel)}
                 {this.props.lockedLabel && this.renderLockedLabel()}
-                {itemDisplayNames &&
-                    this.renderItems(itemDisplayNames)}
+                {itemDisplayNames && this.renderItems(itemDisplayNames)}
                 {hasNoItemsLabel && this.renderNoItemsLabel()}
             </ul>
         )
-        /*
-        return (
-            <Popper
-                anchorEl={this.props.anchorEl}
-                open={this.props.open}
-                placement="bottom-start"
-            >
-                <Paper style={styles.tooltip}>
-                    {
-                        <ul style={styles.list}>
-                            {warningLabel &&
-                                this.renderWarningLabel(warningLabel)}
-                            {this.props.lockedLabel && this.renderLockedLabel()}
-                            {itemDisplayNames &&
-                                this.renderItems(itemDisplayNames)}
-                            {hasNoItemsLabel && this.renderNoItemsLabel()}
-                        </ul>
-                    }
-                </Paper>
-            </Popper>
-        )
-            */
     }
 }
 
-Tooltip.propTypes = {
-    anchorEl: PropTypes.object.isRequired,
+TooltipContent.propTypes = {
     dimensionId: PropTypes.string.isRequired,
     metadata: PropTypes.object.isRequired,
-    open: PropTypes.bool.isRequired,
     displayLimitedAmount: PropTypes.bool,
     itemIds: PropTypes.array,
     lockedLabel: PropTypes.string,
@@ -189,4 +159,4 @@ const mapStateToProps = state => ({
     metadata: sGetMetadata(state),
 })
 
-export default connect(mapStateToProps)(Tooltip)
+export default connect(mapStateToProps)(TooltipContent)

--- a/packages/app/src/components/Layout/__tests__/TooltipContent.spec.js
+++ b/packages/app/src/components/Layout/__tests__/TooltipContent.spec.js
@@ -1,31 +1,24 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import Popper from '@material-ui/core/Popper'
-import { Tooltip } from '../Tooltip'
+import { TooltipContent } from '../TooltipContent'
 
-describe('Tooltip', () => {
+describe('TooltipContent', () => {
     let props
     let shallowTooltip
     const tooltip = () => {
         if (!shallowTooltip) {
-            shallowTooltip = shallow(<Tooltip {...props} />)
+            shallowTooltip = shallow(<TooltipContent {...props} />)
         }
         return shallowTooltip
     }
 
     beforeEach(() => {
         props = {
-            open: true,
-            anchorEl: {},
             dimensionId: 'abc',
             metadata: {},
             itemIds: [],
         }
         shallowTooltip = undefined
-    })
-
-    it('renders a Popper', () => {
-        expect(tooltip().find(Popper).length).toBeGreaterThan(0)
     })
 
     describe('no items provided', () => {

--- a/packages/app/src/components/Layout/__tests__/TooltipContent.spec.js
+++ b/packages/app/src/components/Layout/__tests__/TooltipContent.spec.js
@@ -21,6 +21,10 @@ describe('TooltipContent', () => {
         shallowTooltip = undefined
     })
 
+    it('renders a <ul>', () => {
+        expect(tooltip().find('ul').length).toEqual(1)
+    })
+
     describe('no items provided', () => {
         it('renders a default list item', () => {
             const items = tooltip().find('li')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,19 +1726,26 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/prop-types@^1.5", "@dhis2/prop-types@^1.5.0":
+"@dhis2/prop-types@^1.5":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.5.0.tgz#7e69919f66698be373dd21940a8a770234ded6a1"
   integrity sha512-dueFkkAMOIMbXiU7Mhr3Y+DBRyOd/rHA+5/IDiYWN1xttlUTSuGZLQ5AnJ7osBicEhx+qElaGbTdRYQj3SMBtA==
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-core@^4.16.0", "@dhis2/ui-core@^4.6.1", "@dhis2/ui-core@^4.9.1":
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.16.0.tgz#868555c2d8758af3f26e168d2a469bde39c91b1d"
-  integrity sha512-pa47/ZZrQa9SUXlOW4r8HKyuzfO/i4vENR1u2+2zrPfBtbFK4FPwXANmdVAw+V6epbWJU8k2Fi31j1ZMwauq/w==
+"@dhis2/prop-types@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.6.4.tgz#ec4d256c9440d4d00071524422a727c61ddaa6f6"
+  integrity sha512-qkVj8OuyjDmSxzYDlCWZllvC9hIbrIImMp79/U5CVsIRbjUF0zA/tfbv4rWnsWALmwEHOQFbzl5GnO5D8RNneA==
   dependencies:
-    "@dhis2/prop-types" "^1.5.0"
+    prop-types "^15"
+
+"@dhis2/ui-core@^4.18.0", "@dhis2/ui-core@^4.16.0", "@dhis2/ui-core@^4.6.1", "@dhis2/ui-core@^4.9.1":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.18.0.tgz#3db1f7866155c18acd4be441f0f2f95e502fdb81"
+  integrity sha512-xzVnVp20jCbUjWHSnebhP68wy9kvhpS4DSVpdwlRi1xw4D1aaOgExyoK6ghgklffyXLKHOPRpOhkVS14fLQLtw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
     "@popperjs/core" "^2.1.0"
     classnames "^2.2.6"
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/TECH-322

Part of the effort for reducing the technical debt in DV.

Rewrite the Chip and TooltipContent (renamed from Tooltip to solve name clashing issues with ui-core/Tooltip) components to use ui-core in place of material UI.

The ui-core Tooltip available positioning under the element is centered under it, not in the left corner.

A small issue is present when the Chip is dragged, and that is the Tooltip remains on the screen for the close timeout time.
I don't think there is a way to avoid this in the app.
What we might want is that as soon as the drag starts, the Tooltip is removed.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/150978/80490414-99007b00-8961-11ea-9604-fe9107af4cc7.gif)

Screenshots
Before:
<img width="362" alt="Screenshot 2020-04-28 at 15 00 11" src="https://user-images.githubusercontent.com/150978/80489990-f811c000-8960-11ea-8612-dc7e544bdc8f.png">

After:
<img width="345" alt="Screenshot 2020-04-28 at 14 59 34" src="https://user-images.githubusercontent.com/150978/80489943-e29c9600-8960-11ea-9d15-7ff6d386b0c8.png">