### PR TITLE
fix: options headings for PT and SV

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-28T12:56:12.965Z\n"
-"PO-Revision-Date: 2020-08-28T12:56:12.965Z\n"
+"POT-Creation-Date: 2020-09-15T13:59:55.564Z\n"
+"PO-Revision-Date: 2020-09-15T13:59:55.564Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -309,7 +309,7 @@ msgstr ""
 msgid "Color blind"
 msgstr ""
 
-msgid "Mono patterns"
+msgid "Patterns"
 msgstr ""
 
 msgid "Event data"
@@ -815,10 +815,10 @@ msgstr ""
 msgid "Vertical (y) axis"
 msgstr ""
 
-msgid "Display totals"
+msgid "Totals"
 msgstr ""
 
-msgid "Display empty data"
+msgid "Empty data"
 msgstr ""
 
 msgid "Table title"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^10.0.3",
+        "@dhis2/analytics": "^10.0.5",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.0.7",

--- a/packages/app/src/components/VisualizationOptions/Options/ColorSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/ColorSet.js
@@ -11,7 +11,7 @@ import {
     COLOR_SET_DARK,
     COLOR_SET_GRAY,
     COLOR_SET_COLOR_BLIND,
-    COLOR_SET_MONO_PATTERNS,
+    COLOR_SET_PATTERNS,
 } from '@dhis2/analytics'
 
 import { sGetUiOptions } from '../../../reducers/ui'
@@ -47,8 +47,8 @@ const ColorSet = ({ value, onChange, disabled }) => (
                         label: i18n.t('Color blind'),
                     },
                     {
-                        id: COLOR_SET_MONO_PATTERNS,
-                        label: i18n.t('Mono patterns'),
+                        id: COLOR_SET_PATTERNS,
+                        label: i18n.t('Patterns'),
                     },
                 ].map(({ id, label }) => (
                     <span key={id}>

--- a/packages/app/src/modules/options/pivotTableConfig.js
+++ b/packages/app/src/modules/options/pivotTableConfig.js
@@ -36,15 +36,16 @@ export default () => [
         label: i18n.t('Data'),
         content: [
             {
-                key: 'data-section-1',
+                key: 'data-display',
+                label: i18n.t('Display'),
                 content: React.Children.toArray([
                     <ShowDimensionLabels />,
                     <SkipRounding />,
                 ]),
             },
             {
-                key: 'data-display-totals',
-                label: i18n.t('Display totals'),
+                key: 'data-totals',
+                label: i18n.t('Totals'),
                 content: React.Children.toArray([
                     <ColTotals />,
                     <ColSubTotals />,
@@ -53,8 +54,8 @@ export default () => [
                 ]),
             },
             {
-                key: 'data-display-empty-data',
-                label: i18n.t('Display empty data'),
+                key: 'data-empty-data',
+                label: i18n.t('Empty data'),
                 content: React.Children.toArray([
                     <HideEmptyColumns />,
                     <HideEmptyRows />,

--- a/packages/app/src/modules/options/singleValueConfig.js
+++ b/packages/app/src/modules/options/singleValueConfig.js
@@ -17,7 +17,8 @@ export default () => [
         label: i18n.t('Data'),
         content: [
             {
-                key: 'data-section-1',
+                key: 'data-display',
+                label: i18n.t('Display'),
                 content: React.Children.toArray([<SkipRounding />]),
             },
             {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^10.0.3",
+        "@dhis2/analytics": "^10.0.5",
         "@dhis2/ui": "^5.5.5",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,13 +1302,13 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^10.0.3":
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-10.0.3.tgz#9636bec30824b2a589964364a3b99296c104d7f2"
-  integrity sha512-h81hEvoHJDQshR024gSi/aBa9tpMQ8pwSPpNEDAEzw9QwR3eoNqMkTF8xDc3gO3HcJnfYMrYfdoiLYrQyhE+ZA==
+"@dhis2/analytics@^10.0.5":
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-10.0.5.tgz#de2962956fe1df5674f78a4ddc5767deb1b19c72"
+  integrity sha512-SkP8Qd/3yNuuk9BhGPqpidL6PRCBflZNMfa0sQJgxlXO1zO5sP0m4UikpiLWq0IqcfnlfqC4IDv1R2lmsy1t+w==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.5"
-    "@dhis2/ui" "^5.5.3"
+    "@dhis2/ui" "^5.5.5"
     "@material-ui/core" "^3.9.3"
     "@material-ui/icons" "^3.0.2"
     classnames "^2.2.6"
@@ -1635,7 +1635,7 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.4.2", "@dhis2/ui@^5.5.3", "@dhis2/ui@^5.5.5":
+"@dhis2/ui@^5.4.2", "@dhis2/ui@^5.5.5":
   version "5.5.5"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.5.5.tgz#d982ad369f7249fd9b59280d0ad87fe9dd7d94c5"
   integrity sha512-G5JMtqQqbBUoiD9dieoI84hPUqgT4qKowbqVc8hQtxEN/SaB+0I9yoWCTZvg2GhR4r+vAuPsZz0AKJdCiM075A==


### PR DESCRIPTION
### PT options:
Add missing heading for `Skip rounding` and `Dimension labels`.
Renamed `Display totals` and `Display empty data` to `Totals` and `Empty data`.

![Screenshot 2020-09-15 at 16 06 36](https://user-images.githubusercontent.com/150978/93221031-8ef2e380-f76d-11ea-8fd0-9fbe0b1b7fec.png)

### SV options:
Add missing heading for `Skip rounding`.

![Screenshot 2020-09-15 at 16 06 44](https://user-images.githubusercontent.com/150978/93221046-93b79780-f76d-11ea-9755-e9b3f33a2ebf.png)

### Remove Mono from Mono patterns
There is also the rename of the `Mono patterns` to `Patterns` in the colorSet option as per @cooper-joe suggestion.
This requires https://github.com/dhis2/analytics/pull/599.