### PR TITLE
feat: support for two category charts [DHIS2-7876]

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^8.5.0",
+        "@dhis2/analytics": "^8.6.0",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.0.4",

--- a/packages/app/src/modules/__tests__/layout.spec.js
+++ b/packages/app/src/modules/__tests__/layout.spec.js
@@ -13,7 +13,7 @@ describe('layout', () => {
                 xyz: { axisId: 'rows' },
             }
 
-            expect(getRetransfer(layout, transfer, 'COLUMN')).toMatchObject({
+            expect(getRetransfer(layout, transfer, 'LINE')).toMatchObject({
                 pe: {
                     axisId: 'filters',
                 },
@@ -25,7 +25,7 @@ describe('layout', () => {
                 abc: { axisId: 'rows' },
             }
 
-            expect(getRetransfer(layout, transfer, 'COLUMN')).toMatchObject({
+            expect(getRetransfer(layout, transfer, 'LINE')).toMatchObject({
                 pe: {
                     axisId: 'filters',
                 },

--- a/packages/app/src/modules/__tests__/layout.spec.js
+++ b/packages/app/src/modules/__tests__/layout.spec.js
@@ -13,7 +13,7 @@ describe('layout', () => {
                 xyz: { axisId: 'rows' },
             }
 
-            expect(getRetransfer(layout, transfer, 'LINE')).toMatchObject({
+            expect(getRetransfer(layout, transfer, 'RADAR')).toMatchObject({
                 pe: {
                     axisId: 'filters',
                 },
@@ -25,7 +25,7 @@ describe('layout', () => {
                 abc: { axisId: 'rows' },
             }
 
-            expect(getRetransfer(layout, transfer, 'LINE')).toMatchObject({
+            expect(getRetransfer(layout, transfer, 'RADAR')).toMatchObject({
                 pe: {
                     axisId: 'filters',
                 },

--- a/packages/app/src/modules/__tests__/layoutAdapters.spec.js
+++ b/packages/app/src/modules/__tests__/layoutAdapters.spec.js
@@ -9,6 +9,7 @@ import {
 
 import {
     defaultLayoutAdapter,
+    dualCategoryLayoutAdapter,
     pieLayoutAdapter,
     yearOverYearLayoutAdapter,
 } from '../layoutAdapters'
@@ -39,6 +40,26 @@ describe('defaultLayoutAdapter', () => {
                 otherId,
                 someId,
             ],
+        }
+
+        expect(actualState).toEqual(expectedState)
+    })
+})
+
+describe('dualCategoryLayoutAdapter', () => {
+    it('should keep the 2nd category in rows and move the others to filters (if any),', () => {
+        const initialState = {
+            [AXIS_ID_COLUMNS]: [DIMENSION_ID_DATA],
+            [AXIS_ID_ROWS]: [DIMENSION_ID_PERIOD, otherId, someId],
+            [AXIS_ID_FILTERS]: [DIMENSION_ID_ORGUNIT],
+        }
+
+        const actualState = dualCategoryLayoutAdapter(initialState)
+
+        const expectedState = {
+            [AXIS_ID_COLUMNS]: [DIMENSION_ID_DATA],
+            [AXIS_ID_ROWS]: [DIMENSION_ID_PERIOD, otherId],
+            [AXIS_ID_FILTERS]: [DIMENSION_ID_ORGUNIT, someId],
         }
 
         expect(actualState).toEqual(expectedState)

--- a/packages/app/src/modules/layoutAdapters.js
+++ b/packages/app/src/modules/layoutAdapters.js
@@ -18,6 +18,19 @@ export const defaultLayoutAdapter = layout => {
     }
 }
 
+// Transform from ui.layout to dual category layout format
+export const dualCategoryLayoutAdapter = layout => {
+    const columns = layout[AXIS_ID_COLUMNS].slice()
+    const rows = layout[AXIS_ID_ROWS].slice()
+
+    return {
+        [AXIS_ID_COLUMNS]: columns.length ? [columns.shift()] : columns,
+        [AXIS_ID_ROWS]:
+            rows.length > 2 ? rows.splice(0, 2) : rows.splice(0, rows.length),
+        [AXIS_ID_FILTERS]: [...layout[AXIS_ID_FILTERS], ...columns, ...rows],
+    }
+}
+
 // Transform from ui.layout to pie layout format
 export const pieLayoutAdapter = layout => {
     const columns = layout[AXIS_ID_COLUMNS].slice()

--- a/packages/app/src/modules/ui.js
+++ b/packages/app/src/modules/ui.js
@@ -11,6 +11,7 @@ import {
     VIS_TYPE_PIVOT_TABLE,
     defaultVisType,
     isYearOverYear,
+    isDualCategoryChartType,
 } from '@dhis2/analytics'
 
 import { getInverseLayout } from './layout'
@@ -18,6 +19,7 @@ import { getOptionsFromVisualization } from './options'
 import { BASE_FIELD_YEARLY_SERIES } from './fields/baseFields'
 import {
     defaultLayoutAdapter,
+    dualCategoryLayoutAdapter,
     pieLayoutAdapter,
     yearOverYearLayoutAdapter,
     singleValueLayoutAdapter,
@@ -50,6 +52,12 @@ export const defaultUiAdapter = ui => ({
     layout: defaultLayoutAdapter(ui.layout),
 })
 
+// Transform from store.ui to dual category format
+export const dualCategoryUiAdapter = ui => ({
+    ...ui,
+    layout: dualCategoryLayoutAdapter(ui.layout),
+})
+
 // Transform from store.ui to pie format
 export const pieUiAdapter = ui => ({
     ...ui,
@@ -76,6 +84,10 @@ export const singleValueUiAdapter = ui => ({
 })
 
 export const getAdaptedUiByType = ui => {
+    if (isDualCategoryChartType(ui.type) && ui.layout.rows.length > 1) {
+        return dualCategoryUiAdapter(ui)
+    }
+
     switch (ui.type) {
         case VIS_TYPE_YEAR_OVER_YEAR_LINE:
         case VIS_TYPE_YEAR_OVER_YEAR_COLUMN: {

--- a/packages/app/src/modules/ui.js
+++ b/packages/app/src/modules/ui.js
@@ -11,7 +11,7 @@ import {
     VIS_TYPE_PIVOT_TABLE,
     defaultVisType,
     isYearOverYear,
-    isDualCategoryChartType,
+    isTwoCategoryChartType,
 } from '@dhis2/analytics'
 
 import { getInverseLayout } from './layout'
@@ -84,7 +84,7 @@ export const singleValueUiAdapter = ui => ({
 })
 
 export const getAdaptedUiByType = ui => {
-    if (isDualCategoryChartType(ui.type) && ui.layout.rows.length > 1) {
+    if (isTwoCategoryChartType(ui.type) && ui.layout.rows.length > 1) {
         return dualCategoryUiAdapter(ui)
     }
 

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -6,6 +6,7 @@ import {
     AXIS_ID_ROWS,
     AXIS_ID_FILTERS,
     VIS_TYPE_COLUMN,
+    VIS_TYPE_LINE,
     VIS_TYPE_BAR,
 } from '@dhis2/analytics'
 
@@ -156,7 +157,7 @@ describe('reducer: ui', () => {
 
     it(`${ui.ADD_UI_LAYOUT_DIMENSIONS}: should swap layout dimensions`, () => {
         const state = {
-            type: VIS_TYPE_COLUMN,
+            type: VIS_TYPE_LINE,
             layout: {
                 columns: [DIMENSION_ID_DATA],
                 rows: [DIMENSION_ID_PERIOD],

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -6,7 +6,7 @@ import {
     AXIS_ID_ROWS,
     AXIS_ID_FILTERS,
     VIS_TYPE_COLUMN,
-    VIS_TYPE_LINE,
+    VIS_TYPE_RADAR,
     VIS_TYPE_BAR,
 } from '@dhis2/analytics'
 
@@ -157,7 +157,7 @@ describe('reducer: ui', () => {
 
     it(`${ui.ADD_UI_LAYOUT_DIMENSIONS}: should swap layout dimensions`, () => {
         const state = {
-            type: VIS_TYPE_LINE,
+            type: VIS_TYPE_RADAR,
             layout: {
                 columns: [DIMENSION_ID_DATA],
                 rows: [DIMENSION_ID_PERIOD],

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^8.5.0",
+        "@dhis2/analytics": "^8.6.0",
         "@dhis2/ui": "^5.3.2",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,10 +1524,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-8.5.0.tgz#2469f935940cc908fbcf5fa4fcbff0bd570775dc"
-  integrity sha512-owcCSJG3MBjsTRMCKQoszNBUVbaW9R6+bIkgbkjumS4PD1IsHrF8ThUxFmm/fC6liIokHo2x/3wFZrsqFzC5tw==
+"@dhis2/analytics@^8.6.0":
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-8.6.0.tgz#9b28b898ff033a01dde081fd25066c1d0c23893c"
+  integrity sha512-1KgYsFm75AJrNtAdUsa6vlQBTr7jpi+l0F2LNz5lXVRQM6S5tONBWkRAp4z49aeqlSNxZtpF3r3u9G2qy8CxSQ==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.4"
     "@dhis2/ui" "^5.3.0"


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-7876.

Most of the inplementation is in the analytics dependency, see: https://github.com/dhis2/analytics/pull/508.

The DV app needs to correctly configure the `ui.layout`object when loading an AO saved with 2 categories, otherwise the default layout adapter moves all dimensions besides the first from `rows` to `filters`.