### PR TITLE
chore: set app version (33.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
     },
     "workspaces": [
         "packages/*"
-    ]
+    ],
+    "version": "33.1.13"
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-visualizer-app",
-    "version": "33.0.0",
+    "version": "33.1.13",
     "description": "DHIS2 Data Visualizer app",
     "license": "BSD-3-Clause",
     "private": true,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-visualizer-app",
-    "version": "32.0.2",
+    "version": "33.0.0",
     "description": "DHIS2 Data Visualizer app",
     "license": "BSD-3-Clause",
     "private": true,


### PR DESCRIPTION
Sets app version to 33.0.0 to solve semantic release issue. Also sets a version on the repo package.json.