### PR TITLE
fix: fix paging query parameter passed to data engine

### DIFF
--- a/packages/app/src/components/VisualizationOptions/Options/ApprovalLevel.js
+++ b/packages/app/src/components/VisualizationOptions/Options/ApprovalLevel.js
@@ -23,7 +23,7 @@ const query = {
         params: {
             order: 'level:asc',
             fields: 'id,displayName~rename(name),level',
-            paging: false,
+            paging: 'false',
         },
     },
 }

--- a/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
@@ -20,7 +20,7 @@ const query = {
                 'displayName~rename(name)',
                 'legends[id,displayName~rename(name),startValue,endValue,color]',
             ],
-            paging: false,
+            paging: 'false',
         },
     },
 }


### PR DESCRIPTION
The query parameter value must be a string.

Support for booleans is eventually going to be added to DataEngine.
See: https://github.com/dhis2/app-runtime/issues/578.