### PR TITLE
fix: set visualization type selector z-index (DHIS2-8643)

### DIFF
--- a/packages/app/src/components/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
+++ b/packages/app/src/components/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
@@ -4,6 +4,7 @@
     height: 100%;
     top: 0;
     left: 0;
+    z-index: 110;
 }
 
 .button {


### PR DESCRIPTION
Fixes [DHIS2-8643](https://jira.dhis2.org/browse/DHIS2-8643)

The visualization type selector (aka VTS, the menu accessed by the button in the top left corner) used to be hidden behind the visualization loading spinner because of an incorrect z-index. The VTS z-index has been bumped to 110 (loading spinner backdrop is set to 100) to prevent this from happening.

![image](https://user-images.githubusercontent.com/12590483/87964336-5ced3a00-caba-11ea-8b16-70f4fe0efb3f.png)
