### PR TITLE
fix: Custom error message for deleting an AO used in Dashboards (DHIS2-9310)

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-19T13:40:23.821Z\n"
-"PO-Revision-Date: 2020-08-19T13:40:23.821Z\n"
+"POT-Creation-Date: 2020-08-28T08:43:36.773Z\n"
+"PO-Revision-Date: 2020-08-28T08:43:36.773Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -177,6 +177,11 @@ msgid "Select a period"
 msgstr ""
 
 msgid "Select years"
+msgstr ""
+
+msgid ""
+"This visualization can't be deleted because it is used on one or more "
+"dashboards"
 msgstr ""
 
 msgid "Unsaved visualization"

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import FileMenu from '@dhis2/d2-ui-file-menu'
+import i18n from '@dhis2/d2-i18n'
 
 import UpdateButton from '../UpdateButton/UpdateButton'
 import DownloadMenu from '../DownloadMenu/DownloadMenu'
@@ -11,7 +12,8 @@ import UpdateVisualizationContainer from '../UpdateButton/UpdateVisualizationCon
 import * as fromActions from '../../actions'
 import { sGetCurrent } from '../../reducers/current'
 import history from '../../modules/history'
-import { parseError } from '../../modules/error'
+import { getErrorVariantByStatusCode } from '../../modules/error'
+
 import styles from './styles/MenuBar.module.css'
 
 const onOpen = id => {
@@ -79,11 +81,17 @@ const mapDispatchToProps = dispatch => ({
         dispatch(fromActions.tDoSaveVisualization(details, copy)),
     onDeleteVisualization: () => dispatch(fromActions.tDoDeleteVisualization()),
     onError: error => {
-        const { type, message } = parseError(error)
+        const message =
+            error.errorCode === 'E4030'
+                ? i18n.t(
+                      "This visualization can't be deleted because it is used on one or more dashboards"
+                  )
+                : error.message
+        const variant = getErrorVariantByStatusCode(error.httpStatusCode)
 
         dispatch(
             fromActions.fromSnackbar.acReceivedSnackbarMessage({
-                variant: type,
+                variant,
                 message,
             })
         )

--- a/packages/app/src/modules/__tests__/error.spec.js
+++ b/packages/app/src/modules/__tests__/error.spec.js
@@ -1,6 +1,6 @@
-import { parseError } from '../error'
+import { getErrorVariantByStatusCode } from '../error'
 
-describe('parseError', () => {
+describe('getErrorVariantByStatusCode', () => {
     let error
 
     beforeEach(() => {
@@ -12,32 +12,29 @@ describe('parseError', () => {
         }
     })
 
-    it('should return an object with type and message', () => {
-        const expectedResult = {
-            type: 'warning',
-            message: 'test',
-        }
+    it('should return type warning by default', () => {
+        const expectedResult = 'warning'
 
-        expect(parseError(error)).toEqual(expectedResult)
+        expect(getErrorVariantByStatusCode(error.httpStatusCode)).toEqual(
+            expectedResult
+        )
     })
 
-    it('should return a warning type error when HTTP status code is not 500', () => {
-        const expectedResult = {
-            type: 'warning',
-            message: 'test',
-        }
+    it('should return type warning when HTTP status code is not 500', () => {
+        const expectedResult = 'warning'
 
-        expect(parseError(error)).toEqual(expectedResult)
+        expect(getErrorVariantByStatusCode(error.httpStatusCode)).toEqual(
+            expectedResult
+        )
     })
 
-    it('should return a error type when HTTP status code is 500', () => {
+    it('should return type error when HTTP status code is 500', () => {
         error.httpStatusCode = 500
 
-        const expectedResult = {
-            type: 'error',
-            message: 'test',
-        }
+        const expectedResult = 'error'
 
-        expect(parseError(error)).toEqual(expectedResult)
+        expect(getErrorVariantByStatusCode(error.httpStatusCode)).toEqual(
+            expectedResult
+        )
     })
 })

--- a/packages/app/src/modules/error.js
+++ b/packages/app/src/modules/error.js
@@ -277,9 +277,5 @@ const getAvailableAxesDescription = visType => {
     return axesDescription
 }
 
-export const parseError = ({ message, httpStatusCode }) => ({
-    message,
-    type: String(httpStatusCode).match(/50\d/)
-        ? VARIANT_ERROR
-        : VARIANT_WARNING,
-})
+export const getErrorVariantByStatusCode = statusCode =>
+    String(statusCode).match(/50\d/) ? VARIANT_ERROR : VARIANT_WARNING


### PR DESCRIPTION
Fixes [DHIS2-9310](https://jira.dhis2.org/browse/DHIS2-9310)

- Refactors the `parseError` to become a more generic function `getErrorVariantByStatusCode` instead
- Catches the new error code `E4030` and sets a custom message that replaces the default (server-side) message.
- Updates the tests to work accordingly.

![image](https://user-images.githubusercontent.com/12590483/91548101-2e6a4680-e925-11ea-95c8-f5d6f45d426c.png)
