### PR TITLE
test: replace period instead of data in confirmLeave to avoid flakiness

### DIFF
--- a/cypress/elements/common.js
+++ b/cypress/elements/common.js
@@ -1,0 +1,26 @@
+import { isYearOverYear, DIMENSION_ID_PERIOD } from '@dhis2/analytics'
+
+import { clickMenuBarUpdateButton } from './menuBar'
+import { openDimension, selectYoyCategoryOption } from './layout'
+import {
+    removeAllPeriodItems,
+    selectRelativePeriods,
+} from './dimensionModal/periodDimension'
+import { clickDimensionModalUpdateButton } from './dimensionModal'
+
+export const replacePeriodItems = (visType, useAltData) => {
+    if (isYearOverYear(visType)) {
+        const TEST_PERIOD = !useAltData
+            ? 'Last 2 six-months'
+            : 'Quarters per year'
+        selectYoyCategoryOption(TEST_PERIOD)
+        clickMenuBarUpdateButton()
+    } else {
+        const TEST_PERIOD_TYPE = !useAltData ? 'Six-months' : 'Quarters'
+        const TEST_PERIOD = !useAltData ? 'Last six-month' : 'Last quarter'
+        openDimension(DIMENSION_ID_PERIOD)
+        removeAllPeriodItems()
+        selectRelativePeriods([TEST_PERIOD], TEST_PERIOD_TYPE)
+        clickDimensionModalUpdateButton()
+    }
+}

--- a/cypress/elements/common.js
+++ b/cypress/elements/common.js
@@ -8,7 +8,11 @@ import {
 } from './dimensionModal/periodDimension'
 import { clickDimensionModalUpdateButton } from './dimensionModal'
 
-export const replacePeriodItems = (visType, useAltData) => {
+export const replacePeriodItems = (
+    visType,
+    options = { useAltData: false }
+) => {
+    const useAltData = options.useAltData
     if (isYearOverYear(visType)) {
         const TEST_PERIOD = !useAltData
             ? 'Last 2 six-months'

--- a/cypress/integration/confirmLeave.cy.js
+++ b/cypress/integration/confirmLeave.cy.js
@@ -1,24 +1,15 @@
-import { isYearOverYear, DIMENSION_ID_PERIOD } from '@dhis2/analytics'
-
 import {
     expectAOTitleToBeDirty,
     expectAOTitleToNotBeDirty,
     expectVisualizationToBeVisible,
     expectVisualizationToNotBeVisible,
 } from '../elements/chart'
+import { replacePeriodItems } from '../elements/common'
 import {
     confirmLeave,
     expectConfirmLeaveModalToBeVisible,
 } from '../elements/confirmLeaveModal'
-import {
-    clickDimensionModalUpdateButton,
-    selectRelativePeriods,
-} from '../elements/dimensionModal'
-import { removeAllPeriodItems } from '../elements/dimensionModal/periodDimension'
-import { openDimension } from '../elements/dimensionsPanel'
 import { createNewAO, openAOByName } from '../elements/fileMenu'
-import { selectYoyCategoryOption } from '../elements/layout'
-import { clickMenuBarUpdateButton } from '../elements/menuBar'
 import {
     expectStartScreenToBeVisible,
     goToStartPage,
@@ -35,18 +26,7 @@ describe('confirm leave modal', () => {
         expectAOTitleToNotBeDirty()
     })
     it(`replaces the selected period`, () => {
-        if (isYearOverYear(TEST_AO.type)) {
-            const TEST_PERIOD = 'Last 2 six-months'
-            selectYoyCategoryOption(TEST_PERIOD)
-            clickMenuBarUpdateButton()
-        } else {
-            const TEST_PERIOD_TYPE = 'Six-months'
-            const TEST_PERIOD = 'Last six-month'
-            openDimension(DIMENSION_ID_PERIOD)
-            removeAllPeriodItems()
-            selectRelativePeriods([TEST_PERIOD], TEST_PERIOD_TYPE)
-            clickDimensionModalUpdateButton()
-        }
+        replacePeriodItems(TEST_AO.type)
         expectVisualizationToBeVisible(TEST_AO.type)
         expectAOTitleToBeDirty()
     })

--- a/cypress/integration/confirmLeave.cy.js
+++ b/cypress/integration/confirmLeave.cy.js
@@ -1,8 +1,9 @@
-import { DIMENSION_ID_DATA } from '@dhis2/analytics'
+import { isYearOverYear, DIMENSION_ID_PERIOD } from '@dhis2/analytics'
 
 import {
     expectAOTitleToBeDirty,
     expectAOTitleToNotBeDirty,
+    expectVisualizationToBeVisible,
     expectVisualizationToNotBeVisible,
 } from '../elements/chart'
 import {
@@ -11,30 +12,42 @@ import {
 } from '../elements/confirmLeaveModal'
 import {
     clickDimensionModalUpdateButton,
-    removeAllDataItems,
-    selectDataElements,
+    selectRelativePeriods,
 } from '../elements/dimensionModal'
-import { expectNoDataItemsToBeSelected } from '../elements/dimensionModal/dataDimension'
+import { removeAllPeriodItems } from '../elements/dimensionModal/periodDimension'
 import { openDimension } from '../elements/dimensionsPanel'
-import { createNewAO, openRandomAO } from '../elements/fileMenu'
+import { createNewAO, openAOByName } from '../elements/fileMenu'
+import { selectYoyCategoryOption } from '../elements/layout'
+import { clickMenuBarUpdateButton } from '../elements/menuBar'
 import {
     expectStartScreenToBeVisible,
     goToStartPage,
 } from '../elements/startScreen'
-import { TEST_DATA_ELEMENTS } from '../utils/data'
+import { TEST_AOS } from '../utils/data'
 import { getRandomArrayItem } from '../utils/random'
 
 describe('confirm leave modal', () => {
+    const TEST_AO = getRandomArrayItem(TEST_AOS)
+
     it('navigates to the start page and loads a random saved AO', () => {
         goToStartPage()
-        openRandomAO()
+        openAOByName(TEST_AO.name)
         expectAOTitleToNotBeDirty()
     })
-    it('replaces the data items', () => {
-        openDimension(DIMENSION_ID_DATA)
-        removeAllDataItems().then(() => expectNoDataItemsToBeSelected())
-        selectDataElements([getRandomArrayItem(TEST_DATA_ELEMENTS).name])
-        clickDimensionModalUpdateButton()
+    it(`replaces the selected period`, () => {
+        if (isYearOverYear(TEST_AO.type)) {
+            const TEST_PERIOD = 'Last 2 six-months'
+            selectYoyCategoryOption(TEST_PERIOD)
+            clickMenuBarUpdateButton()
+        } else {
+            const TEST_PERIOD_TYPE = 'Six-months'
+            const TEST_PERIOD = 'Last six-month'
+            openDimension(DIMENSION_ID_PERIOD)
+            removeAllPeriodItems()
+            selectRelativePeriods([TEST_PERIOD], TEST_PERIOD_TYPE)
+            clickDimensionModalUpdateButton()
+        }
+        expectVisualizationToBeVisible(TEST_AO.type)
         expectAOTitleToBeDirty()
     })
     it('tries to open a new AO', () => {

--- a/cypress/integration/open.cy.js
+++ b/cypress/integration/open.cy.js
@@ -1,8 +1,4 @@
-import {
-    isYearOverYear,
-    visTypeDisplayNames,
-    DIMENSION_ID_PERIOD,
-} from '@dhis2/analytics'
+import { visTypeDisplayNames } from '@dhis2/analytics'
 
 import { createNewAO, openAOByName } from '../elements/fileMenu'
 import { confirmLeave } from '../elements/confirmLeaveModal'
@@ -13,15 +9,9 @@ import {
     expectVisualizationToBeVisible,
 } from '../elements/chart'
 import { goToStartPage } from '../elements/startScreen'
-import {
-    clickDimensionModalUpdateButton,
-    selectRelativePeriods,
-} from '../elements/dimensionModal'
-import { openDimension } from '../elements/dimensionsPanel'
 import { TEST_AOS } from '../utils/data'
-import { selectYoyCategoryOption } from '../elements/layout'
-import { clickMenuBarUpdateButton } from '../elements/menuBar'
 import { expectRouteToBeAOId, expectRouteToBeEmpty } from '../elements/route'
+import { replacePeriodItems } from '../elements/common'
 
 describe('opening a saved AO', () => {
     it('navigates to the start page', () => {
@@ -36,18 +26,8 @@ describe('opening a saved AO', () => {
                 expectVisualizationToBeVisible(ao.type)
                 expectAOTitleToNotBeDirty()
             })
-            it(`adds a period`, () => {
-                if (isYearOverYear(ao.type)) {
-                    const TEST_PERIOD = 'Last 2 six-months'
-                    selectYoyCategoryOption(TEST_PERIOD)
-                    clickMenuBarUpdateButton()
-                } else {
-                    const TEST_PERIOD_TYPE = 'Six-months'
-                    const TEST_PERIOD = 'Last six-month'
-                    openDimension(DIMENSION_ID_PERIOD)
-                    selectRelativePeriods([TEST_PERIOD], TEST_PERIOD_TYPE)
-                    clickDimensionModalUpdateButton()
-                }
+            it(`replaces the selected period`, () => {
+                replacePeriodItems(ao.type)
                 expectAOTitleToBeDirty()
                 expectVisualizationToBeVisible(ao.type)
             })

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -1,15 +1,9 @@
-import {
-    DIMENSION_ID_DATA,
-    DIMENSION_ID_PERIOD,
-    isYearOverYear,
-    visTypeDisplayNames,
-} from '@dhis2/analytics'
+import { DIMENSION_ID_DATA, visTypeDisplayNames } from '@dhis2/analytics'
 
 import { openDimension } from '../elements/dimensionsPanel'
 import {
     selectDataElements,
     clickDimensionModalUpdateButton,
-    selectRelativePeriods,
 } from '../elements/dimensionModal'
 import { changeVisType } from '../elements/visualizationTypeSelector'
 import {
@@ -42,15 +36,12 @@ import {
 } from '../elements/fileMenu'
 import { expectRouteToBeAOId, expectRouteToBeEmpty } from '../elements/route'
 import { getRandomVisType } from '../utils/random'
-import {
-    clickMenuBarFileButton,
-    clickMenuBarUpdateButton,
-} from '../elements/menuBar'
-import { selectYoyCategoryOption } from '../elements/layout'
+import { clickMenuBarFileButton } from '../elements/menuBar'
 import {
     expectStartScreenToBeVisible,
     goToStartPage,
 } from '../elements/startScreen'
+import { replacePeriodItems } from '../elements/common'
 
 const TEST_VIS_NAME = `TEST ${new Date().toLocaleString()}`
 const TEST_VIS_NAME_UPDATED = `${TEST_VIS_NAME} - updated`
@@ -111,18 +102,8 @@ describe('saving an AO', () => {
             )
             closeFileMenu()
         })
-        it(`changes the period`, () => {
-            if (isYearOverYear(TEST_VIS_TYPE)) {
-                const TEST_PERIOD = 'Last 2 six-months'
-                selectYoyCategoryOption(TEST_PERIOD)
-                clickMenuBarUpdateButton()
-            } else {
-                const TEST_PERIOD_TYPE = 'Six-months'
-                const TEST_PERIOD = 'Last six-month'
-                openDimension(DIMENSION_ID_PERIOD)
-                selectRelativePeriods([TEST_PERIOD], TEST_PERIOD_TYPE)
-                clickDimensionModalUpdateButton()
-            }
+        it(`replaces the selected period`, () => {
+            replacePeriodItems(TEST_VIS_TYPE)
             expectAOTitleToBeDirty()
             expectVisualizationToBeVisible(TEST_VIS_TYPE)
         })
@@ -144,15 +125,8 @@ describe('saving an AO', () => {
             goToStartPage()
             openAOByName(TEST_VIS_NAME_UPDATED)
         })
-        it(`changes the period`, () => {
-            if (isYearOverYear(TEST_VIS_TYPE)) {
-                selectYoyCategoryOption('Quarters per year')
-                clickMenuBarUpdateButton()
-            } else {
-                openDimension('pe')
-                selectRelativePeriods(['Last quarter'], 'Quarters')
-                clickDimensionModalUpdateButton()
-            }
+        it(`replaces the selected period`, () => {
+            replacePeriodItems(TEST_VIS_TYPE, true)
             expectAOTitleToBeDirty()
         })
         it('saves AO using "Save"', () => {

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -126,7 +126,7 @@ describe('saving an AO', () => {
             openAOByName(TEST_VIS_NAME_UPDATED)
         })
         it(`replaces the selected period`, () => {
-            replacePeriodItems(TEST_VIS_TYPE, true)
+            replacePeriodItems(TEST_VIS_TYPE, { useAltData: true })
             expectAOTitleToBeDirty()
         })
         it('saves AO using "Save"', () => {


### PR DESCRIPTION
### Key features

1. fix flaky test
2. add a common way to change an AO

---

### Description

`confirmLeave` is flaky, I think this is caused by the way MUI handles updates in the data dimension selector (soon to be replaced by non-MUI). The test replaces data items which sometimes isn't performed in order, even though a `then` is used. This PR changes the test to replace period items instead, since the new period selector (non-MUI) seems to be stable. 

`replacePeriodItems` was added to create a common way to change an AO that's easy to use. Period, Data and Org units are the only dimensions that can be assumed are in all AOs, so when loading a "random" AO that should be changed, it must change one of these three dimensions. However Data is flaky (issue above) and the org unit tree is quite complex (plus it might suffer from the same flakiness as Data), which is why I chose to change period instead. I've picked a period which I think is fairly uncommon (`Last 2 six-months`). To be able to alternate between this and an another value (`Quarters per year`) I've added a `useAltData` prop to switch between the two periods.