### PR TITLE
fix: solve font style related issues

### DIFF
--- a/packages/app/src/modules/options/radarConfig.js
+++ b/packages/app/src/modules/options/radarConfig.js
@@ -16,6 +16,7 @@ import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTab
 import getLinesSection from './sections/lines'
 import getVerticalAxisSection from './sections/verticalAxis'
 import getColorSetSection from './sections/colorSet'
+import CategoryAxisLabels from '../../components/VisualizationOptions/Options/CategoryAxisLabels'
 
 export default hasCustomAxes => [
     {
@@ -50,7 +51,10 @@ export default hasCustomAxes => [
             {
                 key: 'axes-horizontal-axis',
                 label: i18n.t('Horizontal (x) axis'),
-                content: React.Children.toArray([<DomainAxisLabel />]),
+                content: React.Children.toArray([
+                    <DomainAxisLabel />,
+                    <CategoryAxisLabels />,
+                ]),
             },
         ],
     },

--- a/packages/app/src/modules/options/stackedAreaConfig.js
+++ b/packages/app/src/modules/options/stackedAreaConfig.js
@@ -17,6 +17,7 @@ import SeriesTable from '../../components/VisualizationOptions/Options/SeriesTab
 import getLinesSection from './sections/lines'
 import getVerticalAxisSection from './sections/verticalAxis'
 import getColorSetSection from './sections/colorSet'
+import CategoryAxisLabels from '../../components/VisualizationOptions/Options/CategoryAxisLabels'
 
 export default hasCustomAxes => [
     {
@@ -52,7 +53,10 @@ export default hasCustomAxes => [
             {
                 key: 'axes-horizontal-axis',
                 label: i18n.t('Horizontal (x) axis'),
-                content: React.Children.toArray([<DomainAxisLabel />]),
+                content: React.Children.toArray([
+                    <DomainAxisLabel />,
+                    <CategoryAxisLabels />,
+                ]),
             },
         ],
     },


### PR DESCRIPTION
Issue: Radar and Stacked Area options missing horizontal axis label font style (`CategoryAxisLabels`)
Solution: Add `CategoryAxisLabels` to Radar and Stacked Area

![image](https://user-images.githubusercontent.com/12590483/93071919-0a2a9b80-f681-11ea-972a-8a695798812b.png)
![image](https://user-images.githubusercontent.com/12590483/93071955-131b6d00-f681-11ea-9b38-4c1961993afc.png)

--------------