### PR TITLE
fix: pass y-axis steps as number (DHIS2-9194) v33

### DIFF
--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -18,7 +18,13 @@ export const TextBaseOption = ({
         disabled={!enabled}
         type={type}
         label={option.label}
-        onChange={event => onChange(event.target.value)}
+        onChange={event =>
+            onChange(
+                type === 'number'
+                    ? parseInt(event.target.value, 10)
+                    : event.target.value
+            )
+        }
         value={value}
         helperText={option.helperText}
     />


### PR DESCRIPTION
Manual backport of [DHIS2-9194](https://jira.dhis2.org/browse/DHIS2-9194) to v33
The 34 and 35 solution couldn't be cherry-picked as it contained changes not compatible for 33.
However the fix for this issue is simply passing the steps value as a number instead of a string. As mentioned by @janhenrikoverland  here: [comment](https://jira.dhis2.org/browse/DHIS2-9194?focusedCommentId=34665&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-34665)