### PR TITLE
fix: display 'and x others...' on tooltip (DHIS2-8753) v33 backport 

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-02-26T13:21:17.550Z\n"
-"PO-Revision-Date: 2020-02-26T13:21:17.550Z\n"
+"POT-Creation-Date: 2020-04-29T13:47:48.626Z\n"
+"PO-Revision-Date: 2020-04-29T13:47:48.626Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -118,6 +118,12 @@ msgid "None selected"
 msgstr ""
 
 msgid "Only '{{name}}' in use"
+msgstr ""
+
+msgid "And 1 other..."
+msgstr ""
+
+msgid "And {{numberOfItems}} others..."
 msgstr ""
 
 msgid "Unsaved chart"

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -11,18 +11,18 @@ import { styles } from './styles/Tooltip.style';
 
 const labels = {
     noneSelected: i18n.t('None selected'),
-    onlyOneInUse: name => i18n.t("Only '{{name}}' in use", { name }),
+    onlyOneInUse: (name) => i18n.t("Only '{{name}}' in use", { name }),
 };
 
 const emptyItems = [];
 
 export class Tooltip extends React.Component {
-    renderItems = itemDisplayNames => {
+    renderItems = (itemDisplayNames) => {
         const renderLimit = 5;
 
         const itemsToRender = itemDisplayNames
             .slice(0, renderLimit)
-            .map(name => (
+            .map((name) => (
                 <li key={`${this.props.dimensionId}-${name}`}>{name}</li>
             ));
 
@@ -42,7 +42,7 @@ export class Tooltip extends React.Component {
         return itemsToRender;
     };
 
-    renderTooltip = names => (
+    renderTooltip = (names) => (
         <Popper
             anchorEl={this.props.anchorEl}
             open={this.props.open}
@@ -66,12 +66,12 @@ export class Tooltip extends React.Component {
                     labels.onlyOneInUse(metadata[id] ? metadata[id].name : id),
                 ];
             } else {
-                names = activeItemIds.map(id =>
+                names = activeItemIds.map((id) =>
                     metadata[id] ? metadata[id].name : id
                 );
             }
         } else if (itemIds.length) {
-            names = itemIds.map(id =>
+            names = itemIds.map((id) =>
                 metadata[id] ? metadata[id].name : id
             );
         } else {

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -11,18 +11,18 @@ import { styles } from './styles/Tooltip.style';
 
 const labels = {
     noneSelected: i18n.t('None selected'),
-    onlyOneInUse: (name) => i18n.t("Only '{{name}}' in use", { name }),
+    onlyOneInUse: name => i18n.t("Only '{{name}}' in use", { name }),
 };
 
 const emptyItems = [];
 
 export class Tooltip extends React.Component {
-    renderItems = (itemDisplayNames) => {
+    renderItems = itemDisplayNames => {
         const renderLimit = 5;
 
         const itemsToRender = itemDisplayNames
             .slice(0, renderLimit)
-            .map((name) => (
+            .map(name => (
                 <li key={`${this.props.dimensionId}-${name}`}>{name}</li>
             ));
 
@@ -42,7 +42,7 @@ export class Tooltip extends React.Component {
         return itemsToRender;
     };
 
-    renderTooltip = (names) => (
+    renderTooltip = names => (
         <Popper
             anchorEl={this.props.anchorEl}
             open={this.props.open}
@@ -66,13 +66,13 @@ export class Tooltip extends React.Component {
                     labels.onlyOneInUse(metadata[id] ? metadata[id].name : id),
                 ];
             } else {
-                names = activeItemIds.map((id) =>
+                names = activeItemIds.map(id =>
                     metadata[id] ? metadata[id].name : id
                 );
             }
         } else if (itemIds.length) {
-            names = itemIds.map((id) =>
-                metadata[id] ? metadata[id].name : id
+            names = itemIds.map(id =>
+                (metadata[id] ? metadata[id].name : id)
             );
         } else {
             names = [labels.noneSelected];

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -11,28 +11,45 @@ import { styles } from './styles/Tooltip.style';
 
 const labels = {
     noneSelected: i18n.t('None selected'),
-    onlyOneInUse: name => i18n.t("Only '{{name}}' in use", { name }),
+    onlyOneInUse: (name) => i18n.t("Only '{{name}}' in use", { name }),
 };
 
 const emptyItems = [];
 
 export class Tooltip extends React.Component {
-    renderTooltip = names => (
+    renderItems = (itemDisplayNames) => {
+        const renderLimit = 5;
+
+        const itemsToRender = itemDisplayNames
+            .slice(0, renderLimit)
+            .map((name) => (
+                <li key={`${this.props.dimensionId}-${name}`}>{name}</li>
+            ));
+
+        if (itemDisplayNames.length > renderLimit) {
+            itemsToRender.push(
+                <li key={`${this.props.dimensionId}-render-limit`}>
+                    {itemDisplayNames.length - renderLimit === 1
+                        ? i18n.t('And 1 other...')
+                        : i18n.t('And {{numberOfItems}} others...', {
+                              numberOfItems:
+                                  itemDisplayNames.length - renderLimit,
+                          })}
+                </li>
+            );
+        }
+
+        return itemsToRender;
+    };
+
+    renderTooltip = (names) => (
         <Popper
             anchorEl={this.props.anchorEl}
             open={this.props.open}
             placement="bottom-start"
         >
             <Paper style={styles.tooltip}>
-                {
-                    <ul style={styles.list}>
-                        {names.map(name => (
-                            <li key={`${this.props.dimensionId}-${name}`}>
-                                {name}
-                            </li>
-                        ))}
-                    </ul>
-                }
+                {<ul style={styles.list}>{this.renderItems(names)}</ul>}
             </Paper>
         </Popper>
     );
@@ -49,12 +66,14 @@ export class Tooltip extends React.Component {
                     labels.onlyOneInUse(metadata[id] ? metadata[id].name : id),
                 ];
             } else {
-                names = activeItemIds.map(id =>
+                names = activeItemIds.map((id) =>
                     metadata[id] ? metadata[id].name : id
                 );
             }
         } else if (itemIds.length) {
-            names = itemIds.map(id => (metadata[id] ? metadata[id].name : id));
+            names = itemIds.map((id) =>
+                metadata[id] ? metadata[id].name : id
+            );
         } else {
             names = [labels.noneSelected];
         }

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -71,9 +71,7 @@ export class Tooltip extends React.Component {
                 );
             }
         } else if (itemIds.length) {
-            names = itemIds.map(id =>
-                (metadata[id] ? metadata[id].name : id)
-            );
+            names = itemIds.map(id => (metadata[id] ? metadata[id].name : id));
         } else {
             names = [labels.noneSelected];
         }

--- a/packages/app/src/components/Layout/Tooltip.js
+++ b/packages/app/src/components/Layout/Tooltip.js
@@ -11,18 +11,18 @@ import { styles } from './styles/Tooltip.style';
 
 const labels = {
     noneSelected: i18n.t('None selected'),
-    onlyOneInUse: (name) => i18n.t("Only '{{name}}' in use", { name }),
+    onlyOneInUse: name => i18n.t("Only '{{name}}' in use", { name }),
 };
 
 const emptyItems = [];
 
 export class Tooltip extends React.Component {
-    renderItems = (itemDisplayNames) => {
+    renderItems = itemDisplayNames => {
         const renderLimit = 5;
 
         const itemsToRender = itemDisplayNames
             .slice(0, renderLimit)
-            .map((name) => (
+            .map(name => (
                 <li key={`${this.props.dimensionId}-${name}`}>{name}</li>
             ));
 
@@ -42,7 +42,7 @@ export class Tooltip extends React.Component {
         return itemsToRender;
     };
 
-    renderTooltip = (names) => (
+    renderTooltip = names => (
         <Popper
             anchorEl={this.props.anchorEl}
             open={this.props.open}
@@ -66,12 +66,12 @@ export class Tooltip extends React.Component {
                     labels.onlyOneInUse(metadata[id] ? metadata[id].name : id),
                 ];
             } else {
-                names = activeItemIds.map((id) =>
+                names = activeItemIds.map(id =>
                     metadata[id] ? metadata[id].name : id
                 );
             }
         } else if (itemIds.length) {
-            names = itemIds.map((id) =>
+            names = itemIds.map(id =>
                 metadata[id] ? metadata[id].name : id
             );
         } else {


### PR DESCRIPTION
[DHIS2-8753](https://jira.dhis2.org/browse/DHIS2-8753) fix for v33. Backported https://github.com/dhis2/data-visualizer-app/pull/925 by manually copy-pasting the fix from https://github.com/dhis2/data-visualizer-app/commit/adaa4854fc00f76f0d413cab186b865293ebb6e2 and generating a new pot file. A clean cherry-pick wasn't possible since v33 didn't implement the `renderItems` method. Please see the original PR for details.