### PR TITLE
fix: display 'and x others...' on tooltip (DHIS2-8753) v34 backport 

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-03-11T02:52:13.220Z\n"
-"PO-Revision-Date: 2020-03-11T02:52:13.220Z\n"
+"POT-Creation-Date: 2020-04-29T13:10:59.082Z\n"
+"PO-Revision-Date: 2020-04-29T13:10:59.082Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -118,9 +118,6 @@ msgstr ""
 msgid "An error occurred in the DHIS2 Data Visualizer application."
 msgstr ""
 
-msgid "Something went wrong"
-msgstr ""
-
 msgid "Refresh to try again"
 msgstr ""
 
@@ -161,6 +158,12 @@ msgid "Levels"
 msgstr ""
 
 msgid "Groups"
+msgstr ""
+
+msgid "And 1 other..."
+msgstr ""
+
+msgid "And {{numberOfItems}} others..."
 msgstr ""
 
 msgid "Unsaved visualization"
@@ -581,6 +584,9 @@ msgid "Assigned Categories cannot be used as Filter"
 msgstr ""
 
 msgid "Fix this problem by moving or removing Assigned Categories."
+msgstr ""
+
+msgid "Something went wrong"
 msgstr ""
 
 msgid "or"

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -81,12 +81,38 @@ export class Tooltip extends React.Component {
         </li>
     )
 
-    renderItems = itemDisplayNames =>
-        itemDisplayNames.map(name => (
-            <li key={`${this.props.dimensionId}-${name}`} style={styles.item}>
-                {name}
-            </li>
-        ))
+    renderItems = itemDisplayNames => {
+        const renderLimit = 5
+
+        const itemsToRender = itemDisplayNames
+            .slice(0, renderLimit)
+            .map(name => (
+                <li
+                    key={`${this.props.dimensionId}-${name}`}
+                    style={styles.item}
+                >
+                    {name}
+                </li>
+            ))
+
+        if (itemDisplayNames.length > renderLimit) {
+            itemsToRender.push(
+                <li
+                    key={`${this.props.dimensionId}-render-limit`}
+                    style={styles.item}
+                >
+                    {itemDisplayNames.length - renderLimit === 1
+                        ? i18n.t('And 1 other...')
+                        : i18n.t('And {{numberOfItems}} others...', {
+                              numberOfItems:
+                                  itemDisplayNames.length - renderLimit,
+                          })}
+                </li>
+            )
+        }
+
+        return itemsToRender
+    }
 
     renderLockedLabel = () => (
         <li style={styles.item}>


### PR DESCRIPTION
[DHIS2-8753](https://jira.dhis2.org/browse/DHIS2-8753) fix for v34. Backported https://github.com/dhis2/data-visualizer-app/pull/925 by cherry-picking https://github.com/dhis2/data-visualizer-app/commit/adaa4854fc00f76f0d413cab186b865293ebb6e2 and generating a new pot file. Please see the original PR for details.