### PR TITLE
fix: change order of item attr when added (DHIS2-10007)

### DIFF
--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -277,8 +277,8 @@ export default (state = DEFAULT_UI, action) => {
                     ...state.itemsByDimension,
                     [dimensionId]: [
                         ...new Set([
-                            ...itemIds,
                             ...state.itemsByDimension[dimensionId],
+                            ...itemIds,
                         ]),
                     ],
                 },


### PR DESCRIPTION
Implements [DHIS2-10007](https://jira.dhis2.org/browse/DHIS2-10007)

---

### Description

Changes the order of item attributes when adding, to prevent the attributes from switching place. 
Previously having `1` and adding `2` would result in `[2, 1]`, but this has now been fixed to return `[1, 2]` instead.
