### PR TITLE
fix: DGS default from settings (DHIS2-9328)

### DIFF
--- a/packages/app/src/actions/__tests__/index.spec.js
+++ b/packages/app/src/actions/__tests__/index.spec.js
@@ -31,8 +31,10 @@ const mockStore = configureMockStore(middlewares)
 
 const rootOrganisationUnit = 'abc123'
 const relativePeriod = 'xyzpdq'
+const digitGroupSeparator = 'COMMA'
 selectors.sGetRootOrgUnit = () => rootOrganisationUnit
 selectors.sGetRelativePeriod = () => relativePeriod
+selectors.sGetSettingsDigitGroupSeparator = () => digitGroupSeparator
 
 jest.mock('../../modules/orgUnit', () => ({
     convertOuLevelsToUids: (ouLevels, vis) => vis,
@@ -176,6 +178,7 @@ describe('index', () => {
                     value: {
                         rootOrganisationUnit,
                         relativePeriod,
+                        digitGroupSeparator,
                     },
                 },
             ]
@@ -206,6 +209,7 @@ describe('index', () => {
                     value: {
                         rootOrganisationUnit,
                         relativePeriod,
+                        digitGroupSeparator,
                     },
                 },
             ]

--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -21,7 +21,11 @@ import { VARIANT_SUCCESS } from '../components/Snackbar/Snackbar'
 
 import { sGetCurrent } from '../reducers/current'
 import { sGetVisualization } from '../reducers/visualization'
-import { sGetRootOrgUnit, sGetRelativePeriod } from '../reducers/settings'
+import {
+    sGetRootOrgUnit,
+    sGetRelativePeriod,
+    sGetSettingsDigitGroupSeparator,
+} from '../reducers/settings'
 
 import history from '../modules/history'
 import { getVisualizationFromCurrent } from '../modules/visualization'
@@ -114,8 +118,15 @@ export const clearVisualization = (dispatch, getState, error = null) => {
 
     const rootOrganisationUnit = sGetRootOrgUnit(getState())
     const relativePeriod = sGetRelativePeriod(getState())
+    const digitGroupSeparator = sGetSettingsDigitGroupSeparator(getState())
 
-    dispatch(fromUi.acClear({ rootOrganisationUnit, relativePeriod }))
+    dispatch(
+        fromUi.acClear({
+            rootOrganisationUnit,
+            relativePeriod,
+            digitGroupSeparator,
+        })
+    )
 }
 
 export const tDoRenameVisualization = ({ name, description }) => (

--- a/packages/app/src/components/VisualizationOptions/Options/DigitGroupSeparator.js
+++ b/packages/app/src/components/VisualizationOptions/Options/DigitGroupSeparator.js
@@ -1,19 +1,14 @@
 import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 
 import i18n from '@dhis2/d2-i18n'
 
 import SelectBaseOption from './SelectBaseOption'
 
-import { sGetSettingsDigitGroupSeparator } from '../../../reducers/settings'
-
-const DigitGroupSeparator = ({ defaultValue }) => (
+const DigitGroupSeparator = () => (
     <SelectBaseOption
         label={i18n.t('Digit group separator')}
         option={{
             name: 'digitGroupSeparator',
-            defaultValue,
             items: [
                 { value: 'NONE', label: i18n.t('None') },
                 { value: 'SPACE', label: i18n.t('Space') },
@@ -23,12 +18,4 @@ const DigitGroupSeparator = ({ defaultValue }) => (
     />
 )
 
-DigitGroupSeparator.propTypes = {
-    defaultValue: PropTypes.string,
-}
-
-const mapStateToProps = state => ({
-    defaultValue: sGetSettingsDigitGroupSeparator(state),
-})
-
-export default connect(mapStateToProps)(DigitGroupSeparator)
+export default DigitGroupSeparator

--- a/packages/app/src/components/VisualizationOptions/Options/SelectBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/SelectBaseOption.js
@@ -82,9 +82,7 @@ SelectBaseOption.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-    value:
-        sGetUiOptions(state)[ownProps.option.name] ||
-        ownProps.option.defaultValue,
+    value: sGetUiOptions(state)[ownProps.option.name],
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/packages/app/src/modules/options.js
+++ b/packages/app/src/modules/options.js
@@ -136,7 +136,7 @@ export const options = {
     },
     fontSize: { defaultValue: 'NORMAL', requestable: false, savable: true },
     digitGroupSeparator: {
-        defaultValue: undefined,
+        defaultValue: 'SPACE',
         requestable: false,
         savable: true,
     },

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -66,6 +66,7 @@ describe('reducer: ui', () => {
         const settings = {
             rootOrganisationUnit: { id: 'ROOT_ORGUNIT' },
             relativePeriod: 'SYSTEM_RELATIVE_PERIOD',
+            digitGroupSeparator: 'SPACE',
         }
 
         const actualState = reducer(
@@ -75,6 +76,10 @@ describe('reducer: ui', () => {
 
         expect(actualState).toEqual({
             ...ui.DEFAULT_UI,
+            options: {
+                ...ui.DEFAULT_UI.options,
+                digitGroupSeparator: settings.digitGroupSeparator,
+            },
             parentGraphMap: {
                 ...ui.DEFAULT_UI.parentGraphMap,
                 [settings.rootOrganisationUnit.id]: '',

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -72,7 +72,11 @@ export const PRESELECTED_YEAR_OVER_YEAR_SERIES = ['THIS_YEAR', 'LAST_YEAR']
 export const PRESELECTED_YEAR_OVER_YEAR_CATEGORY = ['MONTHS_THIS_YEAR']
 
 const getPreselectedUi = options => {
-    const { rootOrganisationUnit, relativePeriod } = options
+    const {
+        rootOrganisationUnit,
+        relativePeriod,
+        digitGroupSeparator,
+    } = options
 
     const rootOrganisationUnits = []
     const parentGraphMap = { ...DEFAULT_UI.parentGraphMap }
@@ -85,6 +89,10 @@ const getPreselectedUi = options => {
 
     return {
         ...DEFAULT_UI,
+        options: {
+            ...DEFAULT_UI.options,
+            digitGroupSeparator,
+        },
         itemsByDimension: {
             ...DEFAULT_UI.itemsByDimension,
             [DIMENSION_ID_ORGUNIT]: rootOrganisationUnits,


### PR DESCRIPTION
Related to [DHIS2-9328](https://jira.dhis2.org/browse/DHIS2-9328).

This fixes the issue of the DGS default from system settings not being used when resetting the ui portion of the DV's Redux store, which ultimately caused the visualization (SV, PT) to not render the digit group separator correctly when working on a non-saved visualization.

The DGS in the store's ui was only set when the option in the options dialog was rendered/interacted with, so for a new visualization, the DGS was undefined even if it was set to a specific value in system settings.
