### PR TITLE
fix: rename and invert the hide legend option (#1152) (DHIS2-9003) v32

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-18T23:27:07.844Z\n"
-"PO-Revision-Date: 2020-05-18T23:27:07.844Z\n"
+"POT-Creation-Date: 2020-09-09T09:35:45.664Z\n"
+"PO-Revision-Date: 2020-09-09T09:35:45.664Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -220,7 +220,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-msgid "Hide chart legend"
+msgid "Show legend key"
 msgstr ""
 
 msgid "Hide subtitle"
@@ -385,9 +385,6 @@ msgstr ""
 msgid "Please add at least one period as {{series}}, {{category}} or {{filter}}"
 msgstr ""
 
-msgid "Please add {{data}} as {{category}} or {{filter}}"
-msgstr ""
-
 msgid "Please add at least one period as {{series}} or {{filter}}"
 msgstr ""
 
@@ -395,9 +392,6 @@ msgid "Please add at least one {{filter}} dimension"
 msgstr ""
 
 msgid "Please add at least one period as a {{series}} dimension"
-msgstr ""
-
-msgid "Please add at least one period as a {{category}} dimension"
 msgstr ""
 
 msgid "Please add {{data}} as a filter dimension"

--- a/packages/app/src/components/VisualizationOptions/Options/CheckboxBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/CheckboxBaseOption.js
@@ -6,14 +6,24 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { sGetUiOptions } from '../../../reducers/ui';
 import { acSetUiOptions } from '../../../actions/ui';
 
-export const CheckboxBaseOption = ({ className, option, value, onChange }) => (
+export const CheckboxBaseOption = ({
+    className,
+    option,
+    value,
+    onChange,
+    inverted,
+}) => (
     <FormControlLabel
         className={className}
         control={
             <Checkbox
-                checked={value}
+                checked={inverted ? !value : value}
                 color={'primary'}
-                onChange={event => onChange(event.target.checked)}
+                onChange={event =>
+                    onChange(
+                        inverted ? !event.target.checked : event.target.checked
+                    )
+                }
             />
         }
         label={option.label}
@@ -22,6 +32,7 @@ export const CheckboxBaseOption = ({ className, option, value, onChange }) => (
 
 CheckboxBaseOption.propTypes = {
     className: PropTypes.string,
+    inverted: PropTypes.bool,
     option: PropTypes.object,
     value: PropTypes.bool,
     onChange: PropTypes.func,

--- a/packages/app/src/components/VisualizationOptions/Options/HideLegend.js
+++ b/packages/app/src/components/VisualizationOptions/Options/HideLegend.js
@@ -6,8 +6,9 @@ const HideLegend = () => (
     <CheckboxBaseOption
         option={{
             name: 'hideLegend',
-            label: i18n.t('Hide chart legend'),
+            label: i18n.t('Show legend key'),
         }}
+        inverted
     />
 );
 


### PR DESCRIPTION
Backport of https://github.com/dhis2/data-visualizer-app/pull/1152 to 33.x

Clean cherry-pick of https://github.com/dhis2/data-visualizer-app/pull/1256/commits/3f26d3d740410962beca2a223a47ff8a59c31c38

* Changes the title of the hideLegend option to a positive case (show).
* As the backend option is a negative case (hide), CheckboxBaseOption now has an inverted prop to flip the checked state.