### PR TITLE
fix: display 'and x others...' on tooltip (DHIS2-8753)

### DIFF
--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -101,11 +101,12 @@ export class Tooltip extends React.Component {
                     key={`${this.props.dimensionId}-render-limit`}
                     style={styles.item}
                 >
-                    {`And ${itemDisplayNames.length - renderLimit} ${
-                        itemDisplayNames.length - renderLimit > 1
-                            ? 'others'
-                            : 'other'
-                    }...`}
+                    {itemDisplayNames.length - renderLimit === 1
+                        ? i18n.t('And 1 other...')
+                        : i18n.t('And {{numberOfItems}} others...', {
+                              numberOfItems:
+                                  itemDisplayNames.length - renderLimit,
+                          })}
                 </li>
             )
         }

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -81,12 +81,37 @@ export class Tooltip extends React.Component {
         </li>
     )
 
-    renderItems = itemDisplayNames =>
-        itemDisplayNames.map(name => (
-            <li key={`${this.props.dimensionId}-${name}`} style={styles.item}>
-                {name}
-            </li>
-        ))
+    renderItems = itemDisplayNames => {
+        const renderLimit = 5
+
+        const itemsToRender = itemDisplayNames
+            .slice(0, renderLimit)
+            .map(name => (
+                <li
+                    key={`${this.props.dimensionId}-${name}`}
+                    style={styles.item}
+                >
+                    {name}
+                </li>
+            ))
+
+        if (itemDisplayNames.length > renderLimit) {
+            itemsToRender.push(
+                <li
+                    key={`${this.props.dimensionId}-render-limit`}
+                    style={styles.item}
+                >
+                    {`And ${itemDisplayNames.length - renderLimit} ${
+                        itemDisplayNames.length - renderLimit > 1
+                            ? 'others'
+                            : 'other'
+                    }...`}
+                </li>
+            )
+        }
+
+        return itemsToRender
+    }
 
     renderLockedLabel = () => (
         <li style={styles.item}>


### PR DESCRIPTION
Fixes [8753](https://jira.dhis2.org/browse/DHIS2-8753) (_No tooltip displayed when items exceed window length_), by reducing the max amount of items displayed in a tooltip to 5 and adding a `and X others...` message to replace the subsequent items.

1-5 items display as normal
6 items display` and X other...`
6+ items display `and X others...`

Note: shouldn't affect other tooltips, like the SV one which has its own logic. Same for no items.

----------------

**Examples**

50 items: `and 45 others...`

![image](https://user-images.githubusercontent.com/12590483/80581508-89d70700-8a0d-11ea-86e5-0d3b7d09d1a8.png)



6 items: `and 1 other...`

![image](https://user-images.githubusercontent.com/12590483/80581595-abd08980-8a0d-11ea-8f7f-3db6044e0b45.png)


5 items: just displays as normal

![image](https://user-images.githubusercontent.com/12590483/80581651-c0ad1d00-8a0d-11ea-91ce-7d6635b9d35a.png)


Single value vis type: unaffected
![image](https://user-images.githubusercontent.com/12590483/80581889-28fbfe80-8a0e-11ea-95d2-5b8feedc533f.png)

No items: unaffected

![image](https://user-images.githubusercontent.com/12590483/80582116-78dac580-8a0e-11ea-8253-b7f4fe5f833e.png)

