### PR TITLE
refactor: replace d2-ui-file-menu with analytics/FileMenu

### DIFF
--- a/cypress/elements/fileMenu/index.js
+++ b/cypress/elements/fileMenu/index.js
@@ -15,12 +15,13 @@ export const FILE_MENU_BUTTON_GETLINK = 'Get link…'
 export const FILE_MENU_BUTTON_DELETE = 'Delete'
 
 export const closeFileMenu = () =>
-    cy
+    cy.get('[data-test="file-menu-toggle-layer"]').click('topLeft')
+/*    cy
         .getBySel(fileMenuItemEl)
         .find('li')
         .contains(FILE_MENU_BUTTON_NEW)
         .type('{esc}', { force: true })
-
+*/
 export const clickFileMenuButton = buttonName =>
     cy.getBySel(fileMenuItemEl).find('li').contains(buttonName).click()
 

--- a/cypress/elements/fileMenu/index.js
+++ b/cypress/elements/fileMenu/index.js
@@ -1,7 +1,7 @@
 import { clickMenuBarFileButton } from '../menuBar'
 
-const deleteModalEl = '[data-test="file-menu-delete-modal"]'
-const fileMenuItemEl = '[data-test="file-menu-container"] li'
+const deleteModalEl = 'file-menu-delete-modal'
+const fileMenuItemEl = 'file-menu-container'
 
 export const FILE_MENU_BUTTON_NEW = 'New'
 export const FILE_MENU_BUTTON_OPEN = 'Open…'
@@ -16,22 +16,29 @@ export const FILE_MENU_BUTTON_DELETE = 'Delete'
 
 export const closeFileMenu = () =>
     cy
-        .get(fileMenuItemEl)
+        .getBySel(fileMenuItemEl)
+        .find('li')
         .contains(FILE_MENU_BUTTON_NEW)
         .type('{esc}', { force: true })
 
 export const clickFileMenuButton = buttonName =>
-    cy.get(fileMenuItemEl).contains(buttonName).click()
+    cy.getBySel(fileMenuItemEl).find('li').contains(buttonName).click()
 
 export const createNewAO = () => {
     clickMenuBarFileButton()
-    cy.get(fileMenuItemEl).contains(FILE_MENU_BUTTON_NEW).click()
+    cy.getBySel(fileMenuItemEl)
+        .find('li')
+        .contains(FILE_MENU_BUTTON_NEW)
+        .click()
 }
 
 export const deleteAO = () => {
     clickMenuBarFileButton()
-    cy.get(fileMenuItemEl).contains(FILE_MENU_BUTTON_DELETE).click()
-    cy.get(deleteModalEl)
+    cy.getBySel(fileMenuItemEl)
+        .find('li')
+        .contains(FILE_MENU_BUTTON_DELETE)
+        .click()
+    cy.getBySel(deleteModalEl)
         .find('button')
         .contains(FILE_MENU_BUTTON_DELETE)
         .click()
@@ -39,7 +46,8 @@ export const deleteAO = () => {
 
 export const expectFileMenuButtonToBeDisabled = (buttonName, inverse) =>
     cy
-        .get(fileMenuItemEl)
+        .getBySel(fileMenuItemEl)
+        .find('li')
         .contains(buttonName)
         .parents('li')
         .invoke('attr', 'class')

--- a/cypress/elements/fileMenu/index.js
+++ b/cypress/elements/fileMenu/index.js
@@ -7,25 +7,27 @@
 
 import { clickMenuBarFileButton } from '../menuBar'
 
-const deleteModalEl = '*[class^="MuiDialog-container"]'
-const fileMenuItemEl = '*[role="menuitem"]'
+const deleteModalEl = '[data-test="file-menu-delete-modal"]'
+const fileMenuItemEl = '[data-test="file-menu-container"] li'
 
 export const FILE_MENU_BUTTON_NEW = 'New'
-export const FILE_MENU_BUTTON_OPEN = 'Open'
-export const FILE_MENU_BUTTON_SAVE = 'Save'
-export const FILE_MENU_BUTTON_SAVEAS = 'Save as...'
-export const FILE_MENU_BUTTON_RENAME = 'Rename'
-export const FILE_MENU_BUTTON_TRANSLATE = 'Translate'
-export const FILE_MENU_BUTTON_SHARE = 'Share'
-export const FILE_MENU_BUTTON_GETLINK = 'Get link'
+export const FILE_MENU_BUTTON_OPEN = 'Open…'
+export const FILE_MENU_BUTTON_SAVE_EXISTING = 'Save'
+export const FILE_MENU_BUTTON_SAVE_NEW = 'Save…'
+export const FILE_MENU_BUTTON_SAVEAS = 'Save as…'
+export const FILE_MENU_BUTTON_RENAME = 'Rename…'
+export const FILE_MENU_BUTTON_TRANSLATE = 'Translate…'
+export const FILE_MENU_BUTTON_SHARE = 'Share…'
+export const FILE_MENU_BUTTON_GETLINK = 'Get link…'
 export const FILE_MENU_BUTTON_DELETE = 'Delete'
 
 export const closeFileMenu = () =>
-    cy
-        .get(fileMenuItemEl)
-        .contains(FILE_MENU_BUTTON_NEW)
-        .parents('ul')
-        .type('{esc}')
+    cy.get('[data-test="file-menu-toggle-layer"]').click('topLeft')
+//    cy
+//        .get(fileMenuItemEl)
+//        .contains(FILE_MENU_BUTTON_NEW)
+//        .parents('ul')
+//        .type('{esc}')
 
 export const clickFileMenuButton = buttonName =>
     cy

--- a/cypress/elements/fileMenu/index.js
+++ b/cypress/elements/fileMenu/index.js
@@ -23,7 +23,7 @@ export const closeFileMenuWithEsc = () =>
     cy.getBySel(fileMenuToggleEl).type('{esc}', { force: true })
 
 export const clickFileMenuButton = buttonName =>
-    cy.getBySel(fileMenuContainerEl).find('li').contains(buttonName).click()
+    cy.getBySel(fileMenuContainerEl).contains(buttonName).click()
 
 export const createNewAO = () => {
     clickMenuBarFileButton()

--- a/cypress/elements/fileMenu/index.js
+++ b/cypress/elements/fileMenu/index.js
@@ -1,7 +1,9 @@
 import { clickMenuBarFileButton } from '../menuBar'
 
 const deleteModalEl = 'file-menu-delete-modal'
-const fileMenuItemEl = 'file-menu-container'
+const fileMenuContainerEl = 'file-menu-container'
+const fileMenuToggleEl = 'file-menu-toggle'
+const fileMenuToggleLayerEl = 'file-menu-toggle-layer'
 
 export const FILE_MENU_BUTTON_NEW = 'New'
 export const FILE_MENU_BUTTON_OPEN = 'Open…'
@@ -14,31 +16,23 @@ export const FILE_MENU_BUTTON_SHARE = 'Share…'
 export const FILE_MENU_BUTTON_GETLINK = 'Get link…'
 export const FILE_MENU_BUTTON_DELETE = 'Delete'
 
-export const closeFileMenu = () =>
-    cy.get('[data-test="file-menu-toggle-layer"]').click('topLeft')
-/*    cy
-        .getBySel(fileMenuItemEl)
-        .find('li')
-        .contains(FILE_MENU_BUTTON_NEW)
-        .type('{esc}', { force: true })
-*/
+export const closeFileMenuWithClick = () =>
+    cy.getBySel(fileMenuToggleLayerEl).click('topLeft')
+
+export const closeFileMenuWithEsc = () =>
+    cy.getBySel(fileMenuToggleEl).type('{esc}', { force: true })
+
 export const clickFileMenuButton = buttonName =>
-    cy.getBySel(fileMenuItemEl).find('li').contains(buttonName).click()
+    cy.getBySel(fileMenuContainerEl).find('li').contains(buttonName).click()
 
 export const createNewAO = () => {
     clickMenuBarFileButton()
-    cy.getBySel(fileMenuItemEl)
-        .find('li')
-        .contains(FILE_MENU_BUTTON_NEW)
-        .click()
+    cy.getBySel(fileMenuContainerEl).contains(FILE_MENU_BUTTON_NEW).click()
 }
 
 export const deleteAO = () => {
     clickMenuBarFileButton()
-    cy.getBySel(fileMenuItemEl)
-        .find('li')
-        .contains(FILE_MENU_BUTTON_DELETE)
-        .click()
+    cy.getBySel(fileMenuContainerEl).contains(FILE_MENU_BUTTON_DELETE).click()
     cy.getBySel(deleteModalEl)
         .find('button')
         .contains(FILE_MENU_BUTTON_DELETE)
@@ -47,8 +41,7 @@ export const deleteAO = () => {
 
 export const expectFileMenuButtonToBeDisabled = (buttonName, inverse) =>
     cy
-        .getBySel(fileMenuItemEl)
-        .find('li')
+        .getBySel(fileMenuContainerEl)
         .contains(buttonName)
         .parents('li')
         .invoke('attr', 'class')

--- a/cypress/elements/fileMenu/index.js
+++ b/cypress/elements/fileMenu/index.js
@@ -1,10 +1,3 @@
-/*  FIXME:
-    Most of the element selection in this file is quite poor because 
-    of the FileMenu being old and still uses MUI.
-    This can be refactored to use proper data-test selectors once the new
-    FileMenu component is in place.
-*/
-
 import { clickMenuBarFileButton } from '../menuBar'
 
 const deleteModalEl = '[data-test="file-menu-delete-modal"]'
@@ -22,24 +15,17 @@ export const FILE_MENU_BUTTON_GETLINK = 'Get link…'
 export const FILE_MENU_BUTTON_DELETE = 'Delete'
 
 export const closeFileMenu = () =>
-    cy.get('[data-test="file-menu-toggle-layer"]').click('topLeft')
-//    cy
-//        .get(fileMenuItemEl)
-//        .contains(FILE_MENU_BUTTON_NEW)
-//        .parents('ul')
-//        .type('{esc}')
+    cy
+        .get(fileMenuItemEl)
+        .contains(FILE_MENU_BUTTON_NEW)
+        .type('{esc}', { force: true })
 
 export const clickFileMenuButton = buttonName =>
-    cy
-        .get(fileMenuItemEl) // TODO: Change once new FileMenu is in place
-        .contains(buttonName)
-        .click()
+    cy.get(fileMenuItemEl).contains(buttonName).click()
 
 export const createNewAO = () => {
     clickMenuBarFileButton()
-    cy.get(fileMenuItemEl) // TODO: Change once new FileMenu is in place
-        .contains(FILE_MENU_BUTTON_NEW)
-        .click()
+    cy.get(fileMenuItemEl).contains(FILE_MENU_BUTTON_NEW).click()
 }
 
 export const deleteAO = () => {

--- a/cypress/elements/fileMenu/open.js
+++ b/cypress/elements/fileMenu/open.js
@@ -5,7 +5,7 @@ import { clickMenuBarFileButton } from '../menuBar'
 const openModalEl = '*[class^="MuiDialogContent"]' // TODO: Add data-test to open modal to target this better
 const openModalFooterEl = '*[class^="MuiTableFooter"]'
 const openModalToolbarEl = '*[class^="MuiToolbar-root"]'
-const createdByOthersEl = 'byothers'
+const createdByOthersEl = '[data-value=byothers]'
 const openModalItemContainerEl = '*[class^="MuiTableBody"]'
 
 const searchAOByName = name =>
@@ -45,7 +45,7 @@ export const openRandomAOCreatedByOthers = () => {
         .click()
         .then(() =>
             cy
-                .getBySel(createdByOthersEl)
+                .get(createdByOthersEl)
                 .click()
                 .then(() => {
                     cy.get(openModalEl)

--- a/cypress/elements/fileMenu/open.js
+++ b/cypress/elements/fileMenu/open.js
@@ -5,7 +5,7 @@ import { clickMenuBarFileButton } from '../menuBar'
 const openModalEl = '*[class^="MuiDialogContent"]' // TODO: Add data-test to open modal to target this better
 const openModalFooterEl = '*[class^="MuiTableFooter"]'
 const openModalToolbarEl = '*[class^="MuiToolbar-root"]'
-const createdByOthersEl = '[data-value="byothers"]'
+const createdByOthersEl = 'byothers'
 const openModalItemContainerEl = '*[class^="MuiTableBody"]'
 
 const searchAOByName = name =>
@@ -45,7 +45,7 @@ export const openRandomAOCreatedByOthers = () => {
         .click()
         .then(() =>
             cy
-                .get(createdByOthersEl)
+                .getBySel(createdByOthersEl)
                 .click()
                 .then(() => {
                     cy.get(openModalEl)

--- a/cypress/elements/fileMenu/save.js
+++ b/cypress/elements/fileMenu/save.js
@@ -1,24 +1,25 @@
 import {
     clickFileMenuButton,
-    FILE_MENU_BUTTON_SAVE,
+    FILE_MENU_BUTTON_SAVE_EXISTING,
+    FILE_MENU_BUTTON_SAVE_NEW,
     FILE_MENU_BUTTON_SAVEAS,
 } from '.'
 import { clickMenuBarFileButton } from '../menuBar'
 
-const saveModalEl = '*[class^="MuiDialog-container"]' // TODO: Add data-test to save modal to target this better
-const saveModalSaveButtonEl = '[type="submit"]'
+const saveModalEl = '[data-test="file-menu-saveas-modal"]'
+const saveModalSaveButtonEl = '[data-test="file-menu-saveas-modal-save"]'
 
 export const saveNewAO = (name, description) => {
     clickMenuBarFileButton()
-    clickFileMenuButton(FILE_MENU_BUTTON_SAVE)
+    clickFileMenuButton(FILE_MENU_BUTTON_SAVE_NEW)
     cy.get(saveModalEl).find('input').clear().type(name)
-    cy.get(saveModalEl).find('textarea').eq(2).type(description)
+    cy.get(saveModalEl).find('textarea').type(description)
     cy.get(saveModalEl).find(saveModalSaveButtonEl).click()
 }
 
 export const saveExistingAO = () => {
     clickMenuBarFileButton()
-    clickFileMenuButton(FILE_MENU_BUTTON_SAVE)
+    clickFileMenuButton(FILE_MENU_BUTTON_SAVE_EXISTING)
 }
 
 export const saveAOAs = (name, description) => {
@@ -28,7 +29,7 @@ export const saveAOAs = (name, description) => {
         cy.get(saveModalEl).find('input').clear().type(name)
     }
     if (description) {
-        cy.get(saveModalEl).find('textarea').eq(2).clear().type(description)
+        cy.get(saveModalEl).find('textarea').clear().type(description)
     }
     cy.get(saveModalEl).find(saveModalSaveButtonEl).click()
 }

--- a/cypress/elements/fileMenu/save.js
+++ b/cypress/elements/fileMenu/save.js
@@ -6,15 +6,16 @@ import {
 } from '.'
 import { clickMenuBarFileButton } from '../menuBar'
 
-const saveModalEl = '[data-test="file-menu-saveas-modal"]'
-const saveModalSaveButtonEl = '[data-test="file-menu-saveas-modal-save"]'
+const saveModalNameEl = 'file-menu-saveas-modal-name'
+const saveModalDescriptionEl = 'file-menu-saveas-modal-description'
+const saveModalSaveButtonEl = 'file-menu-saveas-modal-save'
 
 export const saveNewAO = (name, description) => {
     clickMenuBarFileButton()
     clickFileMenuButton(FILE_MENU_BUTTON_SAVE_NEW)
-    cy.get(saveModalEl).find('input').clear().type(name)
-    cy.get(saveModalEl).find('textarea').type(description)
-    cy.get(saveModalEl).find(saveModalSaveButtonEl).click()
+    cy.getBySel(saveModalNameEl).find('input').clear().type(name)
+    cy.getBySel(saveModalDescriptionEl).find('textarea').type(description)
+    cy.getBySel(saveModalSaveButtonEl).click()
 }
 
 export const saveExistingAO = () => {
@@ -26,10 +27,13 @@ export const saveAOAs = (name, description) => {
     clickMenuBarFileButton()
     clickFileMenuButton(FILE_MENU_BUTTON_SAVEAS)
     if (name) {
-        cy.get(saveModalEl).find('input').clear().type(name)
+        cy.getBySel(saveModalNameEl).find('input').clear().type(name)
     }
     if (description) {
-        cy.get(saveModalEl).find('textarea').clear().type(description)
+        cy.getBySel(saveModalDescriptionEl)
+            .find('textarea')
+            .clear()
+            .type(description)
     }
-    cy.get(saveModalEl).find(saveModalSaveButtonEl).click()
+    cy.getBySel(saveModalSaveButtonEl).click()
 }

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -26,7 +26,7 @@ import {
     expectFileMenuButtonToBeDisabled,
     FILE_MENU_BUTTON_NEW,
     FILE_MENU_BUTTON_OPEN,
-    FILE_MENU_BUTTON_SAVE,
+    FILE_MENU_BUTTON_SAVE_EXISTING,
     FILE_MENU_BUTTON_SAVEAS,
     FILE_MENU_BUTTON_DELETE,
     FILE_MENU_BUTTON_RENAME,
@@ -90,7 +90,7 @@ describe('saving an AO', () => {
             const enabledButtons = [
                 FILE_MENU_BUTTON_NEW,
                 FILE_MENU_BUTTON_OPEN,
-                FILE_MENU_BUTTON_SAVE,
+                FILE_MENU_BUTTON_SAVE_EXISTING,
                 FILE_MENU_BUTTON_SAVEAS,
                 FILE_MENU_BUTTON_RENAME,
                 FILE_MENU_BUTTON_TRANSLATE,

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -17,7 +17,7 @@ import { TEST_DATA_ELEMENTS } from '../utils/data'
 import {
     //openRandomAOCreatedByOthers,
     saveNewAO,
-    closeFileMenu,
+    closeFileMenuWithClick,
     saveAOAs,
     saveExistingAO,
     openAOByName,
@@ -75,7 +75,7 @@ describe('saving an AO', () => {
         it('checks that Save as is disabled', () => {
             clickMenuBarFileButton()
             expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
-            closeFileMenu()
+            closeFileMenuWithClick()
         })
         it('saves new AO using "Save"', () => {
             saveNewAO(TEST_VIS_NAME, TEST_VIS_DESCRIPTION)
@@ -101,7 +101,7 @@ describe('saving an AO', () => {
             enabledButtons.forEach(button =>
                 expectFileMenuButtonToBeEnabled(button)
             )
-            closeFileMenu()
+            closeFileMenuWithClick()
         })
         it(`replaces the selected period`, () => {
             replacePeriodItems(TEST_VIS_TYPE)
@@ -157,7 +157,7 @@ describe('saving an AO', () => {
             expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
             // TODO: This is not always true, as different AOs can have different sharing settings.
             // @edoardo will add additional tests here later
-            closeFileMenu()
+            closeFileMenuWithClick()
         })
     })
     */

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -74,7 +74,7 @@ describe('viewing the start screen', () => {
     it('orgunit dimension has 1 item', () => {
         expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
     })
-    it('primary File menu buttons are enabled', () => {
+    it('primary File menu buttons are enabled and menu is closed with click', () => {
         clickMenuBarFileButton()
         const enabledButtons = [
             FILE_MENU_BUTTON_NEW,
@@ -84,9 +84,9 @@ describe('viewing the start screen', () => {
         enabledButtons.forEach(button =>
             expectFileMenuButtonToBeEnabled(button)
         )
-        closeFileMenuWithEsc()
+        closeFileMenuWithClick()
     })
-    it('secondary File menu buttons are disabled', () => {
+    it('secondary File menu buttons are disabled and menu is closed with click', () => {
         clickMenuBarFileButton()
         const disabledButtons = [
             FILE_MENU_BUTTON_SAVEAS,
@@ -100,5 +100,9 @@ describe('viewing the start screen', () => {
             expectFileMenuButtonToBeDisabled(button)
         )
         closeFileMenuWithClick()
+    })
+    it('Fle menu is closed with Escape', () => {
+        clickMenuBarFileButton()
+        closeFileMenuWithEsc()
     })
 })

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -13,7 +13,7 @@ import {
     expectFileMenuButtonToBeDisabled,
     FILE_MENU_BUTTON_NEW,
     FILE_MENU_BUTTON_OPEN,
-    FILE_MENU_BUTTON_SAVE,
+    FILE_MENU_BUTTON_SAVE_NEW,
     FILE_MENU_BUTTON_SAVEAS,
     FILE_MENU_BUTTON_GETLINK,
     FILE_MENU_BUTTON_SHARE,
@@ -78,7 +78,7 @@ describe('viewing the start screen', () => {
         const enabledButtons = [
             FILE_MENU_BUTTON_NEW,
             FILE_MENU_BUTTON_OPEN,
-            FILE_MENU_BUTTON_SAVE,
+            FILE_MENU_BUTTON_SAVE_NEW,
         ]
         enabledButtons.forEach(button =>
             expectFileMenuButtonToBeEnabled(button)

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -9,7 +9,8 @@ import {
 
 import { expectVisualizationToNotBeVisible } from '../elements/chart'
 import {
-    closeFileMenu,
+    closeFileMenuWithEsc,
+    closeFileMenuWithClick,
     expectFileMenuButtonToBeDisabled,
     FILE_MENU_BUTTON_NEW,
     FILE_MENU_BUTTON_OPEN,
@@ -83,7 +84,7 @@ describe('viewing the start screen', () => {
         enabledButtons.forEach(button =>
             expectFileMenuButtonToBeEnabled(button)
         )
-        closeFileMenu()
+        closeFileMenuWithEsc()
     })
     it('secondary File menu buttons are disabled', () => {
         clickMenuBarFileButton()
@@ -98,6 +99,6 @@ describe('viewing the start screen', () => {
         disabledButtons.forEach(button =>
             expectFileMenuButtonToBeDisabled(button)
         )
-        closeFileMenu()
+        closeFileMenuWithClick()
     })
 })

--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-01-27T16:04:47.179Z\n"
-"PO-Revision-Date: 2021-01-27T16:04:47.179Z\n"
+"POT-Creation-Date: 2021-02-02T10:49:34.913Z\n"
+"PO-Revision-Date: 2021-02-02T10:49:34.913Z\n"
 
 msgid "Rename successful"
 msgstr ""
@@ -841,6 +841,14 @@ msgid "Table title"
 msgstr ""
 
 msgid "Parameters"
+msgstr ""
+
+msgid ""
+"These options only apply to legacy tables like standard reports. Options "
+"set here will have no effect on tables made in Data Visualizer."
+msgstr ""
+
+msgid "Applies to standard reports only"
 msgstr ""
 
 msgid "Base and target lines are available on the Axes tab for scatter charts"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^14.1.0",
+        "@dhis2/analytics": "^14.1.4",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.1.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^14.0.0",
+        "@dhis2/analytics": "^14.1.0",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.1.0",

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -32,7 +32,8 @@ const onNew = () => {
     }
 }
 const getOnRename = props => details => props.onRenameVisualization(details)
-const getOnSave = props => details => props.onSaveVisualization(details, false)
+const getOnSave = props => (details = {}) =>
+    props.onSaveVisualization(details, false)
 const getOnSaveAs = props => details => props.onSaveVisualization(details, true)
 const getOnDelete = props => () => props.onDeleteVisualization()
 const getOnError = props => error => props.onError(error)
@@ -70,8 +71,8 @@ export const MenuBar = ({ dataTest, ...props }, context) => (
 
 MenuBar.propTypes = {
     apiObjectName: PropTypes.string,
-    dataTest: PropTypes.string,
     current: PropTypes.object,
+    dataTest: PropTypes.string,
 }
 
 MenuBar.contextTypes = {

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import FileMenu from '@dhis2/d2-ui-file-menu'
+import { FileMenu } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 
 import UpdateButton from '../UpdateButton/UpdateButton'
@@ -51,8 +51,8 @@ export const MenuBar = ({ dataTest, ...props }, context) => (
         />
         <FileMenu
             d2={context.d2}
-            fileId={props.id || null}
             fileType={props.apiObjectName}
+            fileObject={props.current}
             onOpen={onOpen}
             onNew={onNew}
             onRename={getOnRename(props)}
@@ -71,7 +71,7 @@ export const MenuBar = ({ dataTest, ...props }, context) => (
 MenuBar.propTypes = {
     apiObjectName: PropTypes.string,
     dataTest: PropTypes.string,
-    id: PropTypes.string,
+    current: PropTypes.object,
 }
 
 MenuBar.contextTypes = {
@@ -79,7 +79,7 @@ MenuBar.contextTypes = {
 }
 
 const mapStateToProps = state => ({
-    id: (sGetCurrent(state) || {}).id,
+    current: sGetCurrent(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -32,8 +32,7 @@ const onNew = () => {
     }
 }
 const getOnRename = props => details => props.onRenameVisualization(details)
-const getOnSave = props => (details = {}) =>
-    props.onSaveVisualization(details, false)
+const getOnSave = props => details => props.onSaveVisualization(details, false)
 const getOnSaveAs = props => details => props.onSaveVisualization(details, true)
 const getOnDelete = props => () => props.onDeleteVisualization()
 const getOnError = props => error => props.onError(error)
@@ -86,7 +85,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
     onRenameVisualization: details =>
         dispatch(fromActions.tDoRenameVisualization(details)),
-    onSaveVisualization: (details, copy) =>
+    onSaveVisualization: (details = {}, copy) =>
         dispatch(fromActions.tDoSaveVisualization(details, copy)),
     onDeleteVisualization: () => dispatch(fromActions.tDoDeleteVisualization()),
     onError: error => {

--- a/packages/app/src/modules/fields/baseFields.js
+++ b/packages/app/src/modules/fields/baseFields.js
@@ -98,7 +98,7 @@ export const fieldsByType = {
         getFieldObject('filters'),
         getFieldObject('hideSubtitle', { option: true }),
         getFieldObject('hideTitle', { option: true }),
-        getFieldObject('href', { excluded: true }),
+        getFieldObject('href'), // required for translations via analytics FileMenu and d2-ui TranslationDialog
         getFieldObject('id'),
         getFieldObject('interpretations'),
         getFieldObject('itemOrganisationUnitGroups', { excluded: true }),

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^14.0.0",
+        "@dhis2/analytics": "^14.1.0",
         "@dhis2/ui": "^6.1.3",
         "lodash-es": "^4.17.11"
     },

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^14.1.0",
+        "@dhis2/analytics": "^14.1.4",
         "@dhis2/ui": "^6.1.3",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,12 +1499,16 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-14.0.0.tgz#f173748dda6ec0711ced4cc0529c67f8ef84eb94"
-  integrity sha512-e25vbhtsSzGEqsdztwrV5QILgxVjIlLUHVDh7T2zJF/u/whEZIgezybFq9AuhbcyIDMwmtDMpDKY+PNABUJbxg==
+"@dhis2/analytics@^14.1.4":
+  version "14.1.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-14.1.4.tgz#4c1f70ed5b034b357cdd3e16b48701351ed68e34"
+  integrity sha512-rHnTQtS9JMACM79xqjsiynjaRrcqw0b1kECAqPfIclqr47L/xz6GjS5oRDHGoPOT31M+nzQI612IdbLF7Aumeg==
   dependencies:
+    "@dhis2/app-runtime" "^2.6.1"
+    "@dhis2/d2-ui-favorites-dialog" "^7.1.3"
     "@dhis2/d2-ui-org-unit-dialog" "^7.1.3"
+    "@dhis2/d2-ui-sharing-dialog" "^7.1.3"
+    "@dhis2/d2-ui-translation-dialog" "^7.1.3"
     "@dhis2/ui" "^6.1.3"
     "@material-ui/core" "^3.9.3"
     "@material-ui/icons" "^3.0.2"
@@ -1728,6 +1732,21 @@
     redux-logger "^3.0.6"
     redux-thunk "^2.2.0"
 
+"@dhis2/d2-ui-favorites-dialog@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.1.3.tgz#abfab187634c6f09006cb1c2e5b57f0f0818ec71"
+  integrity sha512-mLhn/A70ZC0MZ2Xrv/mMY+ybp4H2az4y+VtVp/ujpGYdoth4vaoQt7G7ERgx+oM50gK1B6yJNMfEDCd3WZVDyQ==
+  dependencies:
+    "@dhis2/d2-ui-sharing-dialog" "7.1.3"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    babel-runtime "^6.26.0"
+    prop-types "^15.6.0"
+    react-redux "^5.0.7"
+    redux "^3.7.2"
+    redux-logger "^3.0.6"
+    redux-thunk "^2.2.0"
+
 "@dhis2/d2-ui-file-menu@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-file-menu/-/d2-ui-file-menu-7.1.0.tgz#92da470ffa4bff740826a758b6eda9e10f272094"
@@ -1809,7 +1828,7 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-sharing-dialog@7.1.3":
+"@dhis2/d2-ui-sharing-dialog@7.1.3", "@dhis2/d2-ui-sharing-dialog@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.1.3.tgz#27412a4e52dc636f167b0548ee5344f8957a3bb1"
   integrity sha512-vTe1IuGRwgBt8jQeGQoa3pGSd4j0lOuY6q9oyblVvT7IQ7GyBecwHS4YT8sK/kM9LwTZ+xDc4VgHVAzoFESVng==
@@ -1829,6 +1848,20 @@
   integrity sha512-gaQ6RhMHUTOsRbfUasqpN297syTk/j+aHQWALHk/+N46IqAslUaWkB3QO1HK9NHPAeL+/b5nLmWs4MpIYatgBQ==
   dependencies:
     "@dhis2/d2-ui-core" "7.1.0"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    babel-runtime "^6.26.0"
+    d2-utilizr "^0.2.15"
+    prop-types "^15.5.10"
+    react-select "^2.0.0"
+    rxjs "^5.5.7"
+
+"@dhis2/d2-ui-translation-dialog@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.1.3.tgz#6ae4befc6e1541a16c0554f5b54f52d7947b5809"
+  integrity sha512-N5BhTYCkcU32m9RhMEItclNxMr7khgrAQms3s5+4XRrGvdGcJo35CoulRmOU1Zs4e8KNhQg3QJMdCIxcvzsFeQ==
+  dependencies:
+    "@dhis2/d2-ui-core" "7.1.3"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
Implements [DHIS2-9821](https://jira.dhis2.org/browse/DHIS2-9821)

**Requires https://github.com/dhis2/analytics/pull/655**
**Requires https://github.com/dhis2/analytics/pull/798**

---

### Key features

1. Replace `d2-ui-file-menu` with `FileMenu` component from `@dhis2/analytics`

---

### Description

There are no functional differences, only small style differences.
Refer to the analytics PR for more info and screenshot.

---

### Known issues

The use of Esc for closing the menu is not supported in `ui`.
Ideally we should keep the functionality, it would be helpful if it can be implemented in a centralized way, but given the open/close state is handled in the app via conditional rendering, I'm not sure how that can work.
See: https://github.com/dhis2/notes/discussions/215

**Solved** for now in the FileMenu itself.