### PR TITLE
fix: dimension panel search field is missing the 'x' to clear (DHIS2-8790)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "concurrently": "^5.2.0",
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.2",
-        "eslint-plugin-react-hooks": "^2.3.0",
+        "eslint-plugin-react-hooks": "^3.0.0",
         "jest-enzyme": "^7.1.2",
         "loglevel": "^1.6.8"
     },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.3.27",
+        "@dhis2/analytics": "^4.3.28",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^6.5.11",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,7 +19,7 @@
         "@dhis2/d2-ui-file-menu": "^6.5.11",
         "@dhis2/d2-ui-interpretations": "^6.5.11",
         "@dhis2/data-visualizer-plugin": "34.3.47",
-        "@dhis2/ui-core": "^4.19.0",
+        "@dhis2/ui-core": "^4.19.1",
         "@material-ui/icons": "^3.0.1",
         "d2": "31.8.1",
         "history": "^4.7.2",

--- a/packages/app/src/components/DimensionsPanel/DndDimensionsPanel.js
+++ b/packages/app/src/components/DimensionsPanel/DndDimensionsPanel.js
@@ -35,6 +35,7 @@ export class DndDimensionsPanel extends Component {
                     onChange={this.onFilterTextChange}
                     onClear={this.onClearFilter}
                     disableUnderline={true}
+                    type="search"
                 />
                 <DndDimensionList
                     filterText={this.state.filterText}

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.3.27",
+        "@dhis2/analytics": "^4.3.28",
         "d2-analysis": "33.2.14",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,35 +1389,15 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^4.0.1":
-  version "4.3.26"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.3.26.tgz#93213eb908d85afe067ecb64ae3b281364626e24"
-  integrity sha512-39klE4G4CkO1vDezdUNTy4dXJA85g8KRGUduFROrLbJGbU+EtqIllzc5TsW08lZK2LaHqq6FmJNd0CF5iL1SLw==
+"@dhis2/analytics@^4.0.1", "@dhis2/analytics@^4.3.28":
+  version "4.3.28"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.3.28.tgz#4f8f98681de97970159e9e4886db558158231d12"
+  integrity sha512-VAbz1Fgd5azHfEXKH8fS8tMEHB7bO+TfJ6iI0+WXAjSjpZiF08g7fMK8vptLhwM0eTFjmofBZ5WgcLf1DACAJw==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-org-unit-dialog" "^6.5.9"
     "@dhis2/d2-ui-period-selector-dialog" "^6.5.7"
-    "@dhis2/ui-core" "^4.9.1"
-    "@material-ui/core" "^3.9.3"
-    "@material-ui/icons" "^3.0.2"
-    classnames "^2.2.6"
-    d2-utilizr "^0.2.16"
-    d3-color "^1.2.3"
-    highcharts "^7.2.1"
-    lodash "^4.17.13"
-    react-beautiful-dnd "^10.1.1"
-    resize-observer-polyfill "^1.5.1"
-    styled-jsx "^3.2.1"
-
-"@dhis2/analytics@^4.3.27":
-  version "4.3.27"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.3.27.tgz#c388e58327a5d7372de3e4fdac887a4920fa779c"
-  integrity sha512-E2HI8bvox/6oR99mEvjJUEuVpMKynEpJJF0HhCpFgLPryjh4Npnrswk1eTOaYY5H16Fk5uexxOCfLsWd+uudWA==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-org-unit-dialog" "^6.5.9"
-    "@dhis2/d2-ui-period-selector-dialog" "^6.5.7"
-    "@dhis2/ui-core" "^4.16.0"
+    "@dhis2/ui-core" "^4.19.1"
     "@material-ui/core" "^3.9.3"
     "@material-ui/icons" "^3.0.2"
     classnames "^2.2.6"
@@ -1733,7 +1713,7 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-core@^4.16.0", "@dhis2/ui-core@^4.19.1", "@dhis2/ui-core@^4.6.1", "@dhis2/ui-core@^4.9.1":
+"@dhis2/ui-core@^4.19.1", "@dhis2/ui-core@^4.6.1":
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.19.1.tgz#3cf32b2a24f2435d527ebef1daa99b84396da4f8"
   integrity sha512-jvX6h+lRhKaw18B46AQuwltDKIb06e1HxGaPpplFJS1vRrTs8Yvn1pP1BFUBhTgVD3/3zLlO+lD3IsUavJUqOg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5965,10 +5965,10 @@ eslint-plugin-react-hooks@^1.6.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
   integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
 
-eslint-plugin-react-hooks@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz#53e073961f1f5ccf8dd19558036c1fac8c29d99a"
-  integrity sha512-gLKCa52G4ee7uXzdLiorca7JIQZPPXRAQDXV83J4bUEeUuc5pIEyZYAZ45Xnxe5IuupxEqHS+hUhSLIimK1EMw==
+eslint-plugin-react-hooks@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-3.0.0.tgz#9e80c71846eb68dd29c3b21d832728aa66e5bd35"
+  integrity sha512-EjxTHxjLKIBWFgDJdhKKzLh5q+vjTFrqNZX36uIxWS4OfyXe5DawqPj3U5qeJ1ngLwatjzQnmR0Lz0J0YH3kxw==
 
 eslint-plugin-react@7.16.0, eslint-plugin-react@^7.16.0:
   version "7.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,10 +1733,10 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-core@^4.16.0", "@dhis2/ui-core@^4.19.0", "@dhis2/ui-core@^4.6.1", "@dhis2/ui-core@^4.9.1":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.19.0.tgz#c08ca66abe2dc67f86f0f0eacecae60bdeb4395d"
-  integrity sha512-XZ41oy1wBKpHk/aMgGLabexIIMV66CAX5T8tdU8anWZN7Bfw1G4UIqnulN/ytLuGhcVZqGATCDFZFRZPeHakpg==
+"@dhis2/ui-core@^4.16.0", "@dhis2/ui-core@^4.19.1", "@dhis2/ui-core@^4.6.1", "@dhis2/ui-core@^4.9.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.19.1.tgz#3cf32b2a24f2435d527ebef1daa99b84396da4f8"
+  integrity sha512-jvX6h+lRhKaw18B46AQuwltDKIb06e1HxGaPpplFJS1vRrTs8Yvn1pP1BFUBhTgVD3/3zLlO+lD3IsUavJUqOg==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     "@popperjs/core" "^2.1.0"


### PR DESCRIPTION
Fixes [DHIS2-8790](https://jira.dhis2.org/browse/DHIS2-8790).
Adds the browser default 'x' by passing through the `type` prop (which can be set to `search` to get the 'x'.

![image](https://user-images.githubusercontent.com/12590483/80979914-3d823180-8e28-11ea-8671-4880937e575b.png)

Depends on: https://github.com/dhis2/analytics/pull/408