### PR TITLE
feat: handle 404 (DHIS2-9273)

### DIFF
--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -27,7 +27,10 @@ import history from '../modules/history'
 import { getVisualizationFromCurrent } from '../modules/visualization'
 import { convertOuLevelsToUids } from '../modules/orgUnit'
 import { apiPostDataStatistics } from '../api/dataStatistics'
-import { GenericServerError } from '../modules/error'
+import {
+    GenericServerError,
+    VisualizationNotFoundError,
+} from '../modules/error'
 
 export {
     fromVisualization,
@@ -85,12 +88,13 @@ export const tDoLoadVisualization = ({
     } catch (errorResponse) {
         let error = errorResponse
 
-        if (errorResponse && errorResponse.message) {
+        if (errorResponse?.details?.httpStatusCode === 404) {
+            error = new VisualizationNotFoundError()
+        } else if (errorResponse?.message) {
             error = errorResponse.message
         } else {
             error = new GenericServerError()
         }
-
         clearVisualization(dispatch, getState, error)
 
         logError('tDoLoadVisualization', error)

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -162,7 +162,7 @@ export class App extends Component {
                 !isSaving
             ) {
                 this.setState({ locationToConfirm: location })
-            } else {
+            } else if (!location || location.pathname !== '/') {
                 this.setState({ locationToConfirm: null })
                 this.loadVisualization(location)
             }

--- a/packages/app/src/modules/error.js
+++ b/packages/app/src/modules/error.js
@@ -246,6 +246,18 @@ export class AssignedCategoriesAsFilterError extends VisualizationError {
     }
 }
 
+export class VisualizationNotFoundError extends VisualizationError {
+    constructor() {
+        super(
+            GenericError,
+            i18n.t('Visualization not found'),
+            i18n.t(
+                'The visualization you are trying to view could not be found, the ID could be incorrect or it could have been deleted.'
+            )
+        )
+    }
+}
+
 export const genericErrorTitle = i18n.t('Something went wrong')
 
 const getAvailableAxesDescription = visType => {


### PR DESCRIPTION
Implements [DHIS2-9273](https://jira.dhis2.org/browse/DHIS2-9273)

This change implements a catch for 404 errors to display a proper custom error message, rather than the default message.

Also handles a bug where the Update button can't be used after a 404 error has been caught. Instead of updating the visualization, the Update button redirected the user to the start page with a blank (default) AO.

![image](https://user-images.githubusercontent.com/12590483/90641399-7c9a8e00-e231-11ea-9d1b-3072b1edd13b.png)
