### PR TITLE
fix: latest analytics library for period selector translations (v33)

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-13T19:08:48.461Z\n"
-"PO-Revision-Date: 2020-05-13T19:08:48.461Z\n"
+"POT-Creation-Date: 2020-05-14T01:00:50.112Z\n"
+"PO-Revision-Date: 2020-05-14T01:00:50.112Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -468,6 +468,9 @@ msgstr ""
 msgid "Last 6 months"
 msgstr ""
 
+msgid "Last 12 months"
+msgstr ""
+
 msgid "Months this year"
 msgstr ""
 
@@ -522,10 +525,16 @@ msgstr ""
 msgid "Last 5 years"
 msgstr ""
 
-msgid "Weeks per year"
+msgid "User org unit"
 msgstr ""
 
-msgid "Last 12 months"
+msgid "User org unit children"
+msgstr ""
+
+msgid "User org unit grand children"
+msgstr ""
+
+msgid "Weeks per year"
 msgstr ""
 
 msgid "Months per year"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -25,7 +25,7 @@
         "webpack-bundle-analyzer": "^3.0.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "~2.4.13",
+        "@dhis2/analytics": "~2.4.14",
         "@dhis2/d2-i18n": "^1.0.6",
         "@dhis2/d2-ui-core": "^7.0.2",
         "@dhis2/d2-ui-file-menu": "^7.0.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -27,9 +27,9 @@
     "dependencies": {
         "@dhis2/analytics": "~2.4.14",
         "@dhis2/d2-i18n": "^1.0.6",
-        "@dhis2/d2-ui-core": "^7.0.2",
-        "@dhis2/d2-ui-file-menu": "^7.0.2",
-        "@dhis2/d2-ui-interpretations": "^7.0.2",
+        "@dhis2/d2-ui-core": "^7.0.3",
+        "@dhis2/d2-ui-file-menu": "^7.0.3",
+        "@dhis2/d2-ui-interpretations": "^7.0.3",
         "@dhis2/data-visualizer-plugin": "^33.1.11",
         "@dhis2/ui": "^1.0.0-beta.11",
         "@dhis2/ui-core": "^3.4.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -25,7 +25,7 @@
         "webpack-bundle-analyzer": "^3.0.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "~2.4.12",
+        "@dhis2/analytics": "~2.4.13",
         "@dhis2/d2-i18n": "^1.0.6",
         "@dhis2/d2-ui-core": "^7.0.2",
         "@dhis2/d2-ui-file-menu": "^7.0.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -25,7 +25,7 @@
         "webpack-bundle-analyzer": "^3.0.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "~2.4.14",
+        "@dhis2/analytics": "~2.4.15",
         "@dhis2/d2-i18n": "^1.0.6",
         "@dhis2/d2-ui-core": "^7.0.3",
         "@dhis2/d2-ui-file-menu": "^7.0.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -5,7 +5,7 @@
     "main": "./build/index.js",
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "~2.4.12",
+        "@dhis2/analytics": "~2.4.13",
         "@material-ui/core": "^3.1.2",
         "lodash-es": "^4.17.11",
         "react": "^16.6.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/data-visualizer-plugin",
-    "version": "33.1.12",
+    "version": "33.1.13",
     "description": "DHIS2 Data Visualizer plugin",
     "main": "./build/index.js",
     "license": "BSD-3-Clause",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -5,7 +5,7 @@
     "main": "./build/index.js",
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "~2.4.14",
+        "@dhis2/analytics": "~2.4.15",
         "@material-ui/core": "^3.1.2",
         "lodash-es": "^4.17.11",
         "react": "^16.6.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -5,7 +5,7 @@
     "main": "./build/index.js",
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "~2.4.13",
+        "@dhis2/analytics": "~2.4.14",
         "@material-ui/core": "^3.1.2",
         "lodash-es": "^4.17.11",
         "react": "^16.6.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/data-visualizer-plugin",
-    "version": "33.1.11",
+    "version": "33.1.12",
     "description": "DHIS2 Data Visualizer plugin",
     "main": "./build/index.js",
     "license": "BSD-3-Clause",

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,10 +164,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@~2.4.14":
-  version "2.4.14"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.14.tgz#423ba713507e195cdaef86009917ee4869a4208c"
-  integrity sha512-MwzbB7YAbsMo5c5ORxfUAgiOWjKVfFdTYg36VJCbnR1kUpKaguBYeZpe+DZDztEAfmFMnPQLDeIMl46/HCKc/A==
+"@dhis2/analytics@~2.4.15":
+  version "2.4.15"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.15.tgz#98fada63b9ce450c9c5bd448939d298e0d4aa831"
+  integrity sha512-3IECcaJDkvi9emJK44QagKplD2fRLND2inhOtXG17ntVQKczor9LAM98XPIUsuJ+bf76XpQ9lN0pK9rja6gkUQ==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.2"
     "@dhis2/ui-core" "^3.4.0"
@@ -209,7 +209,7 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/d2-ui-core@7.0.2", "@dhis2/d2-ui-core@^7.0.2":
+"@dhis2/d2-ui-core@7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.0.2.tgz#dd255d9fa071380a36fd8f2d6c30a649d52a73e2"
   integrity sha512-RHjaWeOcwm4nX6OM0vp9PnVHmCEsREMc8rLnFWrkrXZnOFO7rCybYEnHC7ZSXZjZaLyGec/dlXoQiDsFHT9aRA==
@@ -220,12 +220,23 @@
     material-ui "^0.20.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-favorites-dialog@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.0.2.tgz#c2f05ab2b321cee02e1cf2edd0572353bf91d8ca"
-  integrity sha512-TbN41ezmR6RkMoCKOHpbOIfSuLWew3d1OL/FtTqdNxho3ocz15XO6cjVdx67f1ww8pTfoPPEiOvUNPb/7nfKBw==
+"@dhis2/d2-ui-core@7.0.3", "@dhis2/d2-ui-core@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.0.3.tgz#75cf0bc7dfadfa6b000bcf61b17fb76f5efb7b1d"
+  integrity sha512-l2uFWjK8Te473B2p6wxaVi+gniN6bMGAMjX6t/qJKQtWMVK9wfF/tZmwWvypP8UlShMvn+MHSdLOZxQF2bINfg==
   dependencies:
-    "@dhis2/d2-ui-sharing-dialog" "7.0.2"
+    babel-runtime "^6.26.0"
+    d2 "~31.7"
+    lodash "^4.17.10"
+    material-ui "^0.20.0"
+    rxjs "^5.5.7"
+
+"@dhis2/d2-ui-favorites-dialog@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.0.3.tgz#561f3e9370c89da7e33ccb26850a7ace117a40e4"
+  integrity sha512-ptBJrhg4HN5/m/EFtV6VAcJHQyYUCB4OyIsy885p5QghZmL3mnRPLd5Vp9gRlqsPZn3Of1tjbWNQR7sJ4TDuQw==
+  dependencies:
+    "@dhis2/d2-ui-sharing-dialog" "7.0.3"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -235,26 +246,26 @@
     redux-logger "^3.0.6"
     redux-thunk "^2.2.0"
 
-"@dhis2/d2-ui-file-menu@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-file-menu/-/d2-ui-file-menu-7.0.2.tgz#d3af57c8c4281cdd9c47de37b59a55e2331d6a01"
-  integrity sha512-RcbJJME9FOWPoKhyiLKbrU591f31+5QF+IdFBYtFpirkCxY1f0Mp0gQ5duHfWKmw5D4DxjbEcfxmW4N7B1lhfQ==
+"@dhis2/d2-ui-file-menu@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-file-menu/-/d2-ui-file-menu-7.0.3.tgz#4c843dcf7b5201d3ba61d1efdde6eb95a66afd93"
+  integrity sha512-2KGI4b6MWsDXS0MeL4b77p4nXZsckkCS+nPYxm3NSoI32bxCFTtJ+2f3KOpFdKOO1yK3NGS7+hVpqirpdtpjzg==
   dependencies:
-    "@dhis2/d2-ui-favorites-dialog" "7.0.2"
-    "@dhis2/d2-ui-sharing-dialog" "7.0.2"
-    "@dhis2/d2-ui-translation-dialog" "7.0.2"
+    "@dhis2/d2-ui-favorites-dialog" "7.0.3"
+    "@dhis2/d2-ui-sharing-dialog" "7.0.3"
+    "@dhis2/d2-ui-translation-dialog" "7.0.3"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.6.0"
 
-"@dhis2/d2-ui-interpretations@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-interpretations/-/d2-ui-interpretations-7.0.2.tgz#9a9b594951fd161bf60d64943dab69a253731e8e"
-  integrity sha512-bNzltdgQlmFO8cOWfpEx5+Kga2/83dAvUwgCiXb0p4wmwFR/pERJwPJr6pCdqBXuG/tzL0G0iSBK+7EUGBNyDQ==
+"@dhis2/d2-ui-interpretations@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-interpretations/-/d2-ui-interpretations-7.0.3.tgz#b8d2099315e4140354193d18dda0ab7848385eb7"
+  integrity sha512-KiHb/Q5WKM2YuLH0fLQW3PpiX2rx3quGpTPoBHIEWruihZvo7cPqkZNTEn4YHR+8YmQ+Dcbeqh3n6NIjzkDe3Q==
   dependencies:
-    "@dhis2/d2-ui-mentions-wrapper" "7.0.2"
-    "@dhis2/d2-ui-rich-text" "7.0.2"
-    "@dhis2/d2-ui-sharing-dialog" "7.0.2"
+    "@dhis2/d2-ui-mentions-wrapper" "7.0.3"
+    "@dhis2/d2-ui-rich-text" "7.0.3"
+    "@dhis2/d2-ui-sharing-dialog" "7.0.3"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -264,10 +275,10 @@
     prop-types "^15.5.10"
     react-portal "^4.1.5"
 
-"@dhis2/d2-ui-mentions-wrapper@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-mentions-wrapper/-/d2-ui-mentions-wrapper-7.0.2.tgz#bdb883be77f37e0f7414b71970e01b0358899eb0"
-  integrity sha512-dO+uhSPF4rX8Q1vP8X0UCQ/w7n5PW5zvaRIiTE1JJgJYfOgqhCllWjYIzdXhz8NEiENLcLpqcHetjoSFtuq7NA==
+"@dhis2/d2-ui-mentions-wrapper@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-mentions-wrapper/-/d2-ui-mentions-wrapper-7.0.3.tgz#ea67c6a920cf015542b6acb50a1441142eb47b7f"
+  integrity sha512-hFxUYnub3p4DjsREKv4gZgrSi/NCfOOoIQT+DJOOj9ZwhVCGZPnOLgXamwdT2kBar9yFXy7AHppBYqwBGBKokQ==
   dependencies:
     "@material-ui/core" "^3.3.1"
     lodash "^4.17.10"
@@ -293,21 +304,21 @@
     babel-runtime "^6.26.0"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-rich-text@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.0.2.tgz#cf9eb9aeeff54304b8c4e67aaae10f220c6cd206"
-  integrity sha512-uLBsZ9KReIERksjXOmEPV43jrVcXBuOrAHcrv6lYY3zbuPS0e9n0V57zWk6qzdmAQKY8XEDSOjPVL77j+tPSyA==
+"@dhis2/d2-ui-rich-text@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.0.3.tgz#26c3e4ecf5dddfb3445476c56c87a62448ce229d"
+  integrity sha512-AiX6yf+AsYzSXjyXtuk7QtS/fx18vKcGvgFRaJvf7QV8HFxgkE2S8Owayj5mnTUFX6KFndTqjiXmsxn9jlKvhw==
   dependencies:
     babel-runtime "^6.26.0"
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/d2-ui-sharing-dialog@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.0.2.tgz#31a262ea5e091022739bad786af1ee1031590274"
-  integrity sha512-c5G0dwqNRz5m8MF56i6u1x8J+HjqxEj1Xj8Tkkhf9s8oOJcGOScijPBdOig1RrIUWJL+OTOXZEOVbjFbURRkcg==
+"@dhis2/d2-ui-sharing-dialog@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.0.3.tgz#585b6e20ce991517b83a4a30e770f7f74b29de8e"
+  integrity sha512-Q33Rp/csZPSyEeVj7ZjN9+GrPow1D4ghf23kFYJCMvvvXUhOjkImj49XTxfxEMQwPZ+BSmNTDJeQQzYy2jV/RA==
   dependencies:
-    "@dhis2/d2-ui-core" "7.0.2"
+    "@dhis2/d2-ui-core" "7.0.3"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -316,12 +327,12 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-translation-dialog@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.0.2.tgz#1623b01987bbf364e4a6b6de7cad628d6a76326a"
-  integrity sha512-MEQiFQLrIRZlYPo+xMyk48J+qRBoXQFVXIYqGu6mb3PiLRE56EvxFIiXU08wbcp8V3ujmfcLDrF5ofSJY18oFw==
+"@dhis2/d2-ui-translation-dialog@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.0.3.tgz#d018861b00c72f6e4fa759c6579385f300c9873c"
+  integrity sha512-da6Y6HUZI5O9A8P2rN2Kp5ESl0feqE/n5HNYk2WsyLoAg18LicYw/lBrOOfziFl2DPy44a741pEyy5U8J0PXMQ==
   dependencies:
-    "@dhis2/d2-ui-core" "7.0.2"
+    "@dhis2/d2-ui-core" "7.0.3"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,10 +164,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@~2.4.12":
-  version "2.4.12"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.12.tgz#2e27a8a8d63d3d2f7795d044bf69a9f96e76362c"
-  integrity sha512-YM0ckmWZAJTNFxY8RkZr3EsekGkVGFbzpWL5lB2F9iPOep8CdqKJOBcQfO5LwY57JExbAqaVh1mwJY+m2Li0oQ==
+"@dhis2/analytics@~2.4.13":
+  version "2.4.13"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.13.tgz#5fa7abce0497dfeb3bdff299a6ddb88749f1546d"
+  integrity sha512-HB/Ixc19Rk2fFUkIR39JmFUNvfxoIq6DR5k0XiPcxGyATamX+AuucZ28wsz3R2ao5Lu/kTzsGeetfQnGaFlhCw==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.2"
     "@dhis2/ui-core" "^3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,10 +164,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@~2.4.13":
-  version "2.4.13"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.13.tgz#5fa7abce0497dfeb3bdff299a6ddb88749f1546d"
-  integrity sha512-HB/Ixc19Rk2fFUkIR39JmFUNvfxoIq6DR5k0XiPcxGyATamX+AuucZ28wsz3R2ao5Lu/kTzsGeetfQnGaFlhCw==
+"@dhis2/analytics@~2.4.14":
+  version "2.4.14"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.4.14.tgz#423ba713507e195cdaef86009917ee4869a4208c"
+  integrity sha512-MwzbB7YAbsMo5c5ORxfUAgiOWjKVfFdTYg36VJCbnR1kUpKaguBYeZpe+DZDztEAfmFMnPQLDeIMl46/HCKc/A==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.2"
     "@dhis2/ui-core" "^3.4.0"


### PR DESCRIPTION
Part of fix for: https://jira.dhis2.org/browse/DHIS2-8638

Note: I already published data-visualizer-plugin v33.1.12 so dashboards could get it.

Finally, fully translated:

![image](https://user-images.githubusercontent.com/6113918/81881669-9e56eb80-9545-11ea-8f8c-f86d52f6bea1.png)
