### PR TITLE
feat: implement latest Period Selector from Analytics (DHIS2-8807)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^5.1.6",
+        "@dhis2/analytics": "^6.0.0",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.0.3",

--- a/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
@@ -267,7 +267,7 @@ export class DialogManager extends Component {
                 return (
                     <PeriodDimension
                         selectedPeriods={selectedItems}
-                        {...dimensionProps}
+                        onSelect={dimensionProps.onSelect}
                         // TODO infoBoxMessage should ideally be implemented for all dimensions
                     />
                 )

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^5.1.6",
+        "@dhis2/analytics": "^6.0.0",
         "@dhis2/ui-core": "^4.21.1",
         "d2-analysis": "33.2.15",
         "lodash-es": "^4.17.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1409,10 +1409,10 @@
     resize-observer-polyfill "^1.5.1"
     styled-jsx "^3.2.1"
 
-"@dhis2/analytics@^5.1.6":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-5.1.6.tgz#4ea54a8ac7f0f942c6e77b1343c400277952aeff"
-  integrity sha512-ivf3yYQ3w64IBMvXuxTjMU4/lbGWDXPyskVnkQp2XVn724S2feM1rZhyKwU4B5U+4MYR8xMMgTzU5tJ8mno4tQ==
+"@dhis2/analytics@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-6.0.0.tgz#bba037ee8d1c4b82c4d41adc226b6715498a0cb3"
+  integrity sha512-oExViPz/eV5VnKJsCY33TGUffpeU4u7JY2gJViMcXpVPXeCDkm6LqUjAM16T65gWI6+yCHgCsh6hpCtvPC54dg==
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.3"


### PR DESCRIPTION
Implements the [latest Analytics changes](https://github.com/dhis2/analytics/pull/452/) for [DHIS2-8807](https://jira.dhis2.org/browse/DHIS2-8807).

- Bumps the Analytics version to [v.6.0.0](https://github.com/dhis2/analytics/releases/tag/v6.0.0)
- Removes `onDeselect` and `onReorder` from the props passed to `PeriodDimension`

Please see the Analytics change for full details and spec.

-------------

![image](https://user-images.githubusercontent.com/12590483/83140732-d38b3e00-a0ee-11ea-97fd-75b039107d40.png)
