### PR TITLE
fix: rename and invert the hide legend option (#1152) (DHIS2-9003) v34

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -366,7 +366,7 @@ msgstr ""
 msgid "Hide empty rows"
 msgstr ""
 
-msgid "Legend key"
+msgid "Show legend key"
 msgstr ""
 
 msgid "Table subtitle"

--- a/packages/app/src/components/VisualizationOptions/Options/CheckboxBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/CheckboxBaseOption.js
@@ -9,19 +9,26 @@ import { acSetUiOptions } from '../../../actions/ui'
 
 import { tabSectionOption } from '../styles/VisualizationOptions.style.js'
 
-export const CheckboxBaseOption = ({ option, label, value, onChange }) => (
+export const CheckboxBaseOption = ({
+    option,
+    label,
+    value,
+    onChange,
+    inverted,
+}) => (
     <div className={tabSectionOption.className}>
         <Checkbox
-            checked={value}
+            checked={inverted ? !value : value}
             label={label}
             name={option.name}
-            onChange={({ checked }) => onChange(checked)}
+            onChange={({ checked }) => onChange(inverted ? !checked : checked)}
             dense
         />
     </div>
 )
 
 CheckboxBaseOption.propTypes = {
+    inverted: PropTypes.bool,
     label: PropTypes.string,
     option: PropTypes.object,
     value: PropTypes.bool,

--- a/packages/app/src/components/VisualizationOptions/Options/HideLegend.js
+++ b/packages/app/src/components/VisualizationOptions/Options/HideLegend.js
@@ -6,10 +6,11 @@ import CheckboxBaseOption from './CheckboxBaseOption'
 
 const HideLegend = () => (
     <CheckboxBaseOption
-        label={i18n.t('Legend key')}
+        label={i18n.t('Show legend key')}
         option={{
             name: 'hideLegend',
         }}
+        inverted={true}
     />
 )
 


### PR DESCRIPTION
Backport of https://github.com/dhis2/data-visualizer-app/pull/1152 to 34.x

* Changes the title of the hideLegend option to a positive case (show).
* As the backend option is a negative case (hide), CheckboxBaseOption now has an inverted prop to flip the checked state.