### PR TITLE
fix: reset app when New is clicked (v35) (DHIS2-9876)

### DIFF
--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -160,6 +160,7 @@ export class App extends Component {
         this.unlisten = history.listen(location => {
             const isSaving = location.state?.isSaving
             const isOpening = location.state?.isOpening
+            const isResetting = location.state?.isResetting
             const { interpretationId } = this.parseLocation(location)
 
             if (
@@ -180,6 +181,7 @@ export class App extends Component {
                 if (
                     isSaving ||
                     isOpening ||
+                    isResetting ||
                     this.state.previousLocation !== location.pathname
                 ) {
                     this.loadVisualization(location)

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -24,7 +24,13 @@ const onOpen = id => {
         history.push(path)
     }
 }
-const onNew = () => history.push('/')
+const onNew = () => {
+    if (history.location.pathname === '/') {
+        history.replace({ pathname: '/', state: { isResetting: true } })
+    } else {
+        history.push('/')
+    }
+}
 const getOnRename = props => details => props.onRenameVisualization(details)
 const getOnSave = props => details => props.onSaveVisualization(details, false)
 const getOnSaveAs = props => details => props.onSaveVisualization(details, true)


### PR DESCRIPTION
The app should reset also when the URL does not change, like when a
non-saved visualization is shown and New in the FileMenu is clicked.
This used to work in 2.34.

(cherry picked from commit 0dc16ed35c83cd4f558e982eb61bf10c67741127)

See the original PR #1406 for more information.