### PR TITLE
fix: avoid unnecessary plugin call (TECH-412)

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -58,7 +58,7 @@ const ChartPlugin = ({
     }, [visualization, responses, extraOptions])
 
     useEffect(() => {
-        renderVisualization(0)
+        renderCounter !== null && renderVisualization(0)
 
         /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, [renderCounter, style])


### PR DESCRIPTION
Make sure `renderVisualization` is not run twice on mount.