### PR TITLE
fix: set a default name if saved vis is untitled (DHIS2-9360)

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,10 +5,13 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-19T13:40:23.821Z\n"
-"PO-Revision-Date: 2020-08-19T13:40:23.821Z\n"
+"POT-Creation-Date: 2020-08-28T12:56:12.965Z\n"
+"PO-Revision-Date: 2020-08-28T12:56:12.965Z\n"
 
 msgid "Rename successful"
+msgstr ""
+
+msgid "Untitled {{visualizationType}} visualization, {{date}}"
 msgstr ""
 
 msgid "\"{{deletedObject}}\" successfully deleted."

--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -31,6 +31,7 @@ import {
     GenericServerError,
     VisualizationNotFoundError,
 } from '../modules/error'
+import { getDisplayNameByVisType } from '@dhis2/analytics'
 
 export {
     fromVisualization,
@@ -187,9 +188,22 @@ export const tDoSaveVisualization = ({ name, description }, copy) => async (
         if (copy) {
             delete visualization.id
         }
-
         if (name) {
             visualization.name = name
+        } else {
+            visualization.name = i18n.t(
+                'Untitled {{visualizationType}} visualization, {{date}}',
+                {
+                    visualizationType: getDisplayNameByVisType(
+                        visualization.type
+                    ),
+                    date: new Date().toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'short',
+                        day: '2-digit',
+                    }),
+                }
+            )
         }
 
         if (description) {

--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -188,23 +188,17 @@ export const tDoSaveVisualization = ({ name, description }, copy) => async (
         if (copy) {
             delete visualization.id
         }
-        if (name) {
-            visualization.name = name
-        } else {
-            visualization.name = i18n.t(
-                'Untitled {{visualizationType}} visualization, {{date}}',
-                {
-                    visualizationType: getDisplayNameByVisType(
-                        visualization.type
-                    ),
-                    date: new Date().toLocaleDateString(undefined, {
-                        year: 'numeric',
-                        month: 'short',
-                        day: '2-digit',
-                    }),
-                }
-            )
-        }
+
+        visualization.name =
+            name ||
+            i18n.t('Untitled {{visualizationType}} visualization, {{date}}', {
+                visualizationType: getDisplayNameByVisType(visualization.type),
+                date: new Date().toLocaleDateString(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                    day: '2-digit',
+                }),
+            })
 
         if (description) {
             visualization.description = description


### PR DESCRIPTION
Fixes [DHIS2-9360](https://jira.dhis2.org/browse/DHIS2-9360)

If no name is provided in the Save dialog the save process will now default to a date-based name in the format of `Untitled {{visualizationType}} visualization, {{date}}`.

The date in turn is based on a localized version of `dd mmm yyyy`.

![image](https://user-images.githubusercontent.com/12590483/91559962-4b107980-e939-11ea-8857-eb80920fd7c4.png)
