### PR TITLE
fix: allow axis range to be reset (not default to 0)

### DIFF
--- a/packages/app/src/modules/current.js
+++ b/packages/app/src/modules/current.js
@@ -82,7 +82,10 @@ export const getOptionsFromUi = ui => {
         'rangeAxisMaxValue',
     ].forEach(option => {
         if (Object.prototype.hasOwnProperty.call(optionsFromUi, option)) {
-            if (optionsFromUi[option] !== undefined) {
+            if (
+                optionsFromUi[option] !== undefined &&
+                optionsFromUi[option] !== ''
+            ) {
                 optionsFromUi[option] = Number(optionsFromUi[option])
             }
         }


### PR DESCRIPTION
Issue: When the axis range (min and max) are used and subsequently erased / reset, they default to `0` instead of `undefined`, causing HighCharts to render a weird looking chart.

Solution: Prevent `''` to be cast to `0` by adding a check in `current.js`

----------

_Bug causing both min and max axis range to default to 0 when it's empty_
![image](https://user-images.githubusercontent.com/12590483/93209667-baba9d00-f75e-11ea-940a-3054c9d1f942.png)

----------

_With the fix the axis range defaults to `undefined` instead, causing the correct chart to be rendered_
![image](https://user-images.githubusercontent.com/12590483/93209931-15ec8f80-f75f-11ea-9d59-d07630e3fea1.png)
