### PR TITLE
chore: set cwd to find the build folder (34.x)

### DIFF
--- a/.github/workflows/dhis2-artifacts.yml
+++ b/.github/workflows/dhis2-artifacts.yml
@@ -29,5 +29,6 @@ jobs:
 
             - uses: dhis2/deploy-build@master
               with:
+                  cwd: ./packages/app
                   build-dir: build/app
                   github-token: ${{ env.GH_TOKEN }}


### PR DESCRIPTION
Sets `cwd` to point at the monorepo app package.