### PR TITLE
fix: confirm dialog with interpretation view

### DIFF
--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -176,7 +176,10 @@ export class App extends Component {
             ) {
                 this.setState({ locationToConfirm: location })
             } else {
-                if (this.state.previousLocation !== location.pathname) {
+                if (
+                    isSaving ||
+                    this.state.previousLocation !== location.pathname
+                ) {
                     this.loadVisualization(location)
                 }
 

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -159,6 +159,7 @@ export class App extends Component {
 
         this.unlisten = history.listen(location => {
             const isSaving = location.state?.isSaving
+            const isOpening = location.state?.isOpening
             const { interpretationId } = this.parseLocation(location)
 
             if (
@@ -178,6 +179,7 @@ export class App extends Component {
             } else {
                 if (
                     isSaving ||
+                    isOpening ||
                     this.state.previousLocation !== location.pathname
                 ) {
                     this.loadVisualization(location)

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -72,6 +72,13 @@ export class App extends Component {
         return false
     }
 
+    parseLocation = location => {
+        const pathParts = location.pathname.slice(1).split('/')
+        const id = pathParts[0]
+        const interpretationId = pathParts[2]
+        return { id, interpretationId }
+    }
+
     loadVisualization = async location => {
         const { store } = this.context
 
@@ -79,9 +86,8 @@ export class App extends Component {
             // /currentAnalyticalObject
             // /${id}/
             // /${id}/interpretation/${interpretationId}
-            const pathParts = location.pathname.slice(1).split('/')
-            const id = pathParts[0]
-            const interpretationId = pathParts[2]
+            const { id, interpretationId } = this.parseLocation(location)
+
             const urlContainsCurrentAOKey = id === CURRENT_AO_KEY
 
             if (urlContainsCurrentAOKey) {
@@ -153,18 +159,28 @@ export class App extends Component {
 
         this.unlisten = history.listen(location => {
             const isSaving = location.state?.isSaving
+            const { interpretationId } = this.parseLocation(location)
+
             if (
+                // currently editing
                 getVisualizationState(
                     this.props.visualization,
                     this.props.current
                 ) === STATE_DIRTY &&
-                this.state.locationToConfirm !== location &&
+                // wanting to navigate elsewhere
+                this.state.previousLocation !== location.pathname &&
+                // currently *not* viewing an interpretation
+                !(this.props.interpretation.id || interpretationId) &&
+                // not saving
                 !isSaving
             ) {
                 this.setState({ locationToConfirm: location })
             } else {
+                if (this.state.previousLocation !== location.pathname) {
+                    this.loadVisualization(location)
+                }
+
                 this.setState({ locationToConfirm: null })
-                this.loadVisualization(location)
             }
         })
 
@@ -258,21 +274,27 @@ export class App extends Component {
                             <ButtonStrip end>
                                 <Button
                                     secondary
-                                    onClick={() =>
+                                    onClick={() => {
                                         this.setState({
                                             locationToConfirm: null,
                                         })
-                                    }
+
+                                        history.goBack()
+                                    }}
                                 >
                                     {i18n.t('No, cancel')}
                                 </Button>
 
                                 <Button
-                                    onClick={() =>
-                                        history.push(
+                                    onClick={() => {
+                                        this.loadVisualization(
                                             this.state.locationToConfirm
                                         )
-                                    }
+
+                                        this.setState({
+                                            locationToConfirm: null,
+                                        })
+                                    }}
                                     primary
                                 >
                                     {i18n.t('Yes, leave')}
@@ -291,7 +313,7 @@ export class App extends Component {
 const mapStateToProps = state => ({
     settings: fromReducers.fromSettings.sGetSettings(state),
     current: fromReducers.fromCurrent.sGetCurrent(state),
-    interpretations: fromReducers.fromVisualization.sGetInterpretations(state),
+    interpretation: fromReducers.fromUi.sGetUiInterpretation(state),
     ui: fromReducers.fromUi.sGetUi(state),
     visualization: sGetVisualization(state),
     snackbar: fromReducers.fromSnackbar.sGetSnackbar(state),
@@ -326,6 +348,7 @@ App.propTypes = {
     clearVisualization: PropTypes.func,
     current: PropTypes.object,
     d2: PropTypes.object,
+    interpretation: PropTypes.object,
     location: PropTypes.object,
     ouLevels: PropTypes.array,
     setCurrentFromUi: PropTypes.func,

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -19,7 +19,7 @@ import styles from './styles/MenuBar.module.css'
 const onOpen = id => {
     const path = `/${id}`
     if (history.location.pathname === path) {
-        history.replace(path)
+        history.replace({ pathname: path, state: { isOpening: true } })
     } else {
         history.push(path)
     }

--- a/packages/app/src/components/__tests__/App.spec.js
+++ b/packages/app/src/components/__tests__/App.spec.js
@@ -112,6 +112,22 @@ describe('App', () => {
             })
         })
 
+        it('reloads visualization when opening the same visualization', done => {
+            props.location.pathname = '/fluttershy'
+
+            app()
+
+            setTimeout(() => {
+                history.replace({
+                    pathname: '/fluttershy',
+                    state: { isOpening: true },
+                })
+                expect(actions.tDoLoadVisualization).toBeCalledTimes(2)
+
+                done()
+            })
+        })
+
         it('reloads visualization when same pathname pushed when saving', done => {
             props.location.pathname = '/fluttershy'
 

--- a/packages/app/src/components/__tests__/App.spec.js
+++ b/packages/app/src/components/__tests__/App.spec.js
@@ -112,13 +112,16 @@ describe('App', () => {
             })
         })
 
-        it('reloads visualization when same pathname pushed', done => {
+        it('reloads visualization when same pathname pushed when saving', done => {
             props.location.pathname = '/fluttershy'
 
             app()
 
             setTimeout(() => {
-                history.replace('/fluttershy')
+                history.replace({
+                    pathname: '/fluttershy',
+                    state: { isSaving: true },
+                })
                 expect(actions.tDoLoadVisualization).toBeCalledTimes(2)
 
                 done()


### PR DESCRIPTION
The changes here are for improving when the navigation confirm dialog is shown and what happens when clicking Yes or No.

Since there is actually no change loss when navigating in and out of an interpretation's view, the confirm dialog does not show, even if there are changes to the visualization.

![ezgif com-optimize (2)](https://user-images.githubusercontent.com/150978/93192303-cfd70200-f745-11ea-9a76-c3062dc2af27.gif)


When answering No to the confirm dialog, the previous URL is loaded so that the state of the app is really what it was before.

![ezgif com-optimize (3)](https://user-images.githubusercontent.com/150978/93192897-77eccb00-f746-11ea-861b-e72f6904cbe2.gif)

