### PR TITLE
fix: set a default name if saved vis is untitled (DHIS2-9360) v34

### DIFF
--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -195,7 +195,11 @@ export const tDoSaveVisualization = ({ name, description }, copy) => async (
         }
 
         visualization.name =
+            // name provided in the Save dialog
             name ||
+            // existing name when saving the same modified visualization
+            visualization.name ||
+            // new visualization with no name provided in Save dialog
             i18n.t('Untitled {{visualizationType}} visualization, {{date}}', {
                 visualizationType: getDisplayNameByVisType(visualization.type),
                 date: new Date().toLocaleDateString(undefined, {


### PR DESCRIPTION
Manual backport of https://github.com/dhis2/data-visualizer-app/pull/1273/commits/aca9a9c783cd978ed2363b7172b678ddb4d9c0a4 for [DHIS2-9360](https://jira.dhis2.org/browse/DHIS2-9360)

Saving named visualization again now retains it's name properly. As seen in https://github.com/dhis2/data-visualizer-app/pull/1273