### PR TITLE
fix: enable skipRounding and digitGroupSeparator options for SV (DHIS2-9340)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^8.9.6",
+        "@dhis2/analytics": "^8.9.7",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.0.5",

--- a/packages/app/src/modules/options/singleValueConfig.js
+++ b/packages/app/src/modules/options/singleValueConfig.js
@@ -8,12 +8,18 @@ import HideSubtitle from '../../components/VisualizationOptions/Options/HideSubt
 import Legend from '../../components/VisualizationOptions/Options/Legend'
 import CompletedOnly from '../../components/VisualizationOptions/Options/CompletedOnly'
 import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTable'
+import SkipRounding from '../../components/VisualizationOptions/Options/SkipRounding'
+import DigitGroupSeparator from '../../components/VisualizationOptions/Options/DigitGroupSeparator'
 
 export default () => [
     {
         key: 'data-tab',
         label: i18n.t('Data'),
         content: [
+            {
+                key: 'data-section-1',
+                content: React.Children.toArray([<SkipRounding />]),
+            },
             {
                 key: 'data-advanced',
                 label: i18n.t('Advanced'),
@@ -56,6 +62,7 @@ export default () => [
                 content: React.Children.toArray([
                     <HideTitle />,
                     <HideSubtitle />,
+                    <DigitGroupSeparator />,
                 ]),
             },
         ],

--- a/packages/app/src/modules/options/singleValueConfig.js
+++ b/packages/app/src/modules/options/singleValueConfig.js
@@ -62,8 +62,11 @@ export default () => [
                 content: React.Children.toArray([
                     <HideTitle />,
                     <HideSubtitle />,
-                    <DigitGroupSeparator />,
                 ]),
+            },
+            {
+                key: 'style-section-2',
+                content: React.Children.toArray([<DigitGroupSeparator />]),
             },
         ],
     },

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^8.9.6",
+        "@dhis2/analytics": "^8.9.7",
         "@dhis2/ui": "^5.5.2",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,7 +143,7 @@
     "@babel/helper-regex" "^7.10.1"
     regexpu-core "^4.7.0"
 
-"@babel/helper-define-map@^7.10.1", "@babel/helper-define-map@^7.10.3":
+"@babel/helper-define-map@^7.10.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.10.3.tgz#d27120a5e57c84727b30944549b2dfeca62401a8"
   integrity sha512-bxRzDi4Sin/k0drWCczppOhov1sBSdBvXJObM1NLHQzjhXhwRtn7aRWGvLJWCYbuu2qUk3EKs6Ci9C9ps8XokQ==
@@ -176,7 +176,7 @@
   dependencies:
     "@babel/types" "^7.10.3"
 
-"@babel/helper-hoist-variables@^7.10.1", "@babel/helper-hoist-variables@^7.10.3":
+"@babel/helper-hoist-variables@^7.10.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.3.tgz#d554f52baf1657ffbd7e5137311abc993bb3f068"
   integrity sha512-9JyafKoBt5h20Yv1+BXQMdcXXavozI1vt401KBiRc2qzUepbVnd7ogVNymY1xkQN9fekGwfxtotH2Yf5xsGzgg==
@@ -265,7 +265,7 @@
   dependencies:
     "@babel/types" "^7.10.1"
 
-"@babel/helper-validator-identifier@^7.10.1", "@babel/helper-validator-identifier@^7.10.3":
+"@babel/helper-validator-identifier@^7.10.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz#60d9847f98c4cea1b279e005fdb7c28be5412d15"
   integrity sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==
@@ -289,7 +289,7 @@
     "@babel/traverse" "^7.10.1"
     "@babel/types" "^7.10.1"
 
-"@babel/highlight@^7.10.1", "@babel/highlight@^7.10.3", "@babel/highlight@^7.8.3":
+"@babel/highlight@^7.10.3", "@babel/highlight@^7.8.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.3.tgz#c633bb34adf07c5c13156692f5922c81ec53f28d"
   integrity sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==
@@ -1302,13 +1302,13 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^8.9.6":
-  version "8.9.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-8.9.6.tgz#22050cf44dee666312235816427b476d14e39e9b"
-  integrity sha512-7tBfFIQtaZ19WbeQTUA5R1qvRj1c8N+AwHJbsMdNArWLyEL5R7H+A4PjK93hDm1iiBbstuyL1BuN2uwBb85keA==
+"@dhis2/analytics@^8.9.7":
+  version "8.9.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-8.9.7.tgz#82edcc8334fb02909f90946c357ca6cdeacf40d1"
+  integrity sha512-TWIoo1vxBEa/50sOyVL1mp0EPcaMRXxdgEn46F7TMFlgTfJ8XDhulbCJQ5YcbYvMsuXxvfw9PrdLi0NTfxhOHw==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.4"
-    "@dhis2/ui" "^5.5.1"
+    "@dhis2/ui" "^5.5.2"
     "@material-ui/core" "^3.9.3"
     "@material-ui/icons" "^3.0.2"
     classnames "^2.2.6"
@@ -1632,7 +1632,7 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.4.2", "@dhis2/ui@^5.5.1", "@dhis2/ui@^5.5.2":
+"@dhis2/ui@^5.4.2", "@dhis2/ui@^5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.5.2.tgz#4644df2a219d019d1f0e5fc3915f8ec8366a5709"
   integrity sha512-c1qr/4F8Pn4PcCXIFxKbFV/XtD40Z4qxan5GeuOPJXV8WFoyEuRIqpXJghH40wD4pAlCg8ddp184nIgWw4mgWg==
@@ -13461,7 +13461,7 @@ string.prototype.trim@^1.2.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
 
-string.prototype.trimend@^1.0.0, string.prototype.trimend@^1.0.1:
+string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
   integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
@@ -13469,25 +13469,7 @@ string.prototype.trimend@^1.0.0, string.prototype.trimend@^1.0.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
-string.prototype.trimleft@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz#4408aa2e5d6ddd0c9a80739b087fbc067c03b3cc"
-  integrity sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimstart "^1.0.0"
-
-string.prototype.trimright@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz#c76f1cef30f21bbad8afeb8db1511496cfb0f2a3"
-  integrity sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimend "^1.0.0"
-
-string.prototype.trimstart@^1.0.0, string.prototype.trimstart@^1.0.1:
+string.prototype.trimstart@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
   integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==


### PR DESCRIPTION
Fixes [DHIS2-9340](https://jira.dhis2.org/browse/DHIS2-9340).

Depends on https://github.com/dhis2/analytics/pull/571.

This allows to format the numeric value in SV with a thousands separator.
It uses the same functions PT uses and looks at the `skipRounding` and `digitGroupSeparator` options, now available in the `Data` and `Style` option tabs.

Options:
![Screenshot 2020-08-26 at 12 20 15](https://user-images.githubusercontent.com/150978/91292277-92123980-e796-11ea-8c9a-7993115cbb33.png)
![Screenshot 2020-08-26 at 12 20 26](https://user-images.githubusercontent.com/150978/91292287-950d2a00-e796-11ea-9596-ece799509a59.png)

Here's an example of a value with comma as digit group separator:
![Screenshot 2020-08-26 at 12 21 47](https://user-images.githubusercontent.com/150978/91292403-bb32ca00-e796-11ea-9cc5-13ba9e858e41.png)


