### PR TITLE
fix: digit group separator default from system settings (DHIS2-6328)

### DIFF
--- a/packages/app/src/components/VisualizationOptions/Options/DigitGroupSeparator.js
+++ b/packages/app/src/components/VisualizationOptions/Options/DigitGroupSeparator.js
@@ -1,14 +1,19 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 
 import i18n from '@dhis2/d2-i18n'
 
 import SelectBaseOption from './SelectBaseOption'
 
-const DigitGroupSeparator = () => (
+import { sGetSettingsDigitGroupSeparator } from '../../../reducers/settings'
+
+const DigitGroupSeparator = ({ defaultValue }) => (
     <SelectBaseOption
         label={i18n.t('Digit group separator')}
         option={{
             name: 'digitGroupSeparator',
+            defaultValue,
             items: [
                 { value: 'NONE', label: i18n.t('None') },
                 { value: 'SPACE', label: i18n.t('Space') },
@@ -18,4 +23,12 @@ const DigitGroupSeparator = () => (
     />
 )
 
-export default DigitGroupSeparator
+DigitGroupSeparator.propTypes = {
+    defaultValue: PropTypes.string,
+}
+
+const mapStateToProps = state => ({
+    defaultValue: sGetSettingsDigitGroupSeparator(state),
+})
+
+export default connect(mapStateToProps)(DigitGroupSeparator)

--- a/packages/app/src/components/VisualizationOptions/Options/SelectBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/SelectBaseOption.js
@@ -82,7 +82,9 @@ SelectBaseOption.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-    value: sGetUiOptions(state)[ownProps.option.name],
+    value:
+        sGetUiOptions(state)[ownProps.option.name] ||
+        ownProps.option.defaultValue,
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/packages/app/src/modules/options.js
+++ b/packages/app/src/modules/options.js
@@ -136,7 +136,7 @@ export const options = {
     },
     fontSize: { defaultValue: 'NORMAL', requestable: false, savable: true },
     digitGroupSeparator: {
-        defaultValue: 'SPACE',
+        defaultValue: undefined,
         requestable: false,
         savable: true,
     },

--- a/packages/app/src/reducers/settings.js
+++ b/packages/app/src/reducers/settings.js
@@ -34,6 +34,9 @@ export const sGetSettings = state => state.settings
 export const sGetSettingsDisplayNameProperty = state =>
     sGetSettings(state).displayNameProperty
 
+export const sGetSettingsDigitGroupSeparator = state =>
+    sGetSettings(state).keyAnalysisDigitGroupSeparator
+
 export const sGetRootOrgUnit = state => sGetSettings(state).rootOrganisationUnit
 
 export const sGetRelativePeriod = state =>


### PR DESCRIPTION
Fixes [DHIS2-9328](https://jira.dhis2.org/browse/DHIS2-9328) for DV.

The solution here works for the `digitGroupSeparator` option in DV, which is enabled for Single Value and Pivot Table visualization types.
A default value override from a select based connected component only works if the option is non toggleable.

Setting options defaults from system settings wasn't covered before; the whole DV options system needs to be revisited for better accommodate this requirement and other recent modifications.

The digit group separator can be set in the system settings app:
![Screenshot 2020-08-28 at 16 40 13](https://user-images.githubusercontent.com/150978/91580339-38a03b00-e94d-11ea-91df-75d5f15884b5.png)

And it should be pre-selected in DV option's Style tab for new visualizations:
![Screenshot 2020-08-28 at 16 41 47](https://user-images.githubusercontent.com/150978/91580431-62596200-e94d-11ea-9908-93046443829a.png)

And it should be respected when displaying a numeric value:
![Screenshot 2020-08-28 at 16 42 30](https://user-images.githubusercontent.com/150978/91580496-7c934000-e94d-11ea-8882-05ded63ed22d.png)
