### PR TITLE
fix: set default layout to 50-50 width

### DIFF
--- a/packages/app/src/components/Layout/DefaultLayout/styles/DefaultLayout.style.js
+++ b/packages/app/src/components/Layout/DefaultLayout/styles/DefaultLayout.style.js
@@ -1,7 +1,7 @@
 import { LAYOUT_HEIGHT } from '../../styles/style'
 
 // Axis
-export const FILTER_AXIS_WIDTH = '67%'
+export const FILTER_AXIS_WIDTH = '50%'
 export const DIMENSION_AXIS_CONTENT_HEIGHT = '36px'
 
 // Axis (generated)


### PR DESCRIPTION
Now that we support two-category charts it makes sense to allocate more space to categories in the layout.

Before:
![Screenshot from 2020-09-15 14-40-38](https://user-images.githubusercontent.com/1010094/93212601-1555f800-f763-11ea-9e3d-a9878630f5f6.png)

This PR fixes this through the smallest possible fix. After:

![Screenshot from 2020-09-15 14-40-49](https://user-images.githubusercontent.com/1010094/93212976-9614f400-f763-11ea-9489-add2ab3102d8.png)

I'm simply changing the default layout. The result is that all chart types that support 2C get this change. The downside is that Radar also gets it, which does not support it, but that is an okay trade-off vs making a separate layout for radar charts at this point. Also, the specific layout for pivot tables could be removed later as it is now identical to the default layout.