### PR TITLE
feat: allow YOY without dx (DHIS2-8806)

### DIFF
--- a/packages/app/src/modules/layoutValidation.js
+++ b/packages/app/src/modules/layoutValidation.js
@@ -68,11 +68,6 @@ const validatePivotTableLayout = layout => {
 }
 
 const validateYearOverYearLayout = layout => {
-    validateDimension(
-        layoutGetDimension(layout, DIMENSION_ID_DATA),
-        new NoDataError(layout.type)
-    )
-
     if (
         !(
             Array.isArray(layout[BASE_FIELD_YEARLY_SERIES]) &&


### PR DESCRIPTION
Depends on https://github.com/dhis2/analytics/pull/574 for the feature to work, but can safely be merged without it.

Removes the `dx` requirement for YOY types. If no DEGS or `dx` the server returns a `E7102` which is already handled by DV.