### PR TITLE
fix: fix double bottom border in Download menu

### DIFF
--- a/packages/app/src/components/DownloadMenu/DownloadMenu.js
+++ b/packages/app/src/components/DownloadMenu/DownloadMenu.js
@@ -8,7 +8,13 @@ import ImageIcon from '@material-ui/icons/Image'
 import PictureAsPdfIcon from '@material-ui/icons/PictureAsPdf'
 import ListIcon from '@material-ui/icons/List'
 import ListAltIcon from '@material-ui/icons/ListAlt'
-import { FlyoutMenu, MenuItem, Divider, Popper, colors } from '@dhis2/ui'
+import {
+    FlyoutMenu,
+    MenuSectionHeader,
+    MenuItem,
+    Popper,
+    colors,
+} from '@dhis2/ui'
 import { VIS_TYPE_PIVOT_TABLE } from '@dhis2/analytics'
 
 import {
@@ -39,7 +45,7 @@ const DenseMenuItem = ({ Icon, children, ...rest }) => (
 
 DenseMenuItem.propTypes = {
     Icon: PropTypes.elementType,
-    children: PropTypes.element,
+    children: PropTypes.array,
 }
 
 export const DownloadMenu = ({
@@ -99,64 +105,59 @@ export const DownloadMenu = ({
         window.open(url, format === 'html' ? '_blank' : '_top')
     }
 
-    const graphicsMenuSection = () => (
-        <>
-            <div className={styles.menuSectionTitle}>{i18n.t('Graphics')}</div>
+    /* eslint-disable react/jsx-key */
+    const graphicsMenuSection = () =>
+        React.Children.toArray([
+            <MenuSectionHeader label={i18n.t('Graphics')} />,
             <DenseMenuItem
                 Icon={ImageIcon}
                 label={i18n.t('Image (.png)')}
                 onClick={downloadImage('png')}
-            />
+            />,
             <DenseMenuItem
                 Icon={PictureAsPdfIcon}
                 label={i18n.t('PDF (.pdf)')}
                 onClick={downloadImage('pdf')}
-            />
-        </>
-    )
+            />,
+        ])
 
-    const tableMenuSection = () => (
-        <>
-            <div className={styles.menuSectionTitle}>
-                {i18n.t('Table layout')}
-            </div>
+    const tableMenuSection = () =>
+        React.Children.toArray([
+            <MenuSectionHeader label={i18n.t('Table layout')} />,
             <DenseMenuItem
                 Icon={ListAltIcon}
                 label={i18n.t('Excel (.xls)')}
                 onClick={downloadTable('xls')}
-            />
+            />,
             <DenseMenuItem
                 Icon={ListAltIcon}
                 label={i18n.t('CSV (.csv)')}
                 onClick={downloadTable('csv')}
-            />
+            />,
             <DenseMenuItem
                 Icon={ListAltIcon}
                 label={i18n.t('HTML (.html)')}
                 onClick={downloadTable('html')}
-            />
-        </>
-    )
+            />,
+        ])
 
-    const plainDataSourceSubLevel = format => (
-        <FlyoutMenu>
-            <div className={styles.menuSectionTitle}>
-                {i18n.t('Metadata ID scheme')}
-            </div>
+    const plainDataSourceSubLevel = format =>
+        React.Children.toArray([
+            <MenuSectionHeader label={i18n.t('Metadata ID scheme')} />,
             <DenseMenuItem
                 label={i18n.t('ID')}
                 onClick={downloadData(format, 'UID')}
-            />
+            />,
             <DenseMenuItem
                 label={i18n.t('Code')}
                 onClick={downloadData(format, 'CODE')}
-            />
+            />,
             <DenseMenuItem
                 label={i18n.t('Name')}
                 onClick={downloadData(format, 'NAME')}
-            />
-        </FlyoutMenu>
-    )
+            />,
+        ])
+    /* eslint-enable react/jsx-key */
 
     const buttonRef = createRef()
 
@@ -175,10 +176,9 @@ export const DownloadMenu = ({
                                 {visType === VIS_TYPE_PIVOT_TABLE
                                     ? tableMenuSection()
                                     : graphicsMenuSection()}
-                                <Divider />
-                                <div className={styles.menuSectionTitle}>
-                                    {i18n.t('Plain data source')}
-                                </div>
+                                <MenuSectionHeader
+                                    label={i18n.t('Plain data source')}
+                                />
                                 <DenseMenuItem
                                     Icon={ListIcon}
                                     label={i18n.t('JSON')}
@@ -207,47 +207,40 @@ export const DownloadMenu = ({
                                     Icon={MoreHorizontalIcon}
                                     label={i18n.t('Advanced')}
                                 >
-                                    <FlyoutMenu>
-                                        <div
-                                            className={styles.menuSectionTitle}
-                                        >
-                                            {i18n.t('Data value set')}
-                                        </div>
-                                        <DenseMenuItem
-                                            label={i18n.t('JSON')}
-                                            onClick={downloadData(
-                                                'json',
-                                                null,
-                                                'dataValueSet'
-                                            )}
-                                        />
-                                        <DenseMenuItem
-                                            label={i18n.t('XML')}
-                                            onClick={downloadData(
-                                                'xml',
-                                                null,
-                                                'dataValueSet'
-                                            )}
-                                        />
-                                        <Divider />
-                                        <div
-                                            className={styles.menuSectionTitle}
-                                        >
-                                            {i18n.t('Other formats')}
-                                        </div>
-                                        <DenseMenuItem
-                                            label={i18n.t('JRXML')}
-                                            onClick={downloadData('jrxml')}
-                                        />
-                                        <DenseMenuItem
-                                            label={i18n.t('Raw data SQL')}
-                                            onClick={downloadData(
-                                                'sql',
-                                                null,
-                                                'debug/sql'
-                                            )}
-                                        />
-                                    </FlyoutMenu>
+                                    <MenuSectionHeader
+                                        label={i18n.t('Data value set')}
+                                    />
+                                    <DenseMenuItem
+                                        label={i18n.t('JSON')}
+                                        onClick={downloadData(
+                                            'json',
+                                            null,
+                                            'dataValueSet'
+                                        )}
+                                    />
+                                    <DenseMenuItem
+                                        label={i18n.t('XML')}
+                                        onClick={downloadData(
+                                            'xml',
+                                            null,
+                                            'dataValueSet'
+                                        )}
+                                    />
+                                    <MenuSectionHeader
+                                        label={i18n.t('Other formats')}
+                                    />
+                                    <DenseMenuItem
+                                        label={i18n.t('JRXML')}
+                                        onClick={downloadData('jrxml')}
+                                    />
+                                    <DenseMenuItem
+                                        label={i18n.t('Raw data SQL')}
+                                        onClick={downloadData(
+                                            'sql',
+                                            null,
+                                            'debug/sql'
+                                        )}
+                                    />
                                 </DenseMenuItem>
                             </FlyoutMenu>
                         </Popper>

--- a/packages/app/src/components/DownloadMenu/DownloadMenu.js
+++ b/packages/app/src/components/DownloadMenu/DownloadMenu.js
@@ -1,5 +1,4 @@
 import React, { useState, createRef } from 'react'
-import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { createSelector } from 'reselect'
@@ -12,7 +11,7 @@ import {
     FlyoutMenu,
     MenuSectionHeader,
     MenuItem,
-    Popper,
+    Popover,
     colors,
 } from '@dhis2/ui'
 import { VIS_TYPE_PIVOT_TABLE } from '@dhis2/analytics'
@@ -31,7 +30,6 @@ import {
 } from '../../api/analytics'
 import MenuButton from '../MenuButton/MenuButton'
 import MoreHorizontalIcon from '../../assets/MoreHorizontalIcon'
-import styles from './styles/DownloadMenu.module.css'
 
 const DenseMenuItem = ({ Icon, children, ...rest }) => (
     <MenuItem
@@ -168,85 +166,70 @@ export const DownloadMenu = ({
                     {i18n.t('Download')}
                 </MenuButton>
             </div>
-            {dialogIsOpen &&
-                createPortal(
-                    <div onClick={toggleMenu} className={styles.backdrop}>
-                        <Popper reference={buttonRef} placement="bottom-start">
-                            <FlyoutMenu>
-                                {visType === VIS_TYPE_PIVOT_TABLE
-                                    ? tableMenuSection()
-                                    : graphicsMenuSection()}
-                                <MenuSectionHeader
-                                    label={i18n.t('Plain data source')}
-                                />
-                                <DenseMenuItem
-                                    Icon={ListIcon}
-                                    label={i18n.t('JSON')}
-                                >
-                                    {plainDataSourceSubLevel('json')}
-                                </DenseMenuItem>
-                                <DenseMenuItem
-                                    Icon={ListIcon}
-                                    label={i18n.t('XML')}
-                                >
-                                    {plainDataSourceSubLevel('xml')}
-                                </DenseMenuItem>
-                                <DenseMenuItem
-                                    Icon={ListIcon}
-                                    label={i18n.t('Excel')}
-                                >
-                                    {plainDataSourceSubLevel('xls')}
-                                </DenseMenuItem>
-                                <DenseMenuItem
-                                    Icon={ListIcon}
-                                    label={i18n.t('CSV')}
-                                >
-                                    {plainDataSourceSubLevel('csv')}
-                                </DenseMenuItem>
-                                <DenseMenuItem
-                                    Icon={MoreHorizontalIcon}
-                                    label={i18n.t('Advanced')}
-                                >
-                                    <MenuSectionHeader
-                                        label={i18n.t('Data value set')}
-                                    />
-                                    <DenseMenuItem
-                                        label={i18n.t('JSON')}
-                                        onClick={downloadData(
-                                            'json',
-                                            null,
-                                            'dataValueSet'
-                                        )}
-                                    />
-                                    <DenseMenuItem
-                                        label={i18n.t('XML')}
-                                        onClick={downloadData(
-                                            'xml',
-                                            null,
-                                            'dataValueSet'
-                                        )}
-                                    />
-                                    <MenuSectionHeader
-                                        label={i18n.t('Other formats')}
-                                    />
-                                    <DenseMenuItem
-                                        label={i18n.t('JRXML')}
-                                        onClick={downloadData('jrxml')}
-                                    />
-                                    <DenseMenuItem
-                                        label={i18n.t('Raw data SQL')}
-                                        onClick={downloadData(
-                                            'sql',
-                                            null,
-                                            'debug/sql'
-                                        )}
-                                    />
-                                </DenseMenuItem>
-                            </FlyoutMenu>
-                        </Popper>
-                    </div>,
-                    document.body
-                )}
+            {dialogIsOpen && (
+                <Popover
+                    arrow={false}
+                    reference={buttonRef}
+                    placement="bottom-start"
+                    onClickOutside={toggleMenu}
+                >
+                    <FlyoutMenu>
+                        {visType === VIS_TYPE_PIVOT_TABLE
+                            ? tableMenuSection()
+                            : graphicsMenuSection()}
+                        <MenuSectionHeader
+                            label={i18n.t('Plain data source')}
+                        />
+                        <DenseMenuItem Icon={ListIcon} label={i18n.t('JSON')}>
+                            {plainDataSourceSubLevel('json')}
+                        </DenseMenuItem>
+                        <DenseMenuItem Icon={ListIcon} label={i18n.t('XML')}>
+                            {plainDataSourceSubLevel('xml')}
+                        </DenseMenuItem>
+                        <DenseMenuItem Icon={ListIcon} label={i18n.t('Excel')}>
+                            {plainDataSourceSubLevel('xls')}
+                        </DenseMenuItem>
+                        <DenseMenuItem Icon={ListIcon} label={i18n.t('CSV')}>
+                            {plainDataSourceSubLevel('csv')}
+                        </DenseMenuItem>
+                        <DenseMenuItem
+                            Icon={MoreHorizontalIcon}
+                            label={i18n.t('Advanced')}
+                        >
+                            <MenuSectionHeader
+                                label={i18n.t('Data value set')}
+                            />
+                            <DenseMenuItem
+                                label={i18n.t('JSON')}
+                                onClick={downloadData(
+                                    'json',
+                                    null,
+                                    'dataValueSet'
+                                )}
+                            />
+                            <DenseMenuItem
+                                label={i18n.t('XML')}
+                                onClick={downloadData(
+                                    'xml',
+                                    null,
+                                    'dataValueSet'
+                                )}
+                            />
+                            <MenuSectionHeader
+                                label={i18n.t('Other formats')}
+                            />
+                            <DenseMenuItem
+                                label={i18n.t('JRXML')}
+                                onClick={downloadData('jrxml')}
+                            />
+                            <DenseMenuItem
+                                label={i18n.t('Raw data SQL')}
+                                onClick={downloadData('sql', null, 'debug/sql')}
+                            />
+                        </DenseMenuItem>
+                    </FlyoutMenu>
+                </Popover>
+            )}
         </>
     )
 }

--- a/packages/app/src/components/DownloadMenu/styles/DownloadMenu.module.css
+++ b/packages/app/src/components/DownloadMenu/styles/DownloadMenu.module.css
@@ -1,8 +1,0 @@
-.backdrop {
-    position: fixed;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-    background-color: transparent;
-}

--- a/packages/app/src/components/DownloadMenu/styles/DownloadMenu.module.css
+++ b/packages/app/src/components/DownloadMenu/styles/DownloadMenu.module.css
@@ -6,9 +6,3 @@
     left: 0;
     background-color: transparent;
 }
-
-.menuSectionTitle {
-    font-size: 14px;
-    font-weight: 500;
-    padding: var(--spacers-dp8) var(--spacers-dp12);
-}


### PR DESCRIPTION
A double bottom border was showing in the sub-levels of the Download menu.
Fixed by properly using the `@dhis2/ui` components.
The sub-levels look a bit different than before, but now the correct ui components are used instead of divs with custom styling.

Before:
![Screenshot 2020-08-24 at 15 49 33](https://user-images.githubusercontent.com/150978/91165146-7f353180-e6d0-11ea-92ca-f5e53dc21e41.png)

After:
![Screenshot 2020-08-25 at 16 18 23](https://user-images.githubusercontent.com/150978/91185884-a26ed980-e6ee-11ea-8f45-07d65d8ded1c.png)

There is a small issue with a double bottom border on the main menu which happens when using `FlyOut` within a `Popover` component. @dhis2/team-apps has been notified.
This issue will be likely fixed in a later patch.