### PR TITLE
feat: move dx to filter for YOY which allows for multiple dx items (DHIS2-8808)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^8.9.6",
+        "@dhis2/analytics": "^9.0.0",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.0.5",

--- a/packages/app/src/modules/current.js
+++ b/packages/app/src/modules/current.js
@@ -140,20 +140,21 @@ export const getPieCurrentFromUi = (state, action) => {
 export const getYearOverYearCurrentFromUi = (state, action) => {
     const ui = action.value
 
-    const dxItem = ui.itemsByDimension[DIMENSION_ID_DATA]
-        ? [ui.itemsByDimension[DIMENSION_ID_DATA][0]]
-        : []
+    const periodDimension = dimensionCreate(
+        DIMENSION_ID_PERIOD,
+        ui.yearOverYearCategory
+    )
+
+    const filtersWithoutPeriod = getAxesFromUi(ui).filters.filter(
+        f => f.dimension !== DIMENSION_ID_PERIOD
+    )
 
     return {
         ...state,
         [BASE_FIELD_TYPE]: ui.type,
-        [AXIS_ID_COLUMNS]: [dimensionCreate(DIMENSION_ID_DATA, dxItem)],
-        [AXIS_ID_ROWS]: [
-            dimensionCreate(DIMENSION_ID_PERIOD, ui.yearOverYearCategory),
-        ],
-        [AXIS_ID_FILTERS]: getAxesFromUi(ui).filters.filter(
-            f => ![DIMENSION_ID_DATA, DIMENSION_ID_PERIOD].includes(f.dimension)
-        ),
+        [AXIS_ID_COLUMNS]: [],
+        [AXIS_ID_ROWS]: [periodDimension],
+        [AXIS_ID_FILTERS]: filtersWithoutPeriod,
         [[BASE_FIELD_YEARLY_SERIES]]: ui.yearOverYearSeries,
         ...getOptionsFromUi(ui),
     }

--- a/packages/app/src/modules/current.js
+++ b/packages/app/src/modules/current.js
@@ -145,16 +145,12 @@ export const getYearOverYearCurrentFromUi = (state, action) => {
         ui.yearOverYearCategory
     )
 
-    const filtersWithoutPeriod = getAxesFromUi(ui).filters.filter(
-        f => f.dimension !== DIMENSION_ID_PERIOD
-    )
-
     return {
         ...state,
         [BASE_FIELD_TYPE]: ui.type,
         [AXIS_ID_COLUMNS]: [],
         [AXIS_ID_ROWS]: [periodDimension],
-        [AXIS_ID_FILTERS]: filtersWithoutPeriod,
+        [AXIS_ID_FILTERS]: getAxesFromUi(ui).filters,
         [[BASE_FIELD_YEARLY_SERIES]]: ui.yearOverYearSeries,
         ...getOptionsFromUi(ui),
     }

--- a/packages/app/src/reducers/__tests__/current.spec.js
+++ b/packages/app/src/reducers/__tests__/current.spec.js
@@ -113,12 +113,7 @@ describe('reducer: current', () => {
         const expectedState = {
             ...getOptionsFromUi(ui),
             type: ui.type,
-            columns: [
-                {
-                    dimension: DIMENSION_ID_DATA,
-                    items: [{ id: 'dxItemId1' }],
-                },
-            ],
+            columns: [],
             rows: [
                 {
                     dimension: DIMENSION_ID_PERIOD,
@@ -126,6 +121,10 @@ describe('reducer: current', () => {
                 },
             ],
             filters: [
+                {
+                    dimension: DIMENSION_ID_DATA,
+                    items: [{ id: 'dxItemId1' }, { id: 'dxItemId2' }],
+                },
                 {
                     dimension: DIMENSION_ID_ORGUNIT,
                     items: [{ id: 'ouItemId1' }, { id: 'ouItemId2' }],

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^8.9.6",
+        "@dhis2/analytics": "^9.0.0",
         "@dhis2/ui": "^5.5.2",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,8 +1302,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^8.9.6", "@dhis2/analytics@file:../analytics":
-  version "8.9.6"
+"@dhis2/analytics@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-9.0.0.tgz#ea4574ea6c79f7149c0ba1b2fe987dba6178158b"
+  integrity sha512-/lConSxUdMbYyw/vhPzAtw5tbNkZ2CHujzKCSmeDbrISzdJT+9adFzN3vIq6ouvS7AjnlbZpN1PnCHA9GTZanA==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.4"
     "@dhis2/ui" "^5.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,7 +143,7 @@
     "@babel/helper-regex" "^7.10.1"
     regexpu-core "^4.7.0"
 
-"@babel/helper-define-map@^7.10.1", "@babel/helper-define-map@^7.10.3":
+"@babel/helper-define-map@^7.10.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.10.3.tgz#d27120a5e57c84727b30944549b2dfeca62401a8"
   integrity sha512-bxRzDi4Sin/k0drWCczppOhov1sBSdBvXJObM1NLHQzjhXhwRtn7aRWGvLJWCYbuu2qUk3EKs6Ci9C9ps8XokQ==
@@ -176,7 +176,7 @@
   dependencies:
     "@babel/types" "^7.10.3"
 
-"@babel/helper-hoist-variables@^7.10.1", "@babel/helper-hoist-variables@^7.10.3":
+"@babel/helper-hoist-variables@^7.10.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.3.tgz#d554f52baf1657ffbd7e5137311abc993bb3f068"
   integrity sha512-9JyafKoBt5h20Yv1+BXQMdcXXavozI1vt401KBiRc2qzUepbVnd7ogVNymY1xkQN9fekGwfxtotH2Yf5xsGzgg==
@@ -265,7 +265,7 @@
   dependencies:
     "@babel/types" "^7.10.1"
 
-"@babel/helper-validator-identifier@^7.10.1", "@babel/helper-validator-identifier@^7.10.3":
+"@babel/helper-validator-identifier@^7.10.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz#60d9847f98c4cea1b279e005fdb7c28be5412d15"
   integrity sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==
@@ -289,7 +289,7 @@
     "@babel/traverse" "^7.10.1"
     "@babel/types" "^7.10.1"
 
-"@babel/highlight@^7.10.1", "@babel/highlight@^7.10.3", "@babel/highlight@^7.8.3":
+"@babel/highlight@^7.10.3", "@babel/highlight@^7.8.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.3.tgz#c633bb34adf07c5c13156692f5922c81ec53f28d"
   integrity sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==
@@ -1302,13 +1302,11 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^8.9.6":
+"@dhis2/analytics@^8.9.6", "@dhis2/analytics@file:../analytics":
   version "8.9.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-8.9.6.tgz#22050cf44dee666312235816427b476d14e39e9b"
-  integrity sha512-7tBfFIQtaZ19WbeQTUA5R1qvRj1c8N+AwHJbsMdNArWLyEL5R7H+A4PjK93hDm1iiBbstuyL1BuN2uwBb85keA==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.4"
-    "@dhis2/ui" "^5.5.1"
+    "@dhis2/ui" "^5.5.2"
     "@material-ui/core" "^3.9.3"
     "@material-ui/icons" "^3.0.2"
     classnames "^2.2.6"
@@ -1632,7 +1630,7 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.4.2", "@dhis2/ui@^5.5.1", "@dhis2/ui@^5.5.2":
+"@dhis2/ui@^5.4.2", "@dhis2/ui@^5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.5.2.tgz#4644df2a219d019d1f0e5fc3915f8ec8366a5709"
   integrity sha512-c1qr/4F8Pn4PcCXIFxKbFV/XtD40Z4qxan5GeuOPJXV8WFoyEuRIqpXJghH40wD4pAlCg8ddp184nIgWw4mgWg==
@@ -13461,7 +13459,7 @@ string.prototype.trim@^1.2.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
 
-string.prototype.trimend@^1.0.0, string.prototype.trimend@^1.0.1:
+string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
   integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
@@ -13469,25 +13467,7 @@ string.prototype.trimend@^1.0.0, string.prototype.trimend@^1.0.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
-string.prototype.trimleft@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz#4408aa2e5d6ddd0c9a80739b087fbc067c03b3cc"
-  integrity sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimstart "^1.0.0"
-
-string.prototype.trimright@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz#c76f1cef30f21bbad8afeb8db1511496cfb0f2a3"
-  integrity sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimend "^1.0.0"
-
-string.prototype.trimstart@^1.0.0, string.prototype.trimstart@^1.0.1:
+string.prototype.trimstart@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
   integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==


### PR DESCRIPTION
Depends on https://github.com/dhis2/analytics/pull/574

Fixes [DHIS2-8808](https://jira.dhis2.org/browse/DHIS2-8808)

The `dx` dimension is now always `filter`, both in the app and the backend. The restriction where only the first item was picked has been removed.

![Screenshot from 2020-08-28 10-30-45](https://user-images.githubusercontent.com/1010094/91539483-afbbdc00-e919-11ea-9dcd-fd483f617d9f.png)
