### PR TITLE
feat: implement colorSet option (DHIS2-670)

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-03T14:19:51.289Z\n"
-"PO-Revision-Date: 2020-08-03T14:19:51.289Z\n"
+"POT-Creation-Date: 2020-08-07T09:47:19.443Z\n"
+"PO-Revision-Date: 2020-08-07T09:47:19.443Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -281,6 +281,27 @@ msgid "Column sub-totals"
 msgstr ""
 
 msgid "Columns totals"
+msgstr ""
+
+msgid "Default"
+msgstr ""
+
+msgid "Bright"
+msgstr ""
+
+msgid "Dark"
+msgstr ""
+
+msgid "Gray"
+msgstr ""
+
+msgid "Color blind"
+msgstr ""
+
+msgid "Mono patterns"
+msgstr ""
+
+msgid "Color sets are not supported yet when using multiple axes"
 msgstr ""
 
 msgid "Event data"
@@ -771,6 +792,9 @@ msgid "Lines"
 msgstr ""
 
 msgid "Vertical (y) axis"
+msgstr ""
+
+msgid "Color set"
 msgstr ""
 
 msgid "Display totals"

--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-07T09:47:19.443Z\n"
-"PO-Revision-Date: 2020-08-07T09:47:19.443Z\n"
+"POT-Creation-Date: 2020-08-12T08:23:07.514Z\n"
+"PO-Revision-Date: 2020-08-12T08:23:07.514Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -299,9 +299,6 @@ msgid "Color blind"
 msgstr ""
 
 msgid "Mono patterns"
-msgstr ""
-
-msgid "Color sets are not supported yet when using multiple axes"
 msgstr ""
 
 msgid "Event data"
@@ -794,9 +791,6 @@ msgstr ""
 msgid "Vertical (y) axis"
 msgstr ""
 
-msgid "Color set"
-msgstr ""
-
 msgid "Display totals"
 msgstr ""
 
@@ -816,6 +810,12 @@ msgid "Limit minimum/maximum values"
 msgstr ""
 
 msgid "Parameters"
+msgstr ""
+
+msgid "Color set"
+msgstr ""
+
+msgid "Color sets are not supported yet when using multiple axes"
 msgstr ""
 
 msgid "Lines are not supported yet when using multiple axes"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^8.4.0",
+        "@dhis2/analytics": "^8.5.0",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.0.4",

--- a/packages/app/src/components/VisualizationOptions/Options/ColorSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/ColorSet.js
@@ -1,0 +1,117 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+import i18n from '@dhis2/d2-i18n'
+import { Field, Radio } from '@dhis2/ui'
+import {
+    colorSets,
+    COLOR_SET_DEFAULT,
+    COLOR_SET_BRIGHT,
+    COLOR_SET_DARK,
+    COLOR_SET_GRAY,
+    COLOR_SET_COLOR_BLIND,
+    COLOR_SET_MONO_PATTERNS,
+} from '@dhis2/analytics'
+
+import { sGetUiOptions } from '../../../reducers/ui'
+import { acSetUiOptions } from '../../../actions/ui'
+
+import { tabSectionOption } from '../styles/VisualizationOptions.style.js'
+
+export const COLOR_SET_OPTION_NAME = 'colorSet'
+
+const ColorSet = ({ value, onChange, disabled }) => (
+    <div className={tabSectionOption.className}>
+        <Field name="colorSet-selector" dense>
+            {[
+                [
+                    {
+                        id: COLOR_SET_DEFAULT,
+                        label: i18n.t('Default'),
+                    },
+                    {
+                        id: COLOR_SET_BRIGHT,
+                        label: i18n.t('Bright'),
+                    },
+                    {
+                        id: COLOR_SET_DARK,
+                        label: i18n.t('Dark'),
+                    },
+                    {
+                        id: COLOR_SET_GRAY,
+                        label: i18n.t('Gray'),
+                    },
+                    {
+                        id: COLOR_SET_COLOR_BLIND,
+                        label: i18n.t('Color blind'),
+                    },
+                ].map(({ id, label }) => (
+                    <span key={id}>
+                        <Radio
+                            label={
+                                <>
+                                    {label}
+                                    <ColorSetPreview
+                                        id={id}
+                                        disabled={disabled}
+                                    />
+                                </>
+                            }
+                            value={id}
+                            dense
+                            onChange={onChange}
+                            checked={value === id}
+                            disabled={disabled}
+                        />
+                    </span>
+                )),
+                <span key={COLOR_SET_MONO_PATTERNS}>
+                    <Radio
+                        label={i18n.t('Mono patterns')}
+                        value={COLOR_SET_MONO_PATTERNS}
+                        dense
+                        onChange={onChange}
+                        checked={value === COLOR_SET_MONO_PATTERNS}
+                        disabled={disabled}
+                    />
+                </span>,
+            ]}
+        </Field>
+    </div>
+)
+
+ColorSet.propTypes = {
+    value: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
+}
+
+const ColorSetPreview = ({ id, disabled }) => (
+    <div
+        style={{ display: 'flex', marginLeft: 4, opacity: disabled ? 0.3 : 1 }}
+    >
+        {colorSets[id].colors.map(color => (
+            <div
+                key={color}
+                style={{ backgroundColor: color, width: 14, height: 14 }}
+            ></div>
+        ))}
+    </div>
+)
+
+ColorSetPreview.propTypes = {
+    id: PropTypes.string.isRequired,
+    disabled: PropTypes.bool,
+}
+
+const mapStateToProps = state => ({
+    value: sGetUiOptions(state)[COLOR_SET_OPTION_NAME],
+})
+
+const mapDispatchToProps = dispatch => ({
+    onChange: colorSet =>
+        dispatch(acSetUiOptions({ [COLOR_SET_OPTION_NAME]: colorSet })),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(ColorSet)

--- a/packages/app/src/components/VisualizationOptions/Options/ColorSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/ColorSet.js
@@ -46,6 +46,10 @@ const ColorSet = ({ value, onChange, disabled }) => (
                         id: COLOR_SET_COLOR_BLIND,
                         label: i18n.t('Color blind'),
                     },
+                    {
+                        id: COLOR_SET_MONO_PATTERNS,
+                        label: i18n.t('Mono patterns'),
+                    },
                 ].map(({ id, label }) => (
                     <span key={id}>
                         <Radio
@@ -53,29 +57,19 @@ const ColorSet = ({ value, onChange, disabled }) => (
                                 <>
                                     {label}
                                     <ColorSetPreview
-                                        id={id}
+                                        colorSet={colorSets[id]}
                                         disabled={disabled}
                                     />
                                 </>
                             }
                             value={id}
                             dense
-                            onChange={onChange}
+                            onChange={({ value }) => onChange(value)}
                             checked={value === id}
                             disabled={disabled}
                         />
                     </span>
                 )),
-                <span key={COLOR_SET_MONO_PATTERNS}>
-                    <Radio
-                        label={i18n.t('Mono patterns')}
-                        value={COLOR_SET_MONO_PATTERNS}
-                        dense
-                        onChange={onChange}
-                        checked={value === COLOR_SET_MONO_PATTERNS}
-                        disabled={disabled}
-                    />
-                </span>,
             ]}
         </Field>
     </div>
@@ -87,21 +81,39 @@ ColorSet.propTypes = {
     disabled: PropTypes.bool,
 }
 
-const ColorSetPreview = ({ id, disabled }) => (
+const ColorSetPreview = ({ colorSet, disabled }) => (
     <div
         style={{ display: 'flex', marginLeft: 4, opacity: disabled ? 0.3 : 1 }}
     >
-        {colorSets[id].colors.map(color => (
-            <div
-                key={color}
-                style={{ backgroundColor: color, width: 14, height: 14 }}
-            ></div>
-        ))}
+        {colorSet?.patterns &&
+            colorSet.patterns.map((pattern, index) => (
+                <div key={`pattern-${index}`}>
+                    <svg
+                        width={14}
+                        height={14}
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            d={pattern.path}
+                            stroke={pattern.color}
+                            strokeWidth={2}
+                            fill="none"
+                        />
+                    </svg>
+                </div>
+            ))}
+        {colorSet?.colors &&
+            colorSet.colors.map(color => (
+                <div
+                    key={color}
+                    style={{ backgroundColor: color, width: 14, height: 14 }}
+                />
+            ))}
     </div>
 )
 
 ColorSetPreview.propTypes = {
-    id: PropTypes.string.isRequired,
+    colorSet: PropTypes.object.isRequired,
     disabled: PropTypes.bool,
 }
 

--- a/packages/app/src/components/VisualizationOptions/Options/RadioBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RadioBaseOption.js
@@ -7,7 +7,13 @@ import { Field, Radio } from '@dhis2/ui'
 import { sGetUiOptions } from '../../../reducers/ui'
 import { acSetUiOptions } from '../../../actions/ui'
 
-export const RadioBaseOption = ({ option, label, value, onChange }) => (
+export const RadioBaseOption = ({
+    option,
+    label,
+    value,
+    onChange,
+    disabled,
+}) => (
     <Field name={option.name} label={label} dense>
         {option.items.map(({ id, label }) => (
             <Radio
@@ -16,6 +22,7 @@ export const RadioBaseOption = ({ option, label, value, onChange }) => (
                 value={id}
                 checked={value === id}
                 onChange={({ value }) => onChange(value)}
+                disabled={disabled}
             />
         ))}
     </Field>
@@ -25,6 +32,7 @@ RadioBaseOption.propTypes = {
     option: PropTypes.object.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
     label: PropTypes.string,
 }
 

--- a/packages/app/src/modules/options.js
+++ b/packages/app/src/modules/options.js
@@ -1,5 +1,7 @@
 import pick from 'lodash-es/pick'
 
+import { COLOR_SET_DEFAULT } from '@dhis2/analytics'
+
 export const options = {
     baseLineLabel: {
         defaultValue: undefined,
@@ -11,7 +13,11 @@ export const options = {
         requestable: false,
         savable: true,
     },
-    // colorSet:
+    colorSet: {
+        defaultValue: COLOR_SET_DEFAULT,
+        requestable: false,
+        savable: true,
+    },
     cumulativeValues: {
         defaultValue: false,
         requestable: false,

--- a/packages/app/src/modules/options/areaConfig.js
+++ b/packages/app/src/modules/options/areaConfig.js
@@ -16,6 +16,7 @@ import CompletedOnly from '../../components/VisualizationOptions/Options/Complet
 import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
 import getLinesSection from './sections/lines'
 import getVerticalAxisSection from './sections/verticalAxis'
+import getColorSetSection from './sections/colorSet'
 
 export default hasCustomAxes => [
     {
@@ -82,6 +83,7 @@ export default hasCustomAxes => [
                     <HideSubtitle />,
                 ]),
             },
+            getColorSetSection(hasCustomAxes),
         ],
     },
 ]

--- a/packages/app/src/modules/options/barConfig.js
+++ b/packages/app/src/modules/options/barConfig.js
@@ -16,6 +16,7 @@ import CompletedOnly from '../../components/VisualizationOptions/Options/Complet
 import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
 import getLinesSection from './sections/lines'
 import getVerticalAxisSection from './sections/verticalAxis'
+import getColorSetSection from './sections/colorSet'
 
 export default hasCustomAxes => [
     {
@@ -88,6 +89,7 @@ export default hasCustomAxes => [
                     <HideSubtitle />,
                 ]),
             },
+            getColorSetSection(hasCustomAxes),
         ],
     },
 ]

--- a/packages/app/src/modules/options/columnConfig.js
+++ b/packages/app/src/modules/options/columnConfig.js
@@ -16,6 +16,7 @@ import CompletedOnly from '../../components/VisualizationOptions/Options/Complet
 import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
 import getLinesSection from './sections/lines'
 import getVerticalAxisSection from './sections/verticalAxis'
+import getColorSetSection from './sections/colorSet'
 
 export default hasCustomAxes => [
     {
@@ -91,6 +92,7 @@ export default hasCustomAxes => [
                     <HideSubtitle />,
                 ]),
             },
+            getColorSetSection(hasCustomAxes),
         ],
     },
 ]

--- a/packages/app/src/modules/options/lineConfig.js
+++ b/packages/app/src/modules/options/lineConfig.js
@@ -15,6 +15,7 @@ import CompletedOnly from '../../components/VisualizationOptions/Options/Complet
 import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
 import getLinesSection from './sections/lines'
 import getVerticalAxisSection from './sections/verticalAxis'
+import getColorSetSection from './sections/colorSet'
 
 export default hasCustomAxes => [
     {
@@ -85,6 +86,7 @@ export default hasCustomAxes => [
                     <HideSubtitle />,
                 ]),
             },
+            getColorSetSection(hasCustomAxes),
         ],
     },
 ]

--- a/packages/app/src/modules/options/pieConfig.js
+++ b/packages/app/src/modules/options/pieConfig.js
@@ -7,6 +7,7 @@ import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
+import getColorSetSection from './sections/colorSet'
 
 export default () => [
     {
@@ -45,6 +46,7 @@ export default () => [
                     <HideSubtitle />,
                 ]),
             },
+            getColorSetSection(),
         ],
     },
 ]

--- a/packages/app/src/modules/options/sections/colorSet.js
+++ b/packages/app/src/modules/options/sections/colorSet.js
@@ -1,0 +1,14 @@
+/* eslint-disable react/jsx-key */
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+
+import ColorSet from '../../../components/VisualizationOptions/Options/ColorSet'
+
+export default hasCustomAxes => ({
+    key: 'style-color-set',
+    getLabel: () => i18n.t('Color set'),
+    helpText: hasCustomAxes
+        ? i18n.t('Color sets are not supported yet when using multiple axes')
+        : null,
+    content: React.Children.toArray([<ColorSet disabled={hasCustomAxes} />]),
+})

--- a/packages/app/src/modules/options/sections/colorSet.js
+++ b/packages/app/src/modules/options/sections/colorSet.js
@@ -6,7 +6,7 @@ import ColorSet from '../../../components/VisualizationOptions/Options/ColorSet'
 
 export default hasCustomAxes => ({
     key: 'style-color-set',
-    getLabel: () => i18n.t('Color set'),
+    label: i18n.t('Color set'),
     helpText: hasCustomAxes
         ? i18n.t('Color sets are not supported yet when using multiple axes')
         : null,

--- a/packages/app/src/modules/options/stackedColumnConfig.js
+++ b/packages/app/src/modules/options/stackedColumnConfig.js
@@ -17,6 +17,7 @@ import CompletedOnly from '../../components/VisualizationOptions/Options/Complet
 import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
 import getLinesSection from './sections/lines'
 import getVerticalAxisSection from './sections/verticalAxis'
+import getColorSetSection from './sections/colorSet'
 
 export default hasCustomAxes => [
     {
@@ -88,6 +89,7 @@ export default hasCustomAxes => [
                     <HideSubtitle />,
                 ]),
             },
+            getColorSetSection(hasCustomAxes),
         ],
     },
 ]

--- a/packages/app/src/modules/options/yearOverYearConfig.js
+++ b/packages/app/src/modules/options/yearOverYearConfig.js
@@ -16,6 +16,7 @@ import CompletedOnly from '../../components/VisualizationOptions/Options/Complet
 import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
 import getLinesSection from './sections/lines'
 import getVerticalAxisSection from './sections/verticalAxis'
+import getColorSetSection from './sections/colorSet'
 
 export default hasCustomAxes => [
     {
@@ -86,6 +87,7 @@ export default hasCustomAxes => [
                     <HideSubtitle />,
                 ]),
             },
+            getColorSetSection(hasCustomAxes),
         ],
     },
 ]

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^8.4.0",
+        "@dhis2/analytics": "^8.5.0",
         "@dhis2/ui": "^5.3.2",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,10 +1524,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^8.4.0":
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-8.4.0.tgz#6940cf1db190eb10bc452cff5e2e0470751d7625"
-  integrity sha512-OZza4wflahLSYK+2KjbJT2eJDIds/ERpQCDyCbDKanNK01LsEFVzS8bBXPpI9Ng9AFWlKi6HQewHYxrSeV0hvA==
+"@dhis2/analytics@^8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-8.5.0.tgz#2469f935940cc908fbcf5fa4fcbff0bd570775dc"
+  integrity sha512-owcCSJG3MBjsTRMCKQoszNBUVbaW9R6+bIkgbkjumS4PD1IsHrF8ThUxFmm/fC6liIokHo2x/3wFZrsqFzC5tw==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.4"
     "@dhis2/ui" "^5.3.0"


### PR DESCRIPTION
Part of the implementation for https://jira.dhis2.org/browse/DHIS2-670

Requires https://github.com/dhis2/analytics/pull/531

The PR adds a new option for `colorSet`.
It renders a radio selector with a list of available color sets (see screenshot).

Screenshots
![Screenshot 2020-08-11 at 08 45 59](https://user-images.githubusercontent.com/150978/89866030-1ff2ff80-dbaf-11ea-826d-5c8c986d0554.png)

The option is disabled when multiple axes are used
![Screenshot 2020-08-11 at 08 47 39](https://user-images.githubusercontent.com/150978/89866154-5a5c9c80-dbaf-11ea-896d-7a2df11c9224.png)


Things to complete:
* ~preview for the Mono patterns~: done using the patterns from Highcharts directly

