### PR TITLE
fix: disable lines and vertical axis options for multi axes (DHIS2-9010, DHIS2-9013, DHIS2-9014) (#1171) v34

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-25T18:22:35.064Z\n"
-"PO-Revision-Date: 2020-05-25T18:22:35.064Z\n"
+"POT-Creation-Date: 2020-08-24T11:15:11.138Z\n"
+"PO-Revision-Date: 2020-08-24T11:15:11.138Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -733,28 +733,28 @@ msgstr ""
 msgid "Data"
 msgstr ""
 
-msgid "Axes"
-msgstr ""
-
-msgid "Style"
-msgstr ""
-
 msgid "Display"
 msgstr ""
 
-msgid "Lines"
-msgstr ""
-
-msgid "Vertical (y) axis"
+msgid "Axes"
 msgstr ""
 
 msgid "Horizontal (x) axis"
+msgstr ""
+
+msgid "Style"
 msgstr ""
 
 msgid "Chart style"
 msgstr ""
 
 msgid "Titles"
+msgstr ""
+
+msgid "Lines"
+msgstr ""
+
+msgid "Vertical (y) axis"
 msgstr ""
 
 msgid "Display totals"
@@ -776,6 +776,12 @@ msgid "Limit minimum/maximum values"
 msgstr ""
 
 msgid "Parameters"
+msgstr ""
+
+msgid "Lines are not supported yet when using multiple axes"
+msgstr ""
+
+msgid "Vertical axis options are not supported yet when using multiple axes"
 msgstr ""
 
 msgid "Weeks per year"

--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,10 +5,13 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-24T11:15:11.138Z\n"
-"PO-Revision-Date: 2020-08-24T11:15:11.138Z\n"
+"POT-Creation-Date: 2020-09-09T14:22:42.172Z\n"
+"PO-Revision-Date: 2020-09-09T14:22:42.172Z\n"
 
 msgid "Rename successful"
+msgstr ""
+
+msgid "Untitled {{visualizationType}} visualization, {{date}}"
 msgstr ""
 
 msgid "\"{{what}}\" successfully deleted."
@@ -222,7 +225,7 @@ msgstr ""
 msgid "Aggregation type"
 msgstr ""
 
-msgid "Determines how the values in the pivot table are aggregated."
+msgid "Overrides aggregation type for all data values."
 msgstr ""
 
 msgid "By data element"
@@ -366,7 +369,7 @@ msgstr ""
 msgid "Hide empty rows"
 msgstr ""
 
-msgid "Legend key"
+msgid "Show legend key"
 msgstr ""
 
 msgid "Table subtitle"
@@ -464,7 +467,9 @@ msgstr ""
 msgid "Auto"
 msgstr ""
 
-msgid "The number of axis steps between the min and max values"
+msgid ""
+"Number of axis tick steps, including the min and max. A value of 2 or lower "
+"will be ignored."
 msgstr ""
 
 msgid "Steps"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "4.5.7-alpha.3",
+        "@dhis2/analytics": "4.5.8-alpha.1",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^7.0.4",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.5.2",
+        "@dhis2/analytics": "4.5.7-alpha.2",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^7.0.4",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "4.5.7-alpha.2",
+        "@dhis2/analytics": "4.5.7-alpha.3",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^7.0.4",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "4.5.8-alpha.1",
+        "@dhis2/analytics": "4.5.11",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-core": "^7.0.4",

--- a/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
@@ -41,7 +41,7 @@ import {
     sGetUiActiveModalDialog,
     sGetUiParentGraphMap,
     sGetUiType,
-    getAxisIdByDimensionId,
+    sGetAxisIdByDimensionId,
     sGetDimensionIdsFromLayout,
 } from '../../../reducers/ui'
 import { sGetDimensions } from '../../../reducers/dimensions'
@@ -383,7 +383,7 @@ const mapStateToProps = state => ({
     selectedItems: sGetUiItems(state),
     type: sGetUiType(state),
     getAxisIdByDimensionId: dimensionId =>
-        getAxisIdByDimensionId(state, dimensionId),
+        sGetAxisIdByDimensionId(state, dimensionId),
     dimensionIdsInLayout: sGetDimensionIdsFromLayout(state),
 })
 

--- a/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
@@ -96,7 +96,7 @@ const mapStateToProps = state => ({
         state
     ),
     getCurrentAxisId: dimensionId =>
-        fromReducers.fromUi.getAxisIdByDimensionId(state, dimensionId),
+        fromReducers.fromUi.sGetAxisIdByDimensionId(state, dimensionId),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/app/src/components/VisualizationOptions/Options/AxisRange.js
+++ b/packages/app/src/components/VisualizationOptions/Options/AxisRange.js
@@ -1,6 +1,6 @@
 import React from 'react'
-
 import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
 import { Label, Help } from '@dhis2/ui-core'
 
 import RangeAxisMinValue from './RangeAxisMinValue'
@@ -11,18 +11,24 @@ import {
     tabSectionOptionComplexInline,
 } from '../styles/VisualizationOptions.style.js'
 
-const AxisRange = () => (
+const AxisRange = ({ disabled }) => (
     <div className={tabSectionOption.className}>
         <Label>{i18n.t('Axis range')}</Label>
         <div className={tabSectionOptionComplexInline.className}>
-            <RangeAxisMinValue />
+            <RangeAxisMinValue disabled={disabled} />
             {'\u00A0\u2013\u00A0'}
-            <RangeAxisMaxValue />
+            <RangeAxisMaxValue disabled={disabled} />
         </div>
-        <Help>
-            {i18n.t('Values outside of the range will not be displayed')}
-        </Help>
+        {!disabled ? (
+            <Help>
+                {i18n.t('Values outside of the range will not be displayed')}
+            </Help>
+        ) : null}
     </div>
 )
+
+AxisRange.propTypes = {
+    disabled: PropTypes.bool,
+}
 
 export default AxisRange

--- a/packages/app/src/components/VisualizationOptions/Options/BaseLine.js
+++ b/packages/app/src/components/VisualizationOptions/Options/BaseLine.js
@@ -16,16 +16,17 @@ import {
     tabSectionOptionComplexInline,
 } from '../styles/VisualizationOptions.style.js'
 
-export const BaseLine = ({ enabled, onChange }) => (
+export const BaseLine = ({ checked, onChange, disabled }) => (
     <div className={tabSectionOption.className}>
         <Checkbox
-            checked={enabled}
+            checked={checked}
             label={i18n.t('Base line')}
             name="baseLine-toggle"
             onChange={({ checked }) => onChange(checked)}
             dense
+            disabled={disabled}
         />
-        {enabled ? (
+        {checked && !disabled ? (
             <div
                 className={`${tabSectionOptionToggleable.className} ${tabSectionOptionComplexInline.className}`}
             >
@@ -43,16 +44,17 @@ export const BaseLine = ({ enabled, onChange }) => (
 )
 
 BaseLine.propTypes = {
-    enabled: PropTypes.bool.isRequired,
+    checked: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
 }
 
 const mapStateToProps = state => ({
-    enabled: sGetUiOptions(state).baseLine,
+    checked: sGetUiOptions(state).baseLine,
 })
 
 const mapDispatchToProps = dispatch => ({
-    onChange: enabled => dispatch(acSetUiOptions({ baseLine: enabled })),
+    onChange: checked => dispatch(acSetUiOptions({ baseLine: checked })),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(BaseLine)

--- a/packages/app/src/components/VisualizationOptions/Options/Legend.js
+++ b/packages/app/src/components/VisualizationOptions/Options/Legend.js
@@ -62,30 +62,34 @@ const Legend = ({
             {legendEnabled ? (
                 <div className={tabSectionOptionToggleable.className}>
                     {!hideStyleOptions ? (
+                        <div className={tabSectionOption.className}>
+                            <FieldSet>
+                                <UiCoreLegend>
+                                    <span
+                                        className={tabSectionTitle.className}
+                                        style={{ marginTop: 8 }}
+                                    >
+                                        {i18n.t('Legend style')}
+                                    </span>
+                                </UiCoreLegend>
+                                <div className={tabSectionOption.className}>
+                                    <LegendDisplayStyle />
+                                </div>
+                            </FieldSet>
+                        </div>
+                    ) : null}
+                    <div>
                         <FieldSet>
                             <UiCoreLegend>
-                                <span
-                                    className={tabSectionTitle.className}
-                                    style={{ marginTop: 8 }}
-                                >
-                                    {i18n.t('Legend style')}
+                                <span className={tabSectionTitle.className}>
+                                    {i18n.t('Legend type')}
                                 </span>
                             </UiCoreLegend>
                             <div className={tabSectionOption.className}>
-                                <LegendDisplayStyle />
+                                <LegendDisplayStrategy />
                             </div>
                         </FieldSet>
-                    ) : null}
-                    <FieldSet>
-                        <UiCoreLegend>
-                            <span className={tabSectionTitle.className}>
-                                {i18n.t('Legend type')}
-                            </span>
-                        </UiCoreLegend>
-                        <div className={tabSectionOption.className}>
-                            <LegendDisplayStrategy />
-                        </div>
-                    </FieldSet>
+                    </div>
                 </div>
             ) : null}
         </div>

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisDecimals.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisDecimals.js
@@ -1,19 +1,24 @@
 import React from 'react'
-
 import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
 
 import TextBaseOption from './TextBaseOption'
 
-const RangeAxisDecimals = () => (
+const RangeAxisDecimals = ({ disabled }) => (
     <TextBaseOption
         type="number"
         width="96px"
         label={i18n.t('Decimals')}
+        disabled={disabled}
         placeholder={i18n.t('Auto')}
         option={{
             name: 'rangeAxisDecimals',
         }}
     />
 )
+
+RangeAxisDecimals.propTypes = {
+    disabled: PropTypes.bool,
+}
 
 export default RangeAxisDecimals

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisLabel.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisLabel.js
@@ -1,6 +1,6 @@
 import React from 'react'
-
 import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
 
 import TextBaseOption from './TextBaseOption'
 import { options } from '../../../modules/options'
@@ -8,11 +8,12 @@ import { options } from '../../../modules/options'
 const optionName = 'rangeAxisLabel'
 const defaultValue = options[optionName].defaultValue
 
-const RangeAxisLabel = () => (
+const RangeAxisLabel = ({ disabled }) => (
     <TextBaseOption
         type="text"
         width="280px"
         label={i18n.t('Axis title')}
+        disabled={disabled}
         placeholder={i18n.t('Add a title')}
         option={{
             name: optionName,
@@ -21,5 +22,9 @@ const RangeAxisLabel = () => (
         toggleable={true}
     />
 )
+
+RangeAxisLabel.propTypes = {
+    disabled: PropTypes.bool,
+}
 
 export default RangeAxisLabel

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisMaxValue.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisMaxValue.js
@@ -1,19 +1,24 @@
 import React from 'react'
-
 import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
 
 import TextBaseOption from './TextBaseOption'
 
-const RangeAxisMaxValue = () => (
+const RangeAxisMaxValue = ({ disabled }) => (
     <TextBaseOption
         type="number"
         width="100px"
         placeholder={i18n.t('Max')}
+        disabled={disabled}
         option={{
             name: 'rangeAxisMaxValue',
         }}
         inline
     />
 )
+
+RangeAxisMaxValue.propTypes = {
+    disabled: PropTypes.bool,
+}
 
 export default RangeAxisMaxValue

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisMinValue.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisMinValue.js
@@ -1,19 +1,24 @@
 import React from 'react'
-
 import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
 
 import TextBaseOption from './TextBaseOption'
 
-const RangeAxisMinValue = () => (
+const RangeAxisMinValue = ({ disabled }) => (
     <TextBaseOption
         type="number"
         width="100px"
         placeholder={i18n.t('Min')}
+        disabled={disabled}
         option={{
             name: 'rangeAxisMinValue',
         }}
         inline
     />
 )
+
+RangeAxisMinValue.propTypes = {
+    disabled: PropTypes.bool,
+}
 
 export default RangeAxisMinValue

--- a/packages/app/src/components/VisualizationOptions/Options/RangeAxisSteps.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RangeAxisSteps.js
@@ -1,10 +1,10 @@
 import React from 'react'
-
 import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
 
 import TextBaseOption from './TextBaseOption'
 
-export const RangeAxisSteps = () => (
+export const RangeAxisSteps = ({ disabled }) => (
     <TextBaseOption
         type="number"
         width="96px"
@@ -12,11 +12,16 @@ export const RangeAxisSteps = () => (
             'The number of axis steps between the min and max values'
         )}
         label={i18n.t('Steps')}
+        disabled={disabled}
         placeholder={i18n.t('Auto')}
         option={{
             name: 'rangeAxisSteps',
         }}
     />
 )
+
+RangeAxisSteps.propTypes = {
+    disabled: PropTypes.bool,
+}
 
 export default RangeAxisSteps

--- a/packages/app/src/components/VisualizationOptions/Options/RegressionType.js
+++ b/packages/app/src/components/VisualizationOptions/Options/RegressionType.js
@@ -1,6 +1,6 @@
 import React from 'react'
-
 import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
 
 import SelectBaseOption from './SelectBaseOption'
 import { options } from '../../../modules/options'
@@ -8,10 +8,11 @@ import { options } from '../../../modules/options'
 const optionName = 'regressionType'
 const defaultValue = options[optionName].defaultValue
 
-const RegressionType = () => (
+const RegressionType = ({ disabled }) => (
     <SelectBaseOption
         toggleable={true}
         label={i18n.t('Trend line')}
+        disabled={disabled}
         option={{
             name: optionName,
             defaultValue: defaultValue,
@@ -23,5 +24,9 @@ const RegressionType = () => (
         }}
     />
 )
+
+RegressionType.propTypes = {
+    disabled: PropTypes.bool,
+}
 
 export default RegressionType

--- a/packages/app/src/components/VisualizationOptions/Options/SelectBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/SelectBaseOption.js
@@ -19,33 +19,32 @@ export const SelectBaseOption = ({
     toggleable,
     value,
     onChange,
+    disabled,
 }) => {
     const defaultValue = option.defaultValue
-
-    const [enabled, setEnabled] = useState(value !== defaultValue)
-
+    const [checked, setChecked] = useState(value !== defaultValue)
     const selected = option.items.find(item => item.value === value) || {}
-
     const onToggle = checked => {
-        setEnabled(checked)
+        setChecked(checked)
 
         onChange(checked ? option.items[0].value : defaultValue)
     }
 
     return (
         <div
-            className={!toggleable || enabled ? '' : tabSectionOption.className}
+            className={!toggleable || checked ? '' : tabSectionOption.className}
         >
             {toggleable ? (
                 <Checkbox
-                    checked={enabled}
+                    checked={checked}
                     label={label}
                     name={`${option.name}-toggle`}
                     onChange={({ checked }) => onToggle(checked)}
                     dense
+                    disabled={disabled}
                 />
             ) : null}
-            {!toggleable || enabled ? (
+            {(!toggleable || checked) && !disabled ? (
                 <div
                     className={
                         toggleable ? tabSectionOptionToggleable.className : ''
@@ -78,6 +77,7 @@ SelectBaseOption.propTypes = {
     option: PropTypes.object.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
     helpText: PropTypes.string,
     label: PropTypes.string,
     toggleable: PropTypes.bool,

--- a/packages/app/src/components/VisualizationOptions/Options/TargetLine.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TargetLine.js
@@ -16,15 +16,16 @@ import {
     tabSectionOptionComplexInline,
 } from '../styles/VisualizationOptions.style.js'
 
-export const TargetLine = ({ enabled, onChange }) => (
+export const TargetLine = ({ checked, onChange, disabled }) => (
     <div className={tabSectionOption.className}>
         <Checkbox
-            checked={enabled}
+            checked={checked}
             label={i18n.t('Target line')}
             onChange={({ checked }) => onChange(checked)}
             dense
+            disabled={disabled}
         />
-        {enabled ? (
+        {checked && !disabled ? (
             <div
                 className={`${tabSectionOptionToggleable.className} ${tabSectionOptionComplexInline.className}`}
             >
@@ -42,16 +43,17 @@ export const TargetLine = ({ enabled, onChange }) => (
 )
 
 TargetLine.propTypes = {
-    enabled: PropTypes.bool.isRequired,
+    checked: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
 }
 
 const mapStateToProps = state => ({
-    enabled: sGetUiOptions(state).targetLine,
+    checked: sGetUiOptions(state).targetLine,
 })
 
 const mapDispatchToProps = dispatch => ({
-    onChange: enabled => dispatch(acSetUiOptions({ targetLine: enabled })),
+    onChange: checked => dispatch(acSetUiOptions({ targetLine: checked })),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(TargetLine)

--- a/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/TextBaseOption.js
@@ -23,24 +23,26 @@ export const TextBaseOption = ({
     onChange,
     onToggle,
     toggleable,
-    enabled,
+    checked,
     inline,
+    disabled,
 }) => (
     <div
         className={
-            !toggleable || enabled || inline ? '' : tabSectionOption.className
+            !toggleable || checked || inline ? '' : tabSectionOption.className
         }
     >
         {toggleable ? (
             <Checkbox
-                checked={enabled}
+                checked={checked}
                 label={label}
                 name={`${option.name}-toggle`}
                 onChange={({ checked }) => onToggle(checked)}
                 dense
+                disabled={disabled}
             />
         ) : null}
-        {!toggleable || enabled ? (
+        {!toggleable || checked ? (
             <div
                 className={
                     toggleable ? tabSectionOptionToggleable.className : ''
@@ -55,6 +57,7 @@ export const TextBaseOption = ({
                             value={value}
                             placeholder={placeholder}
                             dense
+                            disabled={disabled}
                         />
                     </Constrictor>
                 ) : (
@@ -64,10 +67,11 @@ export const TextBaseOption = ({
                         onChange={({ value }) => onChange(value)}
                         name={option.name}
                         value={value}
-                        helpText={helpText}
+                        helpText={disabled ? '' : helpText}
                         placeholder={placeholder}
                         inputWidth={width}
                         dense
+                        disabled={disabled}
                     />
                 )}
             </div>
@@ -76,7 +80,8 @@ export const TextBaseOption = ({
 )
 
 TextBaseOption.propTypes = {
-    enabled: PropTypes.bool,
+    checked: PropTypes.bool,
+    disabled: PropTypes.bool,
     helpText: PropTypes.string,
     inline: PropTypes.bool,
     label: PropTypes.string,
@@ -92,7 +97,7 @@ TextBaseOption.propTypes = {
 
 const mapStateToProps = (state, ownProps) => ({
     value: sGetUiOptions(state)[ownProps.option.name] || '',
-    enabled: sGetUiOptions(state)[ownProps.option.name] !== undefined,
+    checked: sGetUiOptions(state)[ownProps.option.name] !== undefined,
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/packages/app/src/components/VisualizationOptions/__tests__/TextBaseOption.spec.js
+++ b/packages/app/src/components/VisualizationOptions/__tests__/TextBaseOption.spec.js
@@ -134,8 +134,8 @@ describe('DV > Options > TextBaseOption', () => {
             expect(textBaseOption(props).find(InputField)).toHaveLength(0)
         })
 
-        it('does render a <InputField /> when the checkbox is enabled', () => {
-            props.enabled = true
+        it('does render a <InputField /> when the checkbox is checked', () => {
+            props.checked = true
 
             const text = textBaseOption(props)
             expect(text.find(InputField)).toHaveLength(1)

--- a/packages/app/src/components/VisualizationOptions/__tests__/VisualizationOptions.spec.js
+++ b/packages/app/src/components/VisualizationOptions/__tests__/VisualizationOptions.spec.js
@@ -23,6 +23,13 @@ describe('VisualizationOptions', () => {
     beforeEach(() => {
         props = {
             visualizationType: 'COLUMN',
+            columnDimensionItems: ['aaa', 'bbb'],
+            series: [
+                {
+                    dimensionItem: 'aaa',
+                    axis: 0,
+                },
+            ],
         }
 
         shallowVisualizationOptions = undefined

--- a/packages/app/src/components/VisualizationOptions/__tests__/VisualizationOptions.spec.js
+++ b/packages/app/src/components/VisualizationOptions/__tests__/VisualizationOptions.spec.js
@@ -23,13 +23,7 @@ describe('VisualizationOptions', () => {
     beforeEach(() => {
         props = {
             visualizationType: 'COLUMN',
-            columnDimensionItems: ['aaa', 'bbb'],
-            series: [
-                {
-                    dimensionItem: 'aaa',
-                    axis: 0,
-                },
-            ],
+            optionalAxes: {},
         }
 
         shallowVisualizationOptions = undefined

--- a/packages/app/src/modules/options/areaConfig.js
+++ b/packages/app/src/modules/options/areaConfig.js
@@ -52,11 +52,6 @@ export default hasCustomAxes => [
                 label: i18n.t('Horizontal (x) axis'),
                 content: React.Children.toArray([<DomainAxisLabel />]),
             },
-            {
-                key: 'axes-horizontal-axis',
-                getLabel: () => i18n.t('Horizontal (x) axis'),
-                content: React.Children.toArray([<DomainAxisLabel />]),
-            },
         ],
     },
     {

--- a/packages/app/src/modules/options/areaConfig.js
+++ b/packages/app/src/modules/options/areaConfig.js
@@ -6,78 +6,68 @@ import CumulativeValues from '../../components/VisualizationOptions/Options/Cumu
 import PercentStackedValues from '../../components/VisualizationOptions/Options/PercentStackedValues'
 import ShowData from '../../components/VisualizationOptions/Options/ShowData'
 import HideEmptyRowItems from '../../components/VisualizationOptions/Options/HideEmptyRowItems'
-import RegressionType from '../../components/VisualizationOptions/Options/RegressionType'
-import TargetLine from '../../components/VisualizationOptions/Options/TargetLine'
-import BaseLine from '../../components/VisualizationOptions/Options/BaseLine'
 import SortOrder from '../../components/VisualizationOptions/Options/SortOrder'
 import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
-import RangeAxisMinValue from '../../components/VisualizationOptions/Options/RangeAxisMinValue'
-import RangeAxisMaxValue from '../../components/VisualizationOptions/Options/RangeAxisMaxValue'
-import RangeAxisSteps from '../../components/VisualizationOptions/Options/RangeAxisSteps'
-import RangeAxisDecimals from '../../components/VisualizationOptions/Options/RangeAxisDecimals'
-import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeAxisLabel'
 import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
-import Title from '../../components/VisualizationOptions/Options/Title'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
-import Subtitle from '../../components/VisualizationOptions/Options/Subtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
+import getLinesSection from './sections/lines'
+import getVerticalAxisSection from './sections/verticalAxis'
 
-export default [
+export default hasCustomAxes => [
     {
         key: 'data-tab',
-        getLabel: () => i18n.t('Data'),
+        label: i18n.t('Data'),
         content: [
             {
-                key: 'data-section-1',
+                key: 'data-display',
+                label: i18n.t('Display'),
                 content: React.Children.toArray([
-                    <ShowData />,
                     <PercentStackedValues />,
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
-                    <RegressionType />,
-                    <TargetLine />,
-                    <BaseLine />,
                     <SortOrder />,
-                    <AggregationType />,
                 ]),
             },
+            getLinesSection(hasCustomAxes),
             {
                 key: 'data-advanced',
-                getLabel: () => i18n.t('Advanced'),
-                content: React.Children.toArray([<CompletedOnly />]),
+                label: i18n.t('Advanced'),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
             },
         ],
     },
     {
         key: 'axes-tab',
-        getLabel: () => i18n.t('Axes'),
+        label: i18n.t('Axes'),
         content: [
+            getVerticalAxisSection(hasCustomAxes),
             {
-                key: 'axes-section-1',
-                content: React.Children.toArray([
-                    <RangeAxisMinValue />,
-                    <RangeAxisMaxValue />,
-                    <RangeAxisSteps />,
-                    <RangeAxisDecimals />,
-                    <RangeAxisLabel />,
-                    <DomainAxisLabel />,
-                ]),
+                key: 'axes-horizontal-axis',
+                label: i18n.t('Horizontal (x) axis'),
+                content: React.Children.toArray([<DomainAxisLabel />]),
             },
         ],
     },
     {
         key: 'style-tab',
-        getLabel: () => i18n.t('Style'),
+        label: i18n.t('Style'),
         content: [
             {
-                key: 'style-section-1',
+                key: 'style-chart-style',
+                label: i18n.t('Chart style'),
+                content: React.Children.toArray([<ShowData />, <HideLegend />]),
+            },
+            {
+                key: 'style-titles',
+                label: i18n.t('Titles'),
                 content: React.Children.toArray([
-                    <HideLegend />,
-                    <Title />,
                     <HideTitle />,
-                    <Subtitle />,
                     <HideSubtitle />,
                 ]),
             },

--- a/packages/app/src/modules/options/columnConfig.js
+++ b/packages/app/src/modules/options/columnConfig.js
@@ -5,48 +5,35 @@ import i18n from '@dhis2/d2-i18n'
 import CumulativeValues from '../../components/VisualizationOptions/Options/CumulativeValues'
 import ShowData from '../../components/VisualizationOptions/Options/ShowData'
 import HideEmptyRowItems from '../../components/VisualizationOptions/Options/HideEmptyRowItems'
-import RegressionType from '../../components/VisualizationOptions/Options/RegressionType'
-import TargetLine from '../../components/VisualizationOptions/Options/TargetLine'
-import BaseLine from '../../components/VisualizationOptions/Options/BaseLine'
 import SortOrder from '../../components/VisualizationOptions/Options/SortOrder'
 import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
-import AxisRange from '../../components/VisualizationOptions/Options/AxisRange'
-import RangeAxisSteps from '../../components/VisualizationOptions/Options/RangeAxisSteps'
-import RangeAxisDecimals from '../../components/VisualizationOptions/Options/RangeAxisDecimals'
-import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeAxisLabel'
 import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
 import NoSpaceBetweenColumns from '../../components/VisualizationOptions/Options/NoSpaceBetweenColumns'
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
+import getLinesSection from './sections/lines'
+import getVerticalAxisSection from './sections/verticalAxis'
 
-export default [
+export default hasCustomAxes => [
     {
         key: 'data-tab',
-        getLabel: () => i18n.t('Data'),
+        label: i18n.t('Data'),
         content: [
             {
                 key: 'data-display',
-                getLabel: () => i18n.t('Display'),
+                label: i18n.t('Display'),
                 content: React.Children.toArray([
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
                     <SortOrder />,
                 ]),
             },
-            {
-                key: 'data-lines',
-                getLabel: () => i18n.t('Lines'),
-                content: React.Children.toArray([
-                    <RegressionType />,
-                    <TargetLine />,
-                    <BaseLine />,
-                ]),
-            },
+            getLinesSection(hasCustomAxes),
             {
                 key: 'data-advanced',
-                getLabel: () => i18n.t('Advanced'),
+                label: i18n.t('Advanced'),
                 content: React.Children.toArray([
                     <AggregationType />,
                     <CompletedOnly />,
@@ -56,32 +43,23 @@ export default [
     },
     {
         key: 'axes-tab',
-        getLabel: () => i18n.t('Axes'),
+        label: i18n.t('Axes'),
         content: [
-            {
-                key: 'axes-vertical-axis',
-                getLabel: () => i18n.t('Vertical (y) axis'),
-                content: React.Children.toArray([
-                    <RangeAxisLabel />,
-                    <AxisRange />,
-                    <RangeAxisSteps />,
-                    <RangeAxisDecimals />,
-                ]),
-            },
+            getVerticalAxisSection(hasCustomAxes),
             {
                 key: 'axes-horizontal-axis',
-                getLabel: () => i18n.t('Horizontal (x) axis'),
+                label: i18n.t('Horizontal (x) axis'),
                 content: React.Children.toArray([<DomainAxisLabel />]),
             },
         ],
     },
     {
         key: 'style-tab',
-        getLabel: () => i18n.t('Style'),
+        label: i18n.t('Style'),
         content: [
             {
                 key: 'style-chart-style',
-                getLabel: () => i18n.t('Chart style'),
+                label: i18n.t('Chart style'),
                 content: React.Children.toArray([
                     <ShowData />,
                     <NoSpaceBetweenColumns />,
@@ -91,7 +69,7 @@ export default [
             },
             {
                 key: 'style-titles',
-                getLabel: () => i18n.t('Titles'),
+                label: i18n.t('Titles'),
                 content: React.Children.toArray([
                     <HideTitle />,
                     <HideSubtitle />,

--- a/packages/app/src/modules/options/config.js
+++ b/packages/app/src/modules/options/config.js
@@ -23,31 +23,31 @@ import pieConfig from './pieConfig'
 import gaugeConfig from './gaugeConfig'
 import singleValueConfig from './singleValueConfig'
 
-export const getOptionsByType = type => {
+export const getOptionsByType = (type, hasCustomAxes) => {
     switch (type) {
         case VIS_TYPE_COLUMN:
         case VIS_TYPE_BAR:
         case VIS_TYPE_YEAR_OVER_YEAR_LINE:
         case VIS_TYPE_YEAR_OVER_YEAR_COLUMN:
-            return columnConfig
+            return columnConfig(hasCustomAxes)
         case VIS_TYPE_STACKED_COLUMN:
         case VIS_TYPE_STACKED_BAR:
-            return stackedColumnConfig
+            return stackedColumnConfig(hasCustomAxes)
         case VIS_TYPE_LINE:
         case VIS_TYPE_RADAR:
-            return lineConfig
+            return lineConfig(hasCustomAxes)
         case VIS_TYPE_AREA:
-            return areaConfig
+            return areaConfig(hasCustomAxes)
         case VIS_TYPE_GAUGE:
-            return gaugeConfig
+            return gaugeConfig(hasCustomAxes)
         case VIS_TYPE_PIE:
-            return pieConfig
+            return pieConfig(hasCustomAxes)
         case VIS_TYPE_SINGLE_VALUE:
-            return singleValueConfig
+            return singleValueConfig(hasCustomAxes)
         case VIS_TYPE_PIVOT_TABLE:
-            return pivotTableConfig
+            return pivotTableConfig(hasCustomAxes)
         default:
             // return all the options
-            return stackedColumnConfig
+            return stackedColumnConfig(hasCustomAxes)
     }
 }

--- a/packages/app/src/modules/options/gaugeConfig.js
+++ b/packages/app/src/modules/options/gaugeConfig.js
@@ -11,19 +11,19 @@ import AxisRange from '../../components/VisualizationOptions/Options/AxisRange'
 import Legend from '../../components/VisualizationOptions/Options/Legend'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
-export default [
+export default () => [
     {
         key: 'data-tab',
-        getLabel: () => i18n.t('Data'),
+        label: i18n.t('Data'),
         content: [
             {
                 key: 'data-lines',
-                getLabel: () => i18n.t('Lines'),
+                label: i18n.t('Lines'),
                 content: React.Children.toArray([<TargetLine />, <BaseLine />]),
             },
             {
                 key: 'data-advanced',
-                getLabel: () => i18n.t('Advanced'),
+                label: i18n.t('Advanced'),
                 content: React.Children.toArray([
                     <AggregationType />,
                     <CompletedOnly />,
@@ -33,7 +33,7 @@ export default [
     },
     {
         key: 'legend-tab',
-        getLabel: () => i18n.t('Legend'),
+        label: i18n.t('Legend'),
         content: [
             {
                 key: 'legend-section-1',
@@ -43,22 +43,22 @@ export default [
     },
     {
         key: 'axes-tab',
-        getLabel: () => i18n.t('Axes'),
+        label: i18n.t('Axes'),
         content: [
             {
                 key: 'axes-vertical-axis',
-                getLabel: () => i18n.t('Vertical (y) axis'),
+                label: i18n.t('Vertical (y) axis'),
                 content: React.Children.toArray([<AxisRange />]),
             },
         ],
     },
     {
         key: 'style-tab',
-        getLabel: () => i18n.t('Style'),
+        label: i18n.t('Style'),
         content: [
             {
                 key: 'style-titles',
-                getLabel: () => i18n.t('Titles'),
+                label: i18n.t('Titles'),
                 content: React.Children.toArray([
                     <HideTitle />,
                     <HideSubtitle />,

--- a/packages/app/src/modules/options/lineConfig.js
+++ b/packages/app/src/modules/options/lineConfig.js
@@ -5,77 +5,67 @@ import i18n from '@dhis2/d2-i18n'
 import CumulativeValues from '../../components/VisualizationOptions/Options/CumulativeValues'
 import ShowData from '../../components/VisualizationOptions/Options/ShowData'
 import HideEmptyRowItems from '../../components/VisualizationOptions/Options/HideEmptyRowItems'
-import RegressionType from '../../components/VisualizationOptions/Options/RegressionType'
-import TargetLine from '../../components/VisualizationOptions/Options/TargetLine'
-import BaseLine from '../../components/VisualizationOptions/Options/BaseLine'
 import SortOrder from '../../components/VisualizationOptions/Options/SortOrder'
 import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
-import RangeAxisMinValue from '../../components/VisualizationOptions/Options/RangeAxisMinValue'
-import RangeAxisMaxValue from '../../components/VisualizationOptions/Options/RangeAxisMaxValue'
-import RangeAxisSteps from '../../components/VisualizationOptions/Options/RangeAxisSteps'
-import RangeAxisDecimals from '../../components/VisualizationOptions/Options/RangeAxisDecimals'
-import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeAxisLabel'
 import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
-import Title from '../../components/VisualizationOptions/Options/Title'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
-import Subtitle from '../../components/VisualizationOptions/Options/Subtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
+import getLinesSection from './sections/lines'
+import getVerticalAxisSection from './sections/verticalAxis'
 
-export default [
+export default hasCustomAxes => [
     {
         key: 'data-tab',
-        getLabel: () => i18n.t('Data'),
+        label: i18n.t('Data'),
         content: [
             {
-                key: 'data-section-1',
+                key: 'data-display',
+                label: i18n.t('Display'),
                 content: React.Children.toArray([
-                    <ShowData />,
                     <CumulativeValues />,
                     <HideEmptyRowItems />,
-                    <RegressionType />,
-                    <TargetLine />,
-                    <BaseLine />,
                     <SortOrder />,
-                    <AggregationType />,
                 ]),
             },
+            getLinesSection(hasCustomAxes),
             {
                 key: 'data-advanced',
-                getLabel: () => i18n.t('Advanced'),
-                content: React.Children.toArray([<CompletedOnly />]),
+                label: i18n.t('Advanced'),
+                content: React.Children.toArray([
+                    <AggregationType />,
+                    <CompletedOnly />,
+                ]),
             },
         ],
     },
     {
         key: 'axes-tab',
-        getLabel: () => i18n.t('Axes'),
+        label: i18n.t('Axes'),
         content: [
+            getVerticalAxisSection(hasCustomAxes),
             {
-                key: 'axes-section-1',
-                content: React.Children.toArray([
-                    <RangeAxisMinValue />,
-                    <RangeAxisMaxValue />,
-                    <RangeAxisSteps />,
-                    <RangeAxisDecimals />,
-                    <RangeAxisLabel />,
-                    <DomainAxisLabel />,
-                ]),
+                key: 'axes-horizontal-axis',
+                label: i18n.t('Horizontal (x) axis'),
+                content: React.Children.toArray([<DomainAxisLabel />]),
             },
         ],
     },
     {
         key: 'style-tab',
-        getLabel: () => i18n.t('Style'),
+        label: i18n.t('Style'),
         content: [
             {
-                key: 'style-section-1',
+                key: 'style-chart-style',
+                label: i18n.t('Chart style'),
+                content: React.Children.toArray([<ShowData />, <HideLegend />]),
+            },
+            {
+                key: 'style-titles',
+                label: i18n.t('Titles'),
                 content: React.Children.toArray([
-                    <HideLegend />,
-                    <Title />,
                     <HideTitle />,
-                    <Subtitle />,
                     <HideSubtitle />,
                 ]),
             },

--- a/packages/app/src/modules/options/lineConfig.js
+++ b/packages/app/src/modules/options/lineConfig.js
@@ -50,11 +50,6 @@ export default hasCustomAxes => [
                 label: i18n.t('Horizontal (x) axis'),
                 content: React.Children.toArray([<DomainAxisLabel />]),
             },
-            {
-                key: 'axes-horizontal-axis',
-                getLabel: () => i18n.t('Horizontal (x) axis'),
-                content: React.Children.toArray([<DomainAxisLabel />]),
-            },
         ],
     },
     {

--- a/packages/app/src/modules/options/pieConfig.js
+++ b/packages/app/src/modules/options/pieConfig.js
@@ -7,14 +7,14 @@ import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
-export default [
+export default () => [
     {
         key: 'data-tab',
-        getLabel: () => i18n.t('Data'),
+        label: i18n.t('Data'),
         content: [
             {
                 key: 'data-advanced',
-                getLabel: () => i18n.t('Advanced'),
+                label: i18n.t('Advanced'),
                 content: React.Children.toArray([
                     <AggregationType />,
                     <CompletedOnly />,
@@ -24,11 +24,11 @@ export default [
     },
     {
         key: 'style-tab',
-        getLabel: () => i18n.t('Style'),
+        label: i18n.t('Style'),
         content: [
             {
                 key: 'style-titles',
-                getLabel: () => i18n.t('Titles'),
+                label: i18n.t('Titles'),
                 content: React.Children.toArray([
                     <HideTitle />,
                     <HideSubtitle />,

--- a/packages/app/src/modules/options/pivotTableConfig.js
+++ b/packages/app/src/modules/options/pivotTableConfig.js
@@ -29,10 +29,10 @@ import ApprovalLevel from '../../components/VisualizationOptions/Options/Approva
 import ShowHierarchy from '../../components/VisualizationOptions/Options/ShowHierarchy'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
-export default [
+export default () => [
     {
         key: 'data-tab',
-        getLabel: () => i18n.t('Data'),
+        label: i18n.t('Data'),
         content: [
             {
                 key: 'data-section-1',
@@ -43,7 +43,7 @@ export default [
             },
             {
                 key: 'data-display-totals',
-                getLabel: () => i18n.t('Display totals'),
+                label: i18n.t('Display totals'),
                 content: React.Children.toArray([
                     <ColTotals />,
                     <ColSubTotals />,
@@ -53,7 +53,7 @@ export default [
             },
             {
                 key: 'data-display-empty-data',
-                getLabel: () => i18n.t('Display empty data'),
+                label: i18n.t('Display empty data'),
                 content: React.Children.toArray([
                     <HideEmptyColumns />,
                     <HideEmptyRows />,
@@ -61,7 +61,7 @@ export default [
             },
             {
                 key: 'data-advanced',
-                getLabel: () => i18n.t('Advanced'),
+                label: i18n.t('Advanced'),
                 content: React.Children.toArray([
                     <AggregationType />,
                     <NumberType />,
@@ -73,7 +73,7 @@ export default [
     },
     {
         key: 'legend-tab',
-        getLabel: () => i18n.t('Legend'),
+        label: i18n.t('Legend'),
         content: [
             {
                 key: 'legend-section-1',
@@ -83,7 +83,7 @@ export default [
     },
     {
         key: 'style-tab',
-        getLabel: () => i18n.t('Style'),
+        label: i18n.t('Style'),
         content: [
             {
                 key: 'style-section-1',
@@ -96,31 +96,31 @@ export default [
             },
             {
                 key: 'style-section-2',
-                getLabel: () => i18n.t('Labels'),
+                label: i18n.t('Labels'),
                 content: React.Children.toArray([<ShowHierarchy />]),
             },
         ],
     },
     {
         key: 'limitValues-tab',
-        getLabel: () => i18n.t('Limit values'),
+        label: i18n.t('Limit values'),
         content: [
             /*
             {
                 key: 'limitValues-limit-numbers',
-                getLabel: () => i18n.t('Limit number of values'),
+                label: i18n.t('Limit number of values'),
                 content: [<TopLimit />],
             },*/
             {
                 key: 'limitValues-limit-min-max',
-                getLabel: () => i18n.t('Limit minimum/maximum values'),
+                label: i18n.t('Limit minimum/maximum values'),
                 content: React.Children.toArray([<MeasureCriteria />]),
             },
         ],
     },
     {
         key: 'parameters-tab',
-        getLabel: () => i18n.t('Parameters'),
+        label: i18n.t('Parameters'),
         content: [
             {
                 key: 'parameters-section-1',

--- a/packages/app/src/modules/options/sections/lines.js
+++ b/packages/app/src/modules/options/sections/lines.js
@@ -1,0 +1,20 @@
+/* eslint-disable react/jsx-key */
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+
+import RegressionType from '../../../components/VisualizationOptions/Options/RegressionType'
+import TargetLine from '../../../components/VisualizationOptions/Options/TargetLine'
+import BaseLine from '../../../components/VisualizationOptions/Options/BaseLine'
+
+export default hasCustomAxes => ({
+    key: 'data-lines',
+    label: i18n.t('Lines'),
+    helpText: hasCustomAxes
+        ? i18n.t('Lines are not supported yet when using multiple axes')
+        : null,
+    content: React.Children.toArray([
+        <RegressionType disabled={hasCustomAxes} />,
+        <TargetLine disabled={hasCustomAxes} />,
+        <BaseLine disabled={hasCustomAxes} />,
+    ]),
+})

--- a/packages/app/src/modules/options/sections/verticalAxis.js
+++ b/packages/app/src/modules/options/sections/verticalAxis.js
@@ -1,0 +1,24 @@
+/* eslint-disable react/jsx-key */
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+
+import RangeAxisLabel from '../../../components/VisualizationOptions/Options/RangeAxisLabel'
+import AxisRange from '../../../components/VisualizationOptions/Options/AxisRange'
+import RangeAxisSteps from '../../../components/VisualizationOptions/Options/RangeAxisSteps'
+import RangeAxisDecimals from '../../../components/VisualizationOptions/Options/RangeAxisDecimals'
+
+export default hasCustomAxes => ({
+    key: 'axes-vertical-axis',
+    label: i18n.t('Vertical (y) axis'),
+    helpText: hasCustomAxes
+        ? i18n.t(
+              'Vertical axis options are not supported yet when using multiple axes'
+          )
+        : null,
+    content: React.Children.toArray([
+        <RangeAxisLabel disabled={hasCustomAxes} />,
+        <AxisRange disabled={hasCustomAxes} />,
+        <RangeAxisSteps disabled={hasCustomAxes} />,
+        <RangeAxisDecimals disabled={hasCustomAxes} />,
+    ]),
+})

--- a/packages/app/src/modules/options/singleValueConfig.js
+++ b/packages/app/src/modules/options/singleValueConfig.js
@@ -8,14 +8,14 @@ import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubt
 import Legend from '../../components/VisualizationOptions/Options/Legend'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 
-export default [
+export default () => [
     {
         key: 'data-tab',
-        getLabel: () => i18n.t('Data'),
+        label: i18n.t('Data'),
         content: [
             {
                 key: 'data-advanced',
-                getLabel: () => i18n.t('Advanced'),
+                label: i18n.t('Advanced'),
                 content: React.Children.toArray([
                     <AggregationType />,
                     <CompletedOnly />,
@@ -25,7 +25,7 @@ export default [
     },
     {
         key: 'legend-tab',
-        getLabel: () => i18n.t('Legend'),
+        label: i18n.t('Legend'),
         content: [
             {
                 key: 'legend-section-1',
@@ -37,11 +37,11 @@ export default [
     },
     {
         key: 'style-tab',
-        getLabel: () => i18n.t('Style'),
+        label: i18n.t('Style'),
         content: [
             {
                 key: 'style-titles',
-                getLabel: () => i18n.t('Titles'),
+                label: i18n.t('Titles'),
                 content: React.Children.toArray([
                     <HideTitle />,
                     <HideSubtitle />,

--- a/packages/app/src/modules/options/stackedColumnConfig.js
+++ b/packages/app/src/modules/options/stackedColumnConfig.js
@@ -6,30 +6,25 @@ import CumulativeValues from '../../components/VisualizationOptions/Options/Cumu
 import PercentStackedValues from '../../components/VisualizationOptions/Options/PercentStackedValues'
 import ShowData from '../../components/VisualizationOptions/Options/ShowData'
 import HideEmptyRowItems from '../../components/VisualizationOptions/Options/HideEmptyRowItems'
-import RegressionType from '../../components/VisualizationOptions/Options/RegressionType'
-import TargetLine from '../../components/VisualizationOptions/Options/TargetLine'
-import BaseLine from '../../components/VisualizationOptions/Options/BaseLine'
 import SortOrder from '../../components/VisualizationOptions/Options/SortOrder'
 import AggregationType from '../../components/VisualizationOptions/Options/AggregationType'
-import AxisRange from '../../components/VisualizationOptions/Options/AxisRange'
-import RangeAxisSteps from '../../components/VisualizationOptions/Options/RangeAxisSteps'
-import RangeAxisDecimals from '../../components/VisualizationOptions/Options/RangeAxisDecimals'
-import RangeAxisLabel from '../../components/VisualizationOptions/Options/RangeAxisLabel'
 import DomainAxisLabel from '../../components/VisualizationOptions/Options/DomainAxisLabel'
 import NoSpaceBetweenColumns from '../../components/VisualizationOptions/Options/NoSpaceBetweenColumns'
 import HideLegend from '../../components/VisualizationOptions/Options/HideLegend'
 import HideTitle from '../../components/VisualizationOptions/Options/HideTitle'
 import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubtitle'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
+import getLinesSection from './sections/lines'
+import getVerticalAxisSection from './sections/verticalAxis'
 
-export default [
+export default hasCustomAxes => [
     {
         key: 'data-tab',
-        getLabel: () => i18n.t('Data'),
+        label: i18n.t('Data'),
         content: [
             {
                 key: 'data-display',
-                getLabel: () => i18n.t('Display'),
+                label: i18n.t('Display'),
                 content: React.Children.toArray([
                     <ShowData />,
                     <PercentStackedValues />,
@@ -38,18 +33,10 @@ export default [
                     <SortOrder />,
                 ]),
             },
-            {
-                key: 'data-lines',
-                getLabel: () => i18n.t('Lines'),
-                content: React.Children.toArray([
-                    <RegressionType />,
-                    <TargetLine />,
-                    <BaseLine />,
-                ]),
-            },
+            getLinesSection(hasCustomAxes),
             {
                 key: 'data-advanced',
-                getLabel: () => i18n.t('Advanced'),
+                label: i18n.t('Advanced'),
                 content: React.Children.toArray([
                     <AggregationType />,
                     <CompletedOnly />,
@@ -59,32 +46,23 @@ export default [
     },
     {
         key: 'axes-tab',
-        getLabel: () => i18n.t('Axes'),
+        label: i18n.t('Axes'),
         content: [
-            {
-                key: 'axes-vertical-axis',
-                getLabel: () => i18n.t('Vertical (y) axis'),
-                content: React.Children.toArray([
-                    <RangeAxisLabel />,
-                    <AxisRange />,
-                    <RangeAxisSteps />,
-                    <RangeAxisDecimals />,
-                ]),
-            },
+            getVerticalAxisSection(hasCustomAxes),
             {
                 key: 'axes-horizontal-axis',
-                getLabel: () => i18n.t('Horizontal (x) axis'),
+                label: i18n.t('Horizontal (x) axis'),
                 content: React.Children.toArray([<DomainAxisLabel />]),
             },
         ],
     },
     {
         key: 'style-tab',
-        getLabel: () => i18n.t('Style'),
+        label: i18n.t('Style'),
         content: [
             {
                 key: 'style-chart-style',
-                getLabel: () => i18n.t('Chart style'),
+                label: i18n.t('Chart style'),
                 content: React.Children.toArray([
                     <NoSpaceBetweenColumns />,
                     <HideLegend />,
@@ -93,7 +71,7 @@ export default [
             },
             {
                 key: 'style-titles',
-                getLabel: () => i18n.t('Titles'),
+                label: i18n.t('Titles'),
                 content: React.Children.toArray([
                     <HideTitle />,
                     <HideSubtitle />,

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -280,11 +280,11 @@ export const sGetUiParentGraphMap = state => sGetUi(state).parentGraphMap
 export const sGetUiActiveModalDialog = state => sGetUi(state).activeModalDialog
 export const sGetUiRightSidebarOpen = state => sGetUi(state).rightSidebarOpen
 export const sGetUiInterpretation = state => sGetUi(state).interpretation
-export const sGetAxes = state => sGetUi(state).axes
+export const sGetAxes = state => sGetUi(state).axes || {}
 
 // Selectors level 2
 
-export const getAxisIdByDimensionId = (state, dimensionId) =>
+export const sGetAxisIdByDimensionId = (state, dimensionId) =>
     (getInverseLayout(sGetUiLayout(state)) || {})[dimensionId]
 
 export const sGetUiItemsByDimension = (state, dimension) =>

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "4.5.7-alpha.3",
+        "@dhis2/analytics": "4.5.8-alpha.1",
         "@dhis2/ui-core": "^4.21.1",
         "d2-analysis": "33.2.11",
         "lodash-es": "^4.17.11"

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "4.5.8-alpha.1",
+        "@dhis2/analytics": "4.5.11",
         "@dhis2/ui-core": "^4.21.1",
         "d2-analysis": "33.2.11",
         "lodash-es": "^4.17.11"

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.5.2",
+        "@dhis2/analytics": "4.5.7-alpha.2",
         "@dhis2/ui-core": "^4.21.1",
         "d2-analysis": "33.2.11",
         "lodash-es": "^4.17.11"

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "4.5.7-alpha.2",
+        "@dhis2/analytics": "4.5.7-alpha.3",
         "@dhis2/ui-core": "^4.21.1",
         "d2-analysis": "33.2.11",
         "lodash-es": "^4.17.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,6 +1233,7 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+
 "@dhis2/analytics@4.5.7-alpha.2":
   version "4.5.7-alpha.2"
   resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.5.7-alpha.2.tgz#dbf3c1b39bf4716883f970859b100d1bc252cd85"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,11 +1233,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-
-"@dhis2/analytics@4.5.7-alpha.2":
-  version "4.5.7-alpha.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.5.7-alpha.2.tgz#dbf3c1b39bf4716883f970859b100d1bc252cd85"
-  integrity sha512-nCgChB7BXzhQzDmASOQpbLUW7ZvpoE5fxBN4AUl9OeYF7xEUmsar6C1ulYLApL+rABnYBvSHZ7Z8faUhnHbbaQ==
+"@dhis2/analytics@4.5.7-alpha.3":
+  version "4.5.7-alpha.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.5.7-alpha.3.tgz#2c8b043de93f057c536aef41935bce4a898628b4"
+  integrity sha512-QbFm2mOJkPWvusQnqNyG9W7IavnyXoNnQZOaCensUVlfWtgjUEJ1MauPFf23bjMhryIA8HcfxaxUh/54hLcOzw==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.4"
     "@dhis2/ui-core" "^4.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@4.5.7-alpha.3":
-  version "4.5.7-alpha.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.5.7-alpha.3.tgz#2c8b043de93f057c536aef41935bce4a898628b4"
-  integrity sha512-QbFm2mOJkPWvusQnqNyG9W7IavnyXoNnQZOaCensUVlfWtgjUEJ1MauPFf23bjMhryIA8HcfxaxUh/54hLcOzw==
+"@dhis2/analytics@4.5.8-alpha.1":
+  version "4.5.8-alpha.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.5.8-alpha.1.tgz#bb4274574dffdda5c04362c8da92b604bf99ce68"
+  integrity sha512-/lIohjs9aPjU9vnjtkMxnU9y9QpX5NepVgzO20/a7/pyeXoKqAGJxJv4G6avvdQSZsP7hJ/AGS3G11fIGpNqjg==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.4"
     "@dhis2/ui-core" "^4.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^4.5.2":
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.5.2.tgz#1dea46d684ca85c30be7c869b40648aa6859ba5f"
-  integrity sha512-FSSXU4W2gZfYR46D5wrTFFP1WhvMSx6KQkO5VUsXRlQbRzuDzE1Xn3wTmzOnWFIDlw6pB647ZYn6UihnozUarQ==
+"@dhis2/analytics@4.5.7-alpha.2":
+  version "4.5.7-alpha.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.5.7-alpha.2.tgz#dbf3c1b39bf4716883f970859b100d1bc252cd85"
+  integrity sha512-nCgChB7BXzhQzDmASOQpbLUW7ZvpoE5fxBN4AUl9OeYF7xEUmsar6C1ulYLApL+rABnYBvSHZ7Z8faUhnHbbaQ==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.4"
     "@dhis2/ui-core" "^4.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@4.5.8-alpha.1":
-  version "4.5.8-alpha.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.5.8-alpha.1.tgz#bb4274574dffdda5c04362c8da92b604bf99ce68"
-  integrity sha512-/lIohjs9aPjU9vnjtkMxnU9y9QpX5NepVgzO20/a7/pyeXoKqAGJxJv4G6avvdQSZsP7hJ/AGS3G11fIGpNqjg==
+"@dhis2/analytics@4.5.11":
+  version "4.5.11"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.5.11.tgz#6328e9cefe88f3cb70595cafe7d6503c7c8b1e6e"
+  integrity sha512-7g6DWf//ZgR11mFvlSf7wGplTCFEOhVhjA/G4eNmgkT5knZO8yCdN1qbCT4p2L3HOH3MSdGWPPdCU+72Af84lg==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.4"
     "@dhis2/ui-core" "^4.16.0"


### PR DESCRIPTION
Backport of https://github.com/dhis2/data-visualizer-app/pull/1171 to v34

**Depends on https://github.com/dhis2/analytics/pull/568**

Had to change quite a lot and strip the cherry-pick, since not all from the master PR was applicable to 34.x. However that should've made the changes in this PR somewhat simpler to review 🙂 

I've gone through all option tabs for all vis types to look for anomalies, but I think all looks fine now. However as part of this review it would be good to do some local regression testing (which is why I didn't include any screenshots).

**TODO:**
- [x] change `alpha` to final Analytics version once released