### PR TITLE
fix: fix stuck tooltips in dimension chips DHIS2-9063

### DIFF
--- a/packages/app/src/components/Layout/Chip.js
+++ b/packages/app/src/components/Layout/Chip.js
@@ -141,18 +141,22 @@ const Chip = ({
     }
 
     return (
-        <Tooltip content={renderTooltipContent()} placement="bottom">
-            {({ ref, onMouseOver, onMouseOut }) => (
-                <div
-                    style={getWrapperStyles()}
-                    data-dimensionid={dimensionId}
-                    draggable={!isLocked()}
-                    onDragStart={getDragStartHandler()}
-                    ref={ref}
-                    onMouseOver={onMouseOver}
-                    onMouseOut={onMouseOut}
-                >
-                    <div id={id} style={styles.chipLeft} onClick={handleClick}>
+        <div
+            style={getWrapperStyles()}
+            data-dimensionid={dimensionId}
+            draggable={!isLocked()}
+            onDragStart={getDragStartHandler()}
+        >
+            <Tooltip content={renderTooltipContent()} placement="bottom">
+                {({ ref, onMouseOver, onMouseOut }) => (
+                    <div
+                        id={id}
+                        style={styles.chipLeft}
+                        onClick={handleClick}
+                        ref={ref}
+                        onMouseOver={onMouseOver}
+                        onMouseOut={onMouseOut}
+                    >
                         <div style={styles.iconWrapper}>{renderChipIcon()}</div>
                         <span style={styles.label}>{dimensionName}</span>
                         <span>{renderChipLabelSuffix()}</span>
@@ -160,10 +164,10 @@ const Chip = ({
                             WarningIconWrapper}
                         {isLocked() && LockIconWrapper}
                     </div>
-                    {!isLocked() && renderMenu()}
-                </div>
-            )}
-        </Tooltip>
+                )}
+            </Tooltip>
+            {!isLocked() && renderMenu()}
+        </div>
     )
 }
 


### PR DESCRIPTION
The tooltip is now only surrounding the dimension icon and label, so the
3-dotted menu is not interfering with the click/timeout handling of the
tooltip.

Fixes: https://jira.dhis2.org/browse/DHIS2-9063.

Fixed version:
![ezgif com-optimize](https://user-images.githubusercontent.com/150978/88551211-e785ea00-d022-11ea-826e-77e50cb49e12.gif)
