### PR TITLE
fix: reorder options for consistency (DHIS2-9004)

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-06-02T04:24:38.833Z\n"
-"PO-Revision-Date: 2020-06-02T04:24:38.833Z\n"
+"POT-Creation-Date: 2020-07-21T09:20:20.828Z\n"
+"PO-Revision-Date: 2020-07-21T09:20:20.828Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -739,6 +739,12 @@ msgstr ""
 msgid "Data"
 msgstr ""
 
+msgid "Display"
+msgstr ""
+
+msgid "Lines"
+msgstr ""
+
 msgid "Axes"
 msgstr ""
 
@@ -749,12 +755,6 @@ msgid "Horizontal (x) axis"
 msgstr ""
 
 msgid "Style"
-msgstr ""
-
-msgid "Display"
-msgstr ""
-
-msgid "Lines"
 msgstr ""
 
 msgid "Chart style"

--- a/packages/app/src/modules/options/areaConfig.js
+++ b/packages/app/src/modules/options/areaConfig.js
@@ -18,9 +18,7 @@ import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeA
 import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
-import Title from '../../components/VisualizationOptions/Options/Title'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
-import Subtitle from '../../components/VisualizationOptions/Options/Subtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
@@ -29,23 +27,31 @@ export default [
         getLabel: () => i18n.t('Data'),
         content: [
             {
-                key: 'data-section-1',
+                key: 'data-display',
+                getLabel: () => i18n.t('Display'),
                 content: React.Children.toArray([
-                    <ShowData />,
                     <PercentStackedValues />,
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
+                    <SortOrder />,
+                ]),
+            },
+            {
+                key: 'data-lines',
+                getLabel: () => i18n.t('Lines'),
+                content: React.Children.toArray([
                     <RegressionType />,
                     <TargetLine />,
                     <BaseLine />,
-                    <SortOrder />,
-                    <AggregationType />,
                 ]),
             },
             {
                 key: 'data-advanced',
                 getLabel: () => i18n.t('Advanced'),
-                content: React.Children.toArray([<CompletedOnly />]),
+                content: React.Children.toArray([
+                    <CompletedOnly />,
+                    <AggregationType />,
+                ]),
             },
         ],
     },
@@ -55,7 +61,7 @@ export default [
         content: [
             {
                 key: 'axes-vertical-axis',
-                label: i18n.t('Vertical (y) axis'),
+                getLabel: () => i18n.t('Vertical (y) axis'),
                 content: React.Children.toArray([
                     <RangeAxisLabel />,
                     <AxisRange />,
@@ -65,7 +71,7 @@ export default [
             },
             {
                 key: 'axes-horizontal-axis',
-                label: i18n.t('Horizontal (x) axis'),
+                getLabel: () => i18n.t('Horizontal (x) axis'),
                 content: React.Children.toArray([<DomainAxisLabel />]),
             },
         ],
@@ -75,12 +81,15 @@ export default [
         getLabel: () => i18n.t('Style'),
         content: [
             {
-                key: 'style-section-1',
+                key: 'style-chart-style',
+                getLabel: () => i18n.t('Chart style'),
+                content: React.Children.toArray([<ShowData />, <HideLegend />]),
+            },
+            {
+                key: 'style-titles',
+                getLabel: () => i18n.t('Titles'),
                 content: React.Children.toArray([
-                    <HideLegend />,
-                    <Title />,
                     <HideTitle />,
-                    <Subtitle />,
                     <HideSubtitle />,
                 ]),
             },

--- a/packages/app/src/modules/options/areaConfig.js
+++ b/packages/app/src/modules/options/areaConfig.js
@@ -49,8 +49,8 @@ export default [
                 key: 'data-advanced',
                 getLabel: () => i18n.t('Advanced'),
                 content: React.Children.toArray([
-                    <CompletedOnly />,
                     <AggregationType />,
+                    <CompletedOnly />,
                 ]),
             },
         ],

--- a/packages/app/src/modules/options/lineConfig.js
+++ b/packages/app/src/modules/options/lineConfig.js
@@ -17,9 +17,7 @@ import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeA
 import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
-import Title from '../../components/VisualizationOptions/Options/Title'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
-import Subtitle from '../../components/VisualizationOptions/Options/Subtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
@@ -28,22 +26,30 @@ export default [
         getLabel: () => i18n.t('Data'),
         content: [
             {
-                key: 'data-section-1',
+                key: 'data-display',
+                getLabel: () => i18n.t('Display'),
                 content: React.Children.toArray([
-                    <ShowData />,
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
+                    <SortOrder />,
+                ]),
+            },
+            {
+                key: 'data-lines',
+                getLabel: () => i18n.t('Lines'),
+                content: React.Children.toArray([
                     <RegressionType />,
                     <TargetLine />,
                     <BaseLine />,
-                    <SortOrder />,
-                    <AggregationType />,
                 ]),
             },
             {
                 key: 'data-advanced',
                 getLabel: () => i18n.t('Advanced'),
-                content: React.Children.toArray([<CompletedOnly />]),
+                content: React.Children.toArray([
+                    <CompletedOnly />,
+                    <AggregationType />,
+                ]),
             },
         ],
     },
@@ -53,7 +59,7 @@ export default [
         content: [
             {
                 key: 'axes-vertical-axis',
-                label: i18n.t('Vertical (y) axis'),
+                getLabel: () => i18n.t('Vertical (y) axis'),
                 content: React.Children.toArray([
                     <RangeAxisLabel />,
                     <AxisRange />,
@@ -63,7 +69,7 @@ export default [
             },
             {
                 key: 'axes-horizontal-axis',
-                label: i18n.t('Horizontal (x) axis'),
+                getLabel: () => i18n.t('Horizontal (x) axis'),
                 content: React.Children.toArray([<DomainAxisLabel />]),
             },
         ],
@@ -73,12 +79,15 @@ export default [
         getLabel: () => i18n.t('Style'),
         content: [
             {
-                key: 'style-section-1',
+                key: 'style-chart-style',
+                getLabel: () => i18n.t('Chart style'),
+                content: React.Children.toArray([<ShowData />, <HideLegend />]),
+            },
+            {
+                key: 'style-titles',
+                getLabel: () => i18n.t('Titles'),
                 content: React.Children.toArray([
-                    <HideLegend />,
-                    <Title />,
                     <HideTitle />,
-                    <Subtitle />,
                     <HideSubtitle />,
                 ]),
             },

--- a/packages/app/src/modules/options/lineConfig.js
+++ b/packages/app/src/modules/options/lineConfig.js
@@ -47,8 +47,8 @@ export default [
                 key: 'data-advanced',
                 getLabel: () => i18n.t('Advanced'),
                 content: React.Children.toArray([
-                    <CompletedOnly />,
                     <AggregationType />,
+                    <CompletedOnly />,
                 ]),
             },
         ],

--- a/packages/app/src/modules/options/stackedColumnConfig.js
+++ b/packages/app/src/modules/options/stackedColumnConfig.js
@@ -31,7 +31,6 @@ export default [
                 key: 'data-display',
                 getLabel: () => i18n.t('Display'),
                 content: React.Children.toArray([
-                    <ShowData />,
                     <PercentStackedValues />,
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
@@ -86,6 +85,7 @@ export default [
                 key: 'style-chart-style',
                 getLabel: () => i18n.t('Chart style'),
                 content: React.Children.toArray([
+                    <ShowData />,
                     <NoSpaceBetweenColumns />,
                     <HideLegend />,
                     /* TODO new option <BackgroundLines /> */


### PR DESCRIPTION
Fixes [DHIS2-9004](https://jira.dhis2.org/browse/DHIS2-9004)

Available options vary between vis types based on different configs ([spec](https://docs.google.com/spreadsheets/d/1XJxLoC7IAT5S3Pi7cUkKZoAAm4Rztx9aVNkiqGfirnU/edit#gid=0)), however the order of these options should be kept consistent to make it easy to find a certain option, regardless of which vis type is used. Using the `columnConfig` as a template, the other configs are now organised in a similar pattern.

- Removes two incorrect fields in `Style` tab and adds missing section titles (`areaConfig`, `lineConfig`), as per [DHIS2-9004](https://jira.dhis2.org/browse/DHIS2-9004)
- Moves `ShowData` from `Data` to `Style` (`areaConfig`, `lineConfig`, `stackedColumnConfig`)
- Adds missing section splitting in the `Data` tab (`areaConfig`, `lineConfig`)
- Changes the `label` const to instead use the `getLabel` function (`areaConfig`, `lineConfig`)

-----------

original `columnConfig` (reference)

![image](https://user-images.githubusercontent.com/12590483/88039049-61136900-cb47-11ea-85ea-961e7c84ff39.png)

![image](https://user-images.githubusercontent.com/12590483/88039081-68d30d80-cb47-11ea-97ed-9021cd5a20fa.png)

![image](https://user-images.githubusercontent.com/12590483/88039096-6d97c180-cb47-11ea-87c5-658a2363e289.png)

-----------

updated `lineConfig`

![image](https://user-images.githubusercontent.com/12590483/88039127-78eaed00-cb47-11ea-994c-b1e564329729.png)

![image](https://user-images.githubusercontent.com/12590483/88039153-7ee0ce00-cb47-11ea-9adb-7cf023a3710f.png)

![image](https://user-images.githubusercontent.com/12590483/88039181-87d19f80-cb47-11ea-9b60-b1df60bd8265.png)

-----------

updated `areaConfig`

![image](https://user-images.githubusercontent.com/12590483/88039225-9324cb00-cb47-11ea-9e7a-53f178b41b7d.png)

![image](https://user-images.githubusercontent.com/12590483/88039246-991aac00-cb47-11ea-9fd5-f26dd1a4f29b.png)

![image](https://user-images.githubusercontent.com/12590483/88039271-9f108d00-cb47-11ea-90d6-7dda8e42293e.png)
