### PR TITLE
fix: option configs for various vis types

### DIFF
--- a/packages/app/src/modules/options/areaConfig.js
+++ b/packages/app/src/modules/options/areaConfig.js
@@ -3,7 +3,6 @@ import React from 'react'
 import i18n from '@dhis2/d2-i18n'
 
 import CumulativeValues from '../../components/VisualizationOptions/Options/CumulativeValues'
-import PercentStackedValues from '../../components/VisualizationOptions/Options/PercentStackedValues'
 import ShowData from '../../components/VisualizationOptions/Options/ShowData'
 import HideEmptyRowItems from '../../components/VisualizationOptions/Options/HideEmptyRowItems'
 import SortOrder from '../../components/VisualizationOptions/Options/SortOrder'
@@ -27,7 +26,6 @@ export default hasCustomAxes => [
                 key: 'data-display',
                 label: i18n.t('Display'),
                 content: React.Children.toArray([
-                    <PercentStackedValues />,
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
                     <SortOrder />,
@@ -62,7 +60,9 @@ export default hasCustomAxes => [
         content: [
             {
                 key: 'series-table',
-                content: React.Children.toArray([<SeriesTable />]),
+                content: React.Children.toArray([
+                    <SeriesTable showAxisOptions={true} />,
+                ]),
             },
         ],
     },

--- a/packages/app/src/modules/options/config.js
+++ b/packages/app/src/modules/options/config.js
@@ -20,11 +20,13 @@ import columnConfig from './columnConfig'
 import stackedColumnConfig from './stackedColumnConfig'
 import lineConfig from './lineConfig'
 import areaConfig from './areaConfig'
+import stackedAreaConfig from './stackedAreaConfig'
 import pieConfig from './pieConfig'
 import gaugeConfig from './gaugeConfig'
 import singleValueConfig from './singleValueConfig'
 import barConfig from './barConfig'
 import yearOverYearConfig from './yearOverYearConfig'
+import radarConfig from './radarConfig'
 
 export const getOptionsByType = (type, hasCustomAxes) => {
     switch (type) {
@@ -39,11 +41,13 @@ export const getOptionsByType = (type, hasCustomAxes) => {
         case VIS_TYPE_STACKED_BAR:
             return stackedColumnConfig(hasCustomAxes)
         case VIS_TYPE_LINE:
-        case VIS_TYPE_RADAR:
             return lineConfig(hasCustomAxes)
+        case VIS_TYPE_RADAR:
+            return radarConfig(hasCustomAxes)
         case VIS_TYPE_AREA:
-        case VIS_TYPE_STACKED_AREA:
             return areaConfig(hasCustomAxes)
+        case VIS_TYPE_STACKED_AREA:
+            return stackedAreaConfig(hasCustomAxes)
         case VIS_TYPE_GAUGE:
             return gaugeConfig(hasCustomAxes)
         case VIS_TYPE_PIE:

--- a/packages/app/src/modules/options/radarConfig.js
+++ b/packages/app/src/modules/options/radarConfig.js
@@ -1,0 +1,87 @@
+/* eslint-disable react/jsx-key */
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+
+import CumulativeValues from '../../components/VisualizationOptions/Options/CumulativeValues'
+import ShowData from '../../components/VisualizationOptions/Options/ShowData'
+import HideEmptyRowItems from '../../components/VisualizationOptions/Options/HideEmptyRowItems'
+import SortOrder from '../../components/VisualizationOptions/Options/SortOrder'
+import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
+import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
+import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
+import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
+import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
+import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
+import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
+import getLinesSection from './sections/lines'
+import getVerticalAxisSection from './sections/verticalAxis'
+import getColorSetSection from './sections/colorSet'
+
+export default hasCustomAxes => [
+    {
+        key: 'data-tab',
+        label: i18n.t('Data'),
+        content: [
+            {
+                key: 'data-display',
+                label: i18n.t('Display'),
+                content: React.Children.toArray([
+                    <CumulativeValues />,
+                    <HideEmptyRowItems />,
+                    <SortOrder />,
+                ]),
+            },
+            getLinesSection(hasCustomAxes),
+            {
+                key: 'data-advanced',
+                label: i18n.t('Advanced'),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
+            },
+        ],
+    },
+    {
+        key: 'axes-tab',
+        label: i18n.t('Axes'),
+        content: [
+            getVerticalAxisSection(hasCustomAxes),
+            {
+                key: 'axes-horizontal-axis',
+                label: i18n.t('Horizontal (x) axis'),
+                content: React.Children.toArray([<DomainAxisLabel />]),
+            },
+        ],
+    },
+    {
+        key: 'series-tab',
+        label: i18n.t('Series'),
+        content: [
+            {
+                key: 'series-table',
+                content: React.Children.toArray([<SeriesTable />]),
+            },
+        ],
+    },
+    {
+        key: 'style-tab',
+        label: i18n.t('Style'),
+        content: [
+            {
+                key: 'style-chart-style',
+                label: i18n.t('Chart style'),
+                content: React.Children.toArray([<ShowData />, <HideLegend />]),
+            },
+            {
+                key: 'style-titles',
+                label: i18n.t('Titles'),
+                content: React.Children.toArray([
+                    <HideTitle />,
+                    <HideSubtitle />,
+                ]),
+            },
+            getColorSetSection(hasCustomAxes),
+        ],
+    },
+]

--- a/packages/app/src/modules/options/stackedAreaConfig.js
+++ b/packages/app/src/modules/options/stackedAreaConfig.js
@@ -1,0 +1,89 @@
+/* eslint-disable react/jsx-key */
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+
+import CumulativeValues from '../../components/VisualizationOptions/Options/CumulativeValues'
+import PercentStackedValues from '../../components/VisualizationOptions/Options/PercentStackedValues'
+import ShowData from '../../components/VisualizationOptions/Options/ShowData'
+import HideEmptyRowItems from '../../components/VisualizationOptions/Options/HideEmptyRowItems'
+import SortOrder from '../../components/VisualizationOptions/Options/SortOrder'
+import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
+import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
+import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
+import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
+import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
+import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
+import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
+import getLinesSection from './sections/lines'
+import getVerticalAxisSection from './sections/verticalAxis'
+import getColorSetSection from './sections/colorSet'
+
+export default hasCustomAxes => [
+    {
+        key: 'data-tab',
+        label: i18n.t('Data'),
+        content: [
+            {
+                key: 'data-display',
+                label: i18n.t('Display'),
+                content: React.Children.toArray([
+                    <PercentStackedValues />,
+                    <CumulativeValues />,
+                    <HideEmptyRowItems />,
+                    <SortOrder />,
+                ]),
+            },
+            getLinesSection(hasCustomAxes),
+            {
+                key: 'data-advanced',
+                label: i18n.t('Advanced'),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
+            },
+        ],
+    },
+    {
+        key: 'axes-tab',
+        label: i18n.t('Axes'),
+        content: [
+            getVerticalAxisSection(hasCustomAxes),
+            {
+                key: 'axes-horizontal-axis',
+                label: i18n.t('Horizontal (x) axis'),
+                content: React.Children.toArray([<DomainAxisLabel />]),
+            },
+        ],
+    },
+    {
+        key: 'series-tab',
+        label: i18n.t('Series'),
+        content: [
+            {
+                key: 'series-table',
+                content: React.Children.toArray([<SeriesTable />]),
+            },
+        ],
+    },
+    {
+        key: 'style-tab',
+        label: i18n.t('Style'),
+        content: [
+            {
+                key: 'style-chart-style',
+                label: i18n.t('Chart style'),
+                content: React.Children.toArray([<ShowData />, <HideLegend />]),
+            },
+            {
+                key: 'style-titles',
+                label: i18n.t('Titles'),
+                content: React.Children.toArray([
+                    <HideTitle />,
+                    <HideSubtitle />,
+                ]),
+            },
+            getColorSetSection(hasCustomAxes),
+        ],
+    },
+]

--- a/packages/plugin/src/modules/options.js
+++ b/packages/plugin/src/modules/options.js
@@ -1,5 +1,7 @@
 import pick from 'lodash-es/pick'
 
+import { COLOR_SET_DEFAULT } from '@dhis2/analytics'
+
 export const options = {
     baseLineLabel: {
         defaultValue: undefined,
@@ -11,7 +13,11 @@ export const options = {
         requestable: false,
         savable: true,
     },
-    // colorSet:
+    colorSet: {
+        defaultValue: COLOR_SET_DEFAULT,
+        requestable: false,
+        savable: true,
+    },
     cumulativeValues: {
         defaultValue: false,
         requestable: false,


### PR DESCRIPTION
Fixes [DHIS2-9011](https://jira.dhis2.org/browse/DHIS2-9011).

Requires [@dhis2/analytics PR 550](https://github.com/dhis2/analytics/pull/550).

Specifically:
- remove the "Stacked values add up to 100%" option for Area
![Screenshot 2020-08-14 at 15 49 33](https://user-images.githubusercontent.com/150978/90256260-c5270580-de45-11ea-93a9-7ede24544608.png)

- add the same option to Stacked area
![Screenshot 2020-08-14 at 15 47 15](https://user-images.githubusercontent.com/150978/90256119-85601e00-de45-11ea-9b65-5d99b1009de1.png)

- enable multi axis in Series for Area
![Screenshot 2020-08-14 at 15 48 53](https://user-images.githubusercontent.com/150978/90256218-b0e30880-de45-11ea-8410-476635d96387.png)

- disable multi axis in Series for Stacked area and Radar
![Screenshot 2020-08-14 at 15 51 45](https://user-images.githubusercontent.com/150978/90256472-17682680-de46-11ea-950a-bdd7c1997d90.png)
![Screenshot 2020-08-14 at 15 50 23](https://user-images.githubusercontent.com/150978/90256347-e4259780-de45-11ea-9a44-a43c0e9fc703.png)
