### PR TITLE
fix: modal is bumped up when the color picker is opened

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^11.0.5",
+        "@dhis2/analytics": "^11.0.6",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.0.8",

--- a/packages/app/src/components/VisualizationOptions/styles/TextStyle.module.css
+++ b/packages/app/src/components/VisualizationOptions/styles/TextStyle.module.css
@@ -1,5 +1,6 @@
 .container {
     display: flex;
+    position: relative;
     margin: var(--spacers-dp8) 0;
 }
 

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^11.0.5",
+        "@dhis2/analytics": "^11.0.6",
         "@dhis2/ui": "^5.6.1",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,10 +1302,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^11.0.5":
-  version "11.0.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-11.0.5.tgz#4bb0e7115a89f1c044a1328e488c1a49fd85aaf3"
-  integrity sha512-Rsn7wU8q+tKLnSMUllhada39YE1GFJSvKWdwWU4acZrGgDSaWEsVvHQbBao7CRFN4y/GL6uHjSVVwaEzzCDADQ==
+"@dhis2/analytics@^11.0.6":
+  version "11.0.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-11.0.6.tgz#31f9c4a00a09a2c14b42a7d17da72aed568fe0d0"
+  integrity sha512-LoKJe5hJCYhozVe1Bs+ZYy4xmK1rcjfmF0R198eal+kETTM6/qYOCRE4CklQC2k9ziZrUJebhTRXyWXOQvk3Tw==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.0.8"
     "@dhis2/ui" "^5.5.6"
@@ -3779,15 +3779,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
-  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -6384,14 +6376,7 @@ flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.11.0.tgz#afa14f08ba12a52963140fe43212658897bc0ecb"
-  integrity sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==
-  dependencies:
-    debug "^3.0.0"
-
-follow-redirects@^1.10.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
@@ -12757,14 +12742,7 @@ rxjs@^5.0.0-beta.11, rxjs@^5.5.7:
   dependencies:
     symbol-observable "1.0.1"
 
-rxjs@^6.5.2, rxjs@^6.5.3:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
-  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.6.0:
+rxjs@^6.5.2, rxjs@^6.5.3, rxjs@^6.6.0:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==


### PR DESCRIPTION
Issue: In the options modal, using a short Chrome browser window, when the color picker was opened for an element below-the-fold, the modal jumps up to fit the color picker.

Solution: This is caused by using `position: absolute` as part of the custom color picker. Solved by wrapping the container of that element with `position: relative`.

-----------------

Bug: Before jumping
![image](https://user-images.githubusercontent.com/12590483/93896949-d3442d80-fcf1-11ea-8a18-f237f8c0eeb1.png)

Bug: After jumping
![image](https://user-images.githubusercontent.com/12590483/93896975-db03d200-fcf1-11ea-8db5-241ffe6835dd.png)

Fix: Not jumping
![image](https://user-images.githubusercontent.com/12590483/93897026-e820c100-fcf1-11ea-8794-1011c102b50d.png)
