### PR TITLE
fix: reorder options for consistency (DHIS2-9004) (519b0ba) v34

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-25T18:22:35.064Z\n"
-"PO-Revision-Date: 2020-05-25T18:22:35.064Z\n"
+"POT-Creation-Date: 2020-08-21T09:51:29.294Z\n"
+"PO-Revision-Date: 2020-08-21T09:51:29.294Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -733,22 +733,22 @@ msgstr ""
 msgid "Data"
 msgstr ""
 
-msgid "Axes"
-msgstr ""
-
-msgid "Style"
-msgstr ""
-
 msgid "Display"
 msgstr ""
 
 msgid "Lines"
 msgstr ""
 
+msgid "Axes"
+msgstr ""
+
 msgid "Vertical (y) axis"
 msgstr ""
 
 msgid "Horizontal (x) axis"
+msgstr ""
+
+msgid "Style"
 msgstr ""
 
 msgid "Chart style"

--- a/packages/app/src/modules/options/areaConfig.js
+++ b/packages/app/src/modules/options/areaConfig.js
@@ -19,9 +19,7 @@ import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeA
 import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
-import Title from '../../components/VisualizationOptions/Options/Title'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
-import Subtitle from '../../components/VisualizationOptions/Options/Subtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
@@ -30,23 +28,31 @@ export default [
         getLabel: () => i18n.t('Data'),
         content: [
             {
-                key: 'data-section-1',
+                key: 'data-display',
+                getLabel: () => i18n.t('Display'),
                 content: React.Children.toArray([
-                    <ShowData />,
                     <PercentStackedValues />,
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
+                    <SortOrder />,
+                ]),
+            },
+            {
+                key: 'data-lines',
+                getLabel: () => i18n.t('Lines'),
+                content: React.Children.toArray([
                     <RegressionType />,
                     <TargetLine />,
                     <BaseLine />,
-                    <SortOrder />,
-                    <AggregationType />,
                 ]),
             },
             {
                 key: 'data-advanced',
                 getLabel: () => i18n.t('Advanced'),
-                content: React.Children.toArray([<CompletedOnly />]),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
             },
         ],
     },
@@ -55,7 +61,8 @@ export default [
         getLabel: () => i18n.t('Axes'),
         content: [
             {
-                key: 'axes-section-1',
+                key: 'axes-vertical-axis',
+                getLabel: () => i18n.t('Vertical (y) axis'),
                 content: React.Children.toArray([
                     <RangeAxisMinValue />,
                     <RangeAxisMaxValue />,
@@ -65,6 +72,11 @@ export default [
                     <DomainAxisLabel />,
                 ]),
             },
+            {
+                key: 'axes-horizontal-axis',
+                getLabel: () => i18n.t('Horizontal (x) axis'),
+                content: React.Children.toArray([<DomainAxisLabel />]),
+            },
         ],
     },
     {
@@ -72,12 +84,15 @@ export default [
         getLabel: () => i18n.t('Style'),
         content: [
             {
-                key: 'style-section-1',
+                key: 'style-chart-style',
+                getLabel: () => i18n.t('Chart style'),
+                content: React.Children.toArray([<ShowData />, <HideLegend />]),
+            },
+            {
+                key: 'style-titles',
+                getLabel: () => i18n.t('Titles'),
                 content: React.Children.toArray([
-                    <HideLegend />,
-                    <Title />,
                     <HideTitle />,
-                    <Subtitle />,
                     <HideSubtitle />,
                 ]),
             },

--- a/packages/app/src/modules/options/lineConfig.js
+++ b/packages/app/src/modules/options/lineConfig.js
@@ -18,9 +18,7 @@ import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeA
 import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
-import Title from '../../components/VisualizationOptions/Options/Title'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
-import Subtitle from '../../components/VisualizationOptions/Options/Subtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
 export default [
@@ -29,22 +27,30 @@ export default [
         getLabel: () => i18n.t('Data'),
         content: [
             {
-                key: 'data-section-1',
+                key: 'data-display',
+                getLabel: () => i18n.t('Display'),
                 content: React.Children.toArray([
-                    <ShowData />,
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
+                    <SortOrder />,
+                ]),
+            },
+            {
+                key: 'data-lines',
+                getLabel: () => i18n.t('Lines'),
+                content: React.Children.toArray([
                     <RegressionType />,
                     <TargetLine />,
                     <BaseLine />,
-                    <SortOrder />,
-                    <AggregationType />,
                 ]),
             },
             {
                 key: 'data-advanced',
                 getLabel: () => i18n.t('Advanced'),
-                content: React.Children.toArray([<CompletedOnly />]),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
             },
         ],
     },
@@ -53,7 +59,8 @@ export default [
         getLabel: () => i18n.t('Axes'),
         content: [
             {
-                key: 'axes-section-1',
+                key: 'axes-vertical-axis',
+                getLabel: () => i18n.t('Vertical (y) axis'),
                 content: React.Children.toArray([
                     <RangeAxisMinValue />,
                     <RangeAxisMaxValue />,
@@ -63,6 +70,11 @@ export default [
                     <DomainAxisLabel />,
                 ]),
             },
+            {
+                key: 'axes-horizontal-axis',
+                getLabel: () => i18n.t('Horizontal (x) axis'),
+                content: React.Children.toArray([<DomainAxisLabel />]),
+            },
         ],
     },
     {
@@ -70,12 +82,15 @@ export default [
         getLabel: () => i18n.t('Style'),
         content: [
             {
-                key: 'style-section-1',
+                key: 'style-chart-style',
+                getLabel: () => i18n.t('Chart style'),
+                content: React.Children.toArray([<ShowData />, <HideLegend />]),
+            },
+            {
+                key: 'style-titles',
+                getLabel: () => i18n.t('Titles'),
                 content: React.Children.toArray([
-                    <HideLegend />,
-                    <Title />,
                     <HideTitle />,
-                    <Subtitle />,
                     <HideSubtitle />,
                 ]),
             },

--- a/packages/app/src/modules/options/stackedColumnConfig.js
+++ b/packages/app/src/modules/options/stackedColumnConfig.js
@@ -31,7 +31,6 @@ export default [
                 key: 'data-display',
                 getLabel: () => i18n.t('Display'),
                 content: React.Children.toArray([
-                    <ShowData />,
                     <PercentStackedValues />,
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
@@ -86,6 +85,7 @@ export default [
                 key: 'style-chart-style',
                 getLabel: () => i18n.t('Chart style'),
                 content: React.Children.toArray([
+                    <ShowData />,
                     <NoSpaceBetweenColumns />,
                     <HideLegend />,
                     /* TODO new option <BackgroundLines /> */


### PR DESCRIPTION
Backport https://github.com/dhis2/data-visualizer-app/pull/1153 for v34

Regenerated the pot file in a separate commit.

* Removes two incorrect fields in Style tab and adds missing section titles (areaConfig, lineConfig), as per DHIS2-9004
* Moves ShowData from Data to Style (areaConfig, lineConfig, stackedColumnConfig)
* Adds missing section splitting in the Data tab (areaConfig, lineConfig)
* Changes the label const to instead use the getLabel function (areaConfig, lineConfig)