### PR TITLE
fix: yoy chart mismatch between layout years, and chart years

### DIFF
--- a/packages/app/src/modules/__tests__/yearOverYear.spec.js
+++ b/packages/app/src/modules/__tests__/yearOverYear.spec.js
@@ -1,9 +1,9 @@
 import { seriesOptions } from '../yearOverYear'
 
-const intVal = val => parseInt(val, 10)
 describe('yearOverYear', () => {
-    it('has matching year number and string', () => {
+    it('year has matching id and name', () => {
         const lastOption = seriesOptions[seriesOptions.length - 1]
+        console.log('lastOption', lastOption.id, lastOption.getName())
         expect(lastOption.id).toEqual(lastOption.getName())
     })
 
@@ -11,8 +11,8 @@ describe('yearOverYear', () => {
         const lastOption = seriesOptions[seriesOptions.length - 1]
         const secondLastOption = seriesOptions[seriesOptions.length - 2]
 
-        expect(intVal(lastOption.getName())).toEqual(
-            intVal(secondLastOption.getName()) - 1
+        expect(parseInt(lastOption.getName(), 10)).toEqual(
+            secondLastOption.getName() - 1
         )
     })
 })

--- a/packages/app/src/modules/__tests__/yearOverYear.spec.js
+++ b/packages/app/src/modules/__tests__/yearOverYear.spec.js
@@ -3,7 +3,6 @@ import { seriesOptions } from '../yearOverYear'
 describe('yearOverYear', () => {
     it('year has matching id and name', () => {
         const lastOption = seriesOptions[seriesOptions.length - 1]
-        console.log('lastOption', lastOption.id, lastOption.getName())
         expect(lastOption.id).toEqual(lastOption.getName())
     })
 

--- a/packages/app/src/modules/__tests__/yearOverYear.spec.js
+++ b/packages/app/src/modules/__tests__/yearOverYear.spec.js
@@ -1,0 +1,18 @@
+import { seriesOptions } from '../yearOverYear'
+
+const intVal = val => parseInt(val, 10)
+describe('yearOverYear', () => {
+    it('has matching year number and string', () => {
+        const lastOption = seriesOptions[seriesOptions.length - 1]
+        expect(lastOption.id).toEqual(lastOption.getName())
+    })
+
+    it('has sequential years', () => {
+        const lastOption = seriesOptions[seriesOptions.length - 1]
+        const secondLastOption = seriesOptions[seriesOptions.length - 2]
+
+        expect(intVal(lastOption.getName())).toEqual(
+            intVal(secondLastOption.getName()) - 1
+        )
+    })
+})

--- a/packages/app/src/modules/__tests__/yearOverYear.spec.js
+++ b/packages/app/src/modules/__tests__/yearOverYear.spec.js
@@ -11,7 +11,7 @@ describe('yearOverYear', () => {
         const secondLastOption = seriesOptions[seriesOptions.length - 2]
 
         expect(parseInt(lastOption.getName(), 10)).toEqual(
-            secondLastOption.getName() - 1
+            parseInt(secondLastOption.getName(), 10) - 1
         )
     })
 })

--- a/packages/app/src/modules/yearOverYear.js
+++ b/packages/app/src/modules/yearOverYear.js
@@ -4,8 +4,10 @@ import i18n from '@dhis2/d2-i18n'
 const getFixedYears = len => {
     let year = new Date().getFullYear()
     return new Array(len).fill(null).map(() => {
-        const yearString = String(year--)
-        return { id: String(year), getName: () => yearString }
+        const yearId = String(year)
+        const yearName = String(year)
+        --year
+        return { id: yearId, getName: () => yearName }
     })
 }
 

--- a/packages/app/src/modules/yearOverYear.js
+++ b/packages/app/src/modules/yearOverYear.js
@@ -4,10 +4,8 @@ import i18n from '@dhis2/d2-i18n'
 const getFixedYears = len => {
     let year = new Date().getFullYear()
     return new Array(len).fill(null).map(() => {
-        const yearId = String(year)
-        const yearName = String(year)
-        --year
-        return { id: yearId, getName: () => yearName }
+        const yearString = String(year--)
+        return { id: yearString, getName: () => yearString }
     })
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,27 +1443,7 @@
     semver "^6.3.0"
     yargs "^14.2.0"
 
-"@dhis2/d2-i18n-extract@^1.0.7":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-extract/-/d2-i18n-extract-1.0.8.tgz#9d98690d522a51895c8ef3fe7136f026b0f8dacd"
-  integrity sha512-wjQ5J0v8Td12+KcQYSuuZ1tQLReXJ1gBSqkyImf2aNtLwJKERaTOjZ71da+GXdHtd6ph/DP1ezQvFDFKhBHa/A==
-  dependencies:
-    argparse "^1.0.10"
-    i18next-conv "^6.0.0"
-    i18next-scanner "^2.4.4"
-
-"@dhis2/d2-i18n-generate@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-generate/-/d2-i18n-generate-1.1.1.tgz#e800fa39e85a71c23040b6378de1c9439f69fef7"
-  integrity sha512-akKFdEot0d38Yq51WlnflKYuQYMAYvHxDnQuOy3GVUDpmavnQec3wxQNdXbwy6FH9UUHO3kAJhlYL+slxEI+LQ==
-  dependencies:
-    argparse "^1.0.10"
-    handlebars "^4.0.11"
-    i18next-conv "^6.0.0"
-    moment "^2.22.1"
-    rimraf "^2.6.2"
-
-"@dhis2/d2-i18n@*", "@dhis2/d2-i18n@^1.0.3", "@dhis2/d2-i18n@^1.0.5":
+"@dhis2/d2-i18n@*", "@dhis2/d2-i18n@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.6.tgz#2914be8acf296f3a6bf7b51c76c46da6a120b0ff"
   integrity sha512-7YdA4ppFosjuyf7ZMm47BrdsA5TWLM9lmS0lUPgjcCVeeWfUgagqzf4W5JGB9XQ3w1vzK+yy5zH2Ij8IgRAGhA==


### PR DESCRIPTION
This bug is only on master and has not yet been released to play servers. So no Jira issue.

It was caused by decrementing the year after the function that gets the name, but before the function that gets the id.

P.S. A little yarn cleanup seems to have snuck into this PR when I ran a clean install.

Broken:
![image (1)](https://user-images.githubusercontent.com/6113918/84171519-c09e3500-aa2f-11ea-83ca-f431b712602c.png)


Fixed:

![image](https://user-images.githubusercontent.com/6113918/84171338-8fbe0000-aa2f-11ea-8813-1f44bdfce820.png)
