### PR TITLE
fix: pie layout axis width

### DIFF
--- a/packages/app/src/components/Layout/DefaultLayout/DefaultLayout.js
+++ b/packages/app/src/components/Layout/DefaultLayout/DefaultLayout.js
@@ -1,4 +1,9 @@
 import React from 'react'
+import {
+    AXIS_ID_COLUMNS,
+    AXIS_ID_ROWS,
+    AXIS_ID_FILTERS,
+} from '@dhis2/analytics'
 
 import DefaultAxis from './DefaultAxis'
 import styles from './styles/DefaultLayout.style'
@@ -11,14 +16,14 @@ const Layout = () => (
             style={{ ...styles.axisGroup, ...styles.axisGroupLeft }}
         >
             <DefaultAxis
-                axisId="columns"
+                axisId={AXIS_ID_COLUMNS}
                 style={{
                     ...styles.columns,
                     ...defaultAxisStyles.axisContainerLeft,
                 }}
             />
             <DefaultAxis
-                axisId="rows"
+                axisId={AXIS_ID_ROWS}
                 style={{
                     ...styles.rows,
                     ...defaultAxisStyles.axisContainerLeft,
@@ -29,7 +34,7 @@ const Layout = () => (
             id="axis-group-2"
             style={{ ...styles.axisGroup, ...styles.axisGroupRight }}
         >
-            <DefaultAxis axisId="filters" style={styles.filters} />
+            <DefaultAxis axisId={AXIS_ID_FILTERS} style={styles.filters} />
         </div>
     </div>
 )

--- a/packages/app/src/components/Layout/PieLayout/PieLayout.js
+++ b/packages/app/src/components/Layout/PieLayout/PieLayout.js
@@ -4,6 +4,7 @@ import { AXIS_ID_COLUMNS, AXIS_ID_FILTERS } from '@dhis2/analytics'
 import DefaultAxis from '../DefaultLayout/DefaultAxis'
 import defaultAxisStyles from '../DefaultLayout/styles/DefaultAxis.style'
 import defaultLayoutStyles from '../DefaultLayout/styles/DefaultLayout.style'
+import pieLayoutStyles from './styles/PieLayout.style'
 
 const Layout = () => (
     <div id="layout-ct" style={defaultLayoutStyles.ct}>
@@ -11,7 +12,7 @@ const Layout = () => (
             id="axis-group-1"
             style={{
                 ...defaultLayoutStyles.axisGroup,
-                ...defaultLayoutStyles.axisGroupLeft,
+                ...pieLayoutStyles.axisGroupLeft,
             }}
         >
             <DefaultAxis
@@ -26,7 +27,7 @@ const Layout = () => (
             id="axis-group-2"
             style={{
                 ...defaultLayoutStyles.axisGroup,
-                ...defaultLayoutStyles.axisGroupRight,
+                ...pieLayoutStyles.axisGroupRight,
             }}
         >
             <DefaultAxis

--- a/packages/app/src/components/Layout/PieLayout/styles/PieLayout.style.js
+++ b/packages/app/src/components/Layout/PieLayout/styles/PieLayout.style.js
@@ -1,0 +1,14 @@
+// Axis
+export const FILTER_AXIS_WIDTH = '70%'
+
+// Axis (generated)
+export const DIMENSION_AXIS_WIDTH = `${100 - parseInt(FILTER_AXIS_WIDTH, 10)}%`
+
+export default {
+    axisGroupLeft: {
+        flexBasis: DIMENSION_AXIS_WIDTH,
+    },
+    axisGroupRight: {
+        flexBasis: FILTER_AXIS_WIDTH,
+    },
+}


### PR DESCRIPTION
Vis types `pie` and `gauge` support only a single dimension, all other dimensions are filters. Thus is makes sense to allocate less space (30%) for the series dimension and more space (70%) for filters.

![Screenshot from 2020-09-23 11-53-03](https://user-images.githubusercontent.com/1010094/93997150-5c5f7100-fd93-11ea-87bb-504fa101272f.png)
