### PR TITLE
fix: Decimals and Steps options only allow positive values (DHIS2-9002, DHIS2-9194) (#1161) v34

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -464,7 +464,9 @@ msgstr ""
 msgid "Auto"
 msgstr ""
 
-msgid "The number of axis steps between the min and max values"
+msgid ""
+"Number of axis tick steps, including the min and max. A value of 2 or lower "
+"will be ignored."
 msgstr ""
 
 msgid "Steps"

--- a/packages/app/src/components/VisualizationOptions/Options/PositiveNumberBaseType.js
+++ b/packages/app/src/components/VisualizationOptions/Options/PositiveNumberBaseType.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { InputField } from '@dhis2/ui'
+
+import { sGetUiOptions } from '../../../reducers/ui'
+import { acSetUiOptions } from '../../../actions/ui'
+import { tabSectionOption } from '../styles/VisualizationOptions.style.js'
+
+export const PositiveNumberBaseType = ({
+    label,
+    placeholder,
+    helpText,
+    width,
+    option,
+    value,
+    onChange,
+    disabled,
+}) => (
+    <div className={tabSectionOption.className}>
+        <div>
+            <InputField
+                type="number"
+                label={label}
+                onChange={({ value }) => {
+                    const parsedValue = parseInt(value, 10)
+                    parsedValue >= 0
+                        ? onChange(Math.round(value))
+                        : onChange(parsedValue ? 0 : null)
+                }}
+                name={option.name}
+                value={value || value === 0 ? value.toString() : ''}
+                helpText={helpText}
+                placeholder={placeholder}
+                inputWidth={width}
+                dense
+                disabled={disabled}
+            />
+        </div>
+    </div>
+)
+
+PositiveNumberBaseType.propTypes = {
+    disabled: PropTypes.bool,
+    helpText: PropTypes.string,
+    label: PropTypes.string,
+    option: PropTypes.object,
+    placeholder: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    width: PropTypes.string,
+    onChange: PropTypes.func,
+}
+
+const mapStateToProps = (state, ownProps) => ({
+    value: sGetUiOptions(state)[ownProps.option.name],
+    enabled: sGetUiOptions(state)[ownProps.option.name] !== undefined,
+})
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+    onChange: value =>
+        dispatch(acSetUiOptions({ [ownProps.option.name]: value })),
+})
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(PositiveNumberBaseType)

--- a/packages/app/src/components/VisualizationOptions/Options/PositiveNumberBaseType.js
+++ b/packages/app/src/components/VisualizationOptions/Options/PositiveNumberBaseType.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { InputField } from '@dhis2/ui'
+import { InputField } from '@dhis2/ui-core'
 
 import { sGetUiOptions } from '../../../reducers/ui'
 import { acSetUiOptions } from '../../../actions/ui'

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisDecimals.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisDecimals.js
@@ -2,11 +2,10 @@ import React from 'react'
 
 import i18n from '@dhis2/d2-i18n'
 
-import TextBaseOption from './TextBaseOption'
+import PositiveNumberBaseType from './PositiveNumberBaseType'
 
 const RangeAxisDecimals = () => (
-    <TextBaseOption
-        type="number"
+    <PositiveNumberBaseType
         width="96px"
         label={i18n.t('Decimals')}
         placeholder={i18n.t('Auto')}

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisSteps.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisSteps.js
@@ -2,14 +2,13 @@ import React from 'react'
 
 import i18n from '@dhis2/d2-i18n'
 
-import TextBaseOption from './TextBaseOption'
+import PositiveNumberBaseType from './PositiveNumberBaseType'
 
 export const RangeAxisSteps = () => (
-    <TextBaseOption
-        type="number"
+    <PositiveNumberBaseType
         width="96px"
         helpText={i18n.t(
-            'The number of axis steps between the min and max values'
+            'Number of axis tick steps, including the min and max. A value of 2 or lower will be ignored.'
         )}
         label={i18n.t('Steps')}
         placeholder={i18n.t('Auto')}


### PR DESCRIPTION
Backport of https://github.com/dhis2/data-visualizer-app/pull/1161 for v34

Had to change `ui` to `ui-core`, since v34 is using an older version of this library.

* New base type PositiveNumberBaseType added that only allows positive whole numbers
* Math.round prevents decimal numbers and returns Number instead of String, which fixes DHIS2-9194
* parseInt(value, 10) to allow for clearing the value with backspace
* Applies to both typing manually and by using the browser's built-in "stepper arrows".
* New help text for Steps, as per Slack discussion, Number of axis tick steps, including the min and max. A value of 2 or lower will be ignored.