### PR TITLE
fix: YOY charts with relative week periods DHIS2-9729

### DIFF
--- a/packages/plugin/src/__tests__/VisualizationPlugin.spec.js
+++ b/packages/plugin/src/__tests__/VisualizationPlugin.spec.js
@@ -7,6 +7,7 @@ import { VisualizationPlugin } from '../VisualizationPlugin'
 
 import * as api from '../api/analytics'
 import * as options from '../modules/options'
+import * as moduleAnalytics from '../modules/analytics'
 
 import ChartPlugin from '../ChartPlugin'
 
@@ -52,6 +53,7 @@ const yearOverYearCurrentMock = {
     type: analytics.VIS_TYPE_YEAR_OVER_YEAR_LINE,
     columns: [dxMock],
     rows: [peMock],
+    filters: [ouMock],
     yearlySeries: ['LAST_YEAR'],
 }
 
@@ -111,6 +113,7 @@ describe('VisualizationPlugin', () => {
             ...props,
         }
         let plugin
+
         await act(async () => {
             plugin = mount(<VisualizationPlugin {...combinedProps} />)
             await new Promise(resolve => {
@@ -186,6 +189,15 @@ describe('VisualizationPlugin', () => {
                 ChartPlugin.mockClear()
 
                 /* eslint-disable no-import-assign, import/namespace */
+                moduleAnalytics.getRelativePeriodTypeUsed = jest
+                    .fn()
+                    .mockReturnValue(undefined)
+
+                analytics.layoutGetDimensionItems = jest
+                    .fn()
+                    .mockReturnValue(peMock.items)
+
+                /* eslint-disable no-import-assign, import/namespace */
                 api.apiFetchAnalyticsForYearOverYear = jest
                     .fn()
                     .mockResolvedValue(new MockYoYAnalyticsResponse())
@@ -215,6 +227,7 @@ describe('VisualizationPlugin', () => {
                 const expectedExtraOptions = {
                     yearlySeries: mockYoYSeriesLabels,
                     xAxisLabels: ['period 1', 'period 2'],
+                    periodKeyAxisIndexMap: { p1: 0, p2: 1 },
                 }
 
                 expect(ChartPlugin.mock.calls[0][0].extraOptions).toEqual({

--- a/packages/plugin/src/__tests__/yoy-weekly-edge-cases.spec.js
+++ b/packages/plugin/src/__tests__/yoy-weekly-edge-cases.spec.js
@@ -4,39 +4,6 @@ import {
     computeGenericPeriodNamesFromMatrix,
 } from '../modules/analytics'
 
-// 2020 has 53 weeks, while 2019 52
-// last 4 weeks from 27th january 2021 are different for the 2 years
-// for 2021: W53 of 2020 and weeks 1 to 3 of 2021
-// for 2020: W52 of 2019 and weeks 1 to 3 of 2020
-const responses20210127 = [
-    {
-        metaData: {
-            dimensions: {
-                pe: ['2020W53', '2021W1', '2021W2', '2021W3'],
-            },
-            items: {
-                '2020W53': { name: 'Week 53 2020' },
-                '2021W1': { name: 'Week 1 2021' },
-                '2021W2': { name: 'Week 2 2021' },
-                '2021W3': { name: 'Week 3 2021' },
-            },
-        },
-    },
-    {
-        metaData: {
-            dimensions: {
-                pe: ['2019W52', '2020W1', '2020W2', '2020W3'],
-            },
-            items: {
-                '2019W52': { name: 'Week 52 2019' },
-                '2020W1': { name: 'Week 1 2020' },
-                '2020W2': { name: 'Week 2 2020' },
-                '2020W3': { name: 'Week 3 2020' },
-            },
-        },
-    },
-]
-
 // 1st january 2021 is in week 53, so last 4 weeks from that date are
 // all in 2020, starting from W52 and counting 4 weeks backwards
 // to avoid the 2 series to refer to the same year (2020), data for the same 4 weeks of 2019
@@ -66,6 +33,39 @@ const responses20210101 = [
                 '2019W50': { name: 'Week 50 2019' },
                 '2019W51': { name: 'Week 51 2019' },
                 '2019W52': { name: 'Week 52 2019' },
+            },
+        },
+    },
+]
+
+// 2020 has 53 weeks, while 2019 52
+// last 4 weeks from 27th january 2021 are different for the 2 years
+// for 2021: W53 of 2020 and weeks 1 to 3 of 2021
+// for 2020: W52 of 2019 and weeks 1 to 3 of 2020
+const responses20210127 = [
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2020W53', '2021W1', '2021W2', '2021W3'],
+            },
+            items: {
+                '2020W53': { name: 'Week 53 2020' },
+                '2021W1': { name: 'Week 1 2021' },
+                '2021W2': { name: 'Week 2 2021' },
+                '2021W3': { name: 'Week 3 2021' },
+            },
+        },
+    },
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2019W52', '2020W1', '2020W2', '2020W3'],
+            },
+            items: {
+                '2019W52': { name: 'Week 52 2019' },
+                '2020W1': { name: 'Week 1 2020' },
+                '2020W2': { name: 'Week 2 2020' },
+                '2020W3': { name: 'Week 3 2020' },
             },
         },
     },
@@ -136,56 +136,59 @@ const responses20160111 = [
 
 describe('YOY edge cases testing: LAST_4_WEEKS across 2 years', () => {
     const testCases = [
-        responses20210127,
-        responses20210101,
-        responses20160104,
-        responses20160111,
+        {
+            responses: responses20210101,
+            expectedMatrix: [
+                ['2020W49', '2019W49'],
+                ['2020W50', '2019W50'],
+                ['2020W51', '2019W51'],
+                ['2020W52', '2019W52'],
+            ],
+            expectedPeriodNames: ['W49', 'W50', 'W51', 'W52'],
+        },
+        {
+            responses: responses20210127,
+            expectedMatrix: [
+                ['2019W52'],
+                ['2020W53'],
+                ['2021W1', '2020W1'],
+                ['2021W2', '2020W2'],
+                ['2021W3', '2020W3'],
+            ],
+            expectedPeriodNames: ['W52', 'W53', 'W1', 'W2', 'W3'],
+        },
+        {
+            responses: responses20160104,
+            expectedMatrix: [
+                ['2014W49'],
+                ['2015W50', '2014W50'],
+                ['2015W51', '2014W51'],
+                ['2015W52', '2014W52'],
+                ['2015W53'],
+            ],
+
+            expectedPeriodNames: ['W49', 'W50', 'W51', 'W52', 'W53'],
+        },
+        {
+            responses: responses20160111,
+            expectedMatrix: [
+                ['2014W50'],
+                ['2015W51', '2014W51'],
+                ['2015W52', '2014W52'],
+                ['2015W53'],
+                ['2016W1', '2015W1'],
+            ],
+            expectedPeriodNames: ['W50', 'W51', 'W52', 'W53', 'W1'],
+        },
     ]
 
-    const expected = [
-        [
-            ['2019W52'],
-            ['2020W53'],
-            ['2021W1', '2020W1'],
-            ['2021W2', '2020W2'],
-            ['2021W3', '2020W3'],
-        ],
-        [
-            ['2020W49', '2019W49'],
-            ['2020W50', '2019W50'],
-            ['2020W51', '2019W51'],
-            ['2020W52', '2019W52'],
-        ],
-        [
-            ['2014W49'],
-            ['2015W50', '2014W50'],
-            ['2015W51', '2014W51'],
-            ['2015W52', '2014W52'],
-            ['2015W53'],
-        ],
-        [
-            ['2014W50'],
-            ['2015W51', '2014W51'],
-            ['2015W52', '2014W52'],
-            ['2015W53'],
-            ['2016W1', '2015W1'],
-        ],
-    ]
-
-    const expectedPeriodNames = [
-        ['W52', 'W53', 'W1', 'W2', 'W3'],
-        ['W49', 'W50', 'W51', 'W52'],
-        ['W49', 'W50', 'W51', 'W52', 'W53'],
-        ['W50', 'W51', 'W52', 'W53', 'W1'],
-    ]
-
-    testCases.forEach((testCase, index) =>
+    testCases.forEach(testCase =>
         it('generated correct matrix from analytics responses', () => {
-            const matrix = computeYoYMatrix(testCase, WEEKS)
+            const matrix = computeYoYMatrix(testCase.responses, WEEKS)
 
-            expect(matrix).toEqual(expected[index])
+            expect(matrix).toEqual(testCase.expectedMatrix)
             expect(computeGenericPeriodNamesFromMatrix(matrix, WEEKS)).toEqual(
-                expectedPeriodNames[index]
+                testCase.expectedPeriodNames
             )
         })
     )

--- a/packages/plugin/src/__tests__/yoy-weekly-edge-cases.spec.js
+++ b/packages/plugin/src/__tests__/yoy-weekly-edge-cases.spec.js
@@ -1,5 +1,8 @@
 import { WEEKS } from '@dhis2/analytics'
-import { computeYoYMatrix } from '../modules/analytics'
+import {
+    computeYoYMatrix,
+    computeGenericPeriodNamesFromMatrix,
+} from '../modules/analytics'
 
 // 2020 has 53 weeks, while 2019 52
 // last 4 weeks from 27th january 2021 are different for the 2 years
@@ -169,9 +172,21 @@ describe('YOY edge cases testing: LAST_4_WEEKS across 2 years', () => {
         ],
     ]
 
+    const expectedPeriodNames = [
+        ['W52', 'W53', 'W1', 'W2', 'W3'],
+        ['W49', 'W50', 'W51', 'W52'],
+        ['W49', 'W50', 'W51', 'W52', 'W53'],
+        ['W50', 'W51', 'W52', 'W53', 'W1'],
+    ]
+
     testCases.forEach((testCase, index) =>
         it('generated correct matrix from analytics responses', () => {
-            expect(computeYoYMatrix(testCase, WEEKS)).toEqual(expected[index])
+            const matrix = computeYoYMatrix(testCase, WEEKS)
+
+            expect(matrix).toEqual(expected[index])
+            expect(computeGenericPeriodNamesFromMatrix(matrix, WEEKS)).toEqual(
+                expectedPeriodNames[index]
+            )
         })
     )
 })

--- a/packages/plugin/src/__tests__/yoy-weekly-edge-cases.spec.js
+++ b/packages/plugin/src/__tests__/yoy-weekly-edge-cases.spec.js
@@ -1,0 +1,177 @@
+import { WEEKS } from '@dhis2/analytics'
+import { computeYoYMatrix } from '../modules/analytics'
+
+// 2020 has 53 weeks, while 2019 52
+// last 4 weeks from 27th january 2021 are different for the 2 years
+// for 2021: W53 of 2020 and weeks 1 to 3 of 2021
+// for 2020: W52 of 2019 and weeks 1 to 3 of 2020
+const responses20210127 = [
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2020W53', '2021W1', '2021W2', '2021W3'],
+            },
+            items: {
+                '2020W53': { name: 'Week 53 2020' },
+                '2021W1': { name: 'Week 1 2021' },
+                '2021W2': { name: 'Week 2 2021' },
+                '2021W3': { name: 'Week 3 2021' },
+            },
+        },
+    },
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2019W52', '2020W1', '2020W2', '2020W3'],
+            },
+            items: {
+                '2019W52': { name: 'Week 52 2019' },
+                '2020W1': { name: 'Week 1 2020' },
+                '2020W2': { name: 'Week 2 2020' },
+                '2020W3': { name: 'Week 3 2020' },
+            },
+        },
+    },
+]
+
+// 1st january 2021 is in week 53, so last 4 weeks from that date are
+// all in 2020, starting from W52 and counting 4 weeks backwards
+// to avoid the 2 series to refer to the same year (2020), data for the same 4 weeks of 2019
+// is fetched for the 2nd serie (2020)
+// no gaps in this case
+const responses20210101 = [
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2020W49', '2020W50', '2020W51', '2020W52'],
+            },
+            items: {
+                '2020W49': { name: 'Week 49 2020' },
+                '2020W50': { name: 'Week 50 2020' },
+                '2020W51': { name: 'Week 51 2020' },
+                '2020W52': { name: 'Week 52 2020' },
+            },
+        },
+    },
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2019W49', '2019W50', '2019W51', '2019W52'],
+            },
+            items: {
+                '2019W49': { name: 'Week 49 2019' },
+                '2019W50': { name: 'Week 50 2019' },
+                '2019W51': { name: 'Week 51 2019' },
+                '2019W52': { name: 'Week 52 2019' },
+            },
+        },
+    },
+]
+
+// 4th january 2016 is in week 1, and 2015 has 53 weeks
+// last 4 weeks from the date are then weeks 50 to 53 of 2015
+// 2014 does not have W53, so weeks for that year are 49 to 52
+const responses20160104 = [
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2015W50', '2015W51', '2015W52', '2015W53'],
+            },
+            items: {
+                '2015W50': { name: 'Week 50 2015' },
+                '2015W51': { name: 'Week 51 2015' },
+                '2015W52': { name: 'Week 52 2015' },
+                '2015W53': { name: 'Week 53 2015' },
+            },
+        },
+    },
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2014W49', '2014W50', '2014W51', '2014W52'],
+            },
+            items: {
+                '2014W49': { name: 'Week 49 2014' },
+                '2014W50': { name: 'Week 50 2014' },
+                '2014W51': { name: 'Week 51 2014' },
+                '2014W52': { name: 'Week 52 2014' },
+            },
+        },
+    },
+]
+
+// both periods end with week 1, but they start at a different week
+// due to 2015 having the extra week 53
+const responses20160111 = [
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2015W51', '2015W52', '2015W53', '2016W1'],
+            },
+            items: {
+                '2015W51': { name: 'Week 51 2015' },
+                '2015W52': { name: 'Week 52 2015' },
+                '2015W53': { name: 'Week 53 2015' },
+                '2016W1': { name: 'Week 1 2016' },
+            },
+        },
+    },
+    {
+        metaData: {
+            dimensions: {
+                pe: ['2014W50', '2014W51', '2014W52', '2015W1'],
+            },
+            items: {
+                '2014W50': { name: 'Week 50 2014' },
+                '2014W51': { name: 'Week 51 2014' },
+                '2014W52': { name: 'Week 52 2014' },
+                '2015W1': { name: 'Week 1 2015' },
+            },
+        },
+    },
+]
+
+describe('YOY edge cases testing: LAST_4_WEEKS across 2 years', () => {
+    const testCases = [
+        responses20210127,
+        responses20210101,
+        responses20160104,
+        responses20160111,
+    ]
+
+    const expected = [
+        [
+            ['2019W52'],
+            ['2020W53'],
+            ['2021W1', '2020W1'],
+            ['2021W2', '2020W2'],
+            ['2021W3', '2020W3'],
+        ],
+        [
+            ['2020W49', '2019W49'],
+            ['2020W50', '2019W50'],
+            ['2020W51', '2019W51'],
+            ['2020W52', '2019W52'],
+        ],
+        [
+            ['2014W49'],
+            ['2015W50', '2014W50'],
+            ['2015W51', '2014W51'],
+            ['2015W52', '2014W52'],
+            ['2015W53'],
+        ],
+        [
+            ['2014W50'],
+            ['2015W51', '2014W51'],
+            ['2015W52', '2014W52'],
+            ['2015W53'],
+            ['2016W1', '2015W1'],
+        ],
+    ]
+
+    testCases.forEach((testCase, index) =>
+        it('generated correct matrix from analytics responses', () => {
+            expect(computeYoYMatrix(testCase, WEEKS)).toEqual(expected[index])
+        })
+    )
+})

--- a/packages/plugin/src/api/analytics.js
+++ b/packages/plugin/src/api/analytics.js
@@ -2,10 +2,11 @@ import {
     Analytics,
     VIS_TYPE_PIVOT_TABLE,
     layoutGetDimensionItems,
-    getRelativePeriodsOptionsById,
-    WEEKS,
     DIMENSION_ID_PERIOD,
+    WEEKS,
 } from '@dhis2/analytics'
+
+import { getRelativePeriodTypeUsed } from '../modules/analytics'
 
 const peId = DIMENSION_ID_PERIOD
 
@@ -56,11 +57,7 @@ export const apiFetchAnalyticsForYearOverYear = async (
     console.log('pe items', peItems)
 
     // relative week period in use
-    if (
-        getRelativePeriodsOptionsById(WEEKS)
-            .getPeriods()
-            .find(p => p.id === peItems[0].id)
-    ) {
+    if (getRelativePeriodTypeUsed(peItems) === WEEKS) {
         console.log('relative weeks period in use')
         const relativeWeeksData = await prepareRequestsForRelativeWeeks({
             analyticsEngine,

--- a/packages/plugin/src/api/analytics.js
+++ b/packages/plugin/src/api/analytics.js
@@ -54,11 +54,9 @@ export const apiFetchAnalyticsForYearOverYear = async (
     const currentMonth = ('' + (now.getMonth() + 1)).padStart(2, 0)
 
     const peItems = layoutGetDimensionItems(visualization, peId)
-    console.log('pe items', peItems)
 
     // relative week period in use
     if (getRelativePeriodTypeUsed(peItems) === WEEKS) {
-        console.log('relative weeks period in use')
         const relativeWeeksData = await prepareRequestsForRelativeWeeks({
             analyticsEngine,
             visualization,
@@ -85,8 +83,6 @@ export const apiFetchAnalyticsForYearOverYear = async (
                 periodDates.push(`${year}-${currentMonth}-${currentDay}`)
             })
     }
-
-    console.log('periodDates', periodDates)
 
     // request analytics data/metaData for each year in the serie with its own specific relativePeriodDate
     const requests = periodDates.reduce((list, periodDate) => {
@@ -134,7 +130,6 @@ const prepareRequestsForRelativeWeeks = async ({
     //    this is done by adding 1 day to the endDate of the week period obtained above
     // 4. request analytics data/metaData for each year in the serie with its own specific relativePeriodDate
     const referencePeriodYear = yearlySeriesIds.shift()
-    console.log('ref period year', referencePeriodYear)
 
     yearlySeriesLabels.push(
         yearlySeriesRes.metaData.items[referencePeriodYear].name
@@ -156,8 +151,6 @@ const prepareRequestsForRelativeWeeks = async ({
         referencePeriodReq
     )
 
-    console.log('ref period res', referencePeriodRes)
-
     // 2. extract the last week number of the LAST_x_WEEKS period
     //    special handling for the week 53 case as not all years have 53 weeks
     const referenceWeekPeriod = referencePeriodRes.metaData.dimensions[
@@ -166,9 +159,7 @@ const prepareRequestsForRelativeWeeks = async ({
     const [referenceWeekYear, referenceWeekNumber] = referenceWeekPeriod.split(
         'W'
     )
-    console.log('ref week number', referenceWeekNumber)
     const referenceWeekYearDelta = referencePeriodYear - referenceWeekYear
-    console.log('ref week year delta', referenceWeekYearDelta)
 
     const weekPeriods = yearlySeriesIds.reduce((periods, year) => {
         yearlySeriesLabels.push(yearlySeriesRes.metaData.items[year].name)
@@ -182,7 +173,6 @@ const prepareRequestsForRelativeWeeks = async ({
 
         return periods
     }, [])
-    console.log('week periods', weekPeriods)
 
     if (weekPeriods.length) {
         // 3. request metadata for the same week number for each one of the other years of the serie
@@ -195,7 +185,6 @@ const prepareRequestsForRelativeWeeks = async ({
         const weekPeriodsRes = await analyticsEngine.aggregate.fetch(
             weekPeriodsReq
         )
-        console.log('res week periods', weekPeriodsRes)
 
         // 3. compute relativePeriodDate for each other year of the serie:
         //    this is done by adding 1 day to the endDate of the week period obtained above

--- a/packages/plugin/src/api/analytics.js
+++ b/packages/plugin/src/api/analytics.js
@@ -8,7 +8,7 @@ import {
 
 import { getRelativePeriodTypeUsed } from '../modules/analytics'
 
-const peId = DIMENSION_ID_PERIOD
+const periodId = DIMENSION_ID_PERIOD
 
 export const apiFetchAnalytics = async (dataEngine, visualization, options) => {
     const analyticsEngine = Analytics.getAnalytics(dataEngine)
@@ -53,10 +53,10 @@ export const apiFetchAnalyticsForYearOverYear = async (
     const currentDay = ('' + now.getDate()).padStart(2, 0)
     const currentMonth = ('' + (now.getMonth() + 1)).padStart(2, 0)
 
-    const peItems = layoutGetDimensionItems(visualization, peId)
+    const periodItems = layoutGetDimensionItems(visualization, periodId)
 
     // relative week period in use
-    if (getRelativePeriodTypeUsed(peItems) === WEEKS) {
+    if (getRelativePeriodTypeUsed(periodItems) === WEEKS) {
         const relativeWeeksData = await prepareRequestsForRelativeWeeks({
             analyticsEngine,
             visualization,
@@ -72,7 +72,7 @@ export const apiFetchAnalyticsForYearOverYear = async (
         // relative day period in use
         // similar to the above to handle the Feb 29 extra day
     } else {
-        yearlySeriesRes.metaData.dimensions[peId]
+        yearlySeriesRes.metaData.dimensions[periodId]
             .sort()
             .reverse()
             .forEach(year => {
@@ -118,7 +118,7 @@ const prepareRequestsForRelativeWeeks = async ({
     const yearlySeriesLabels = []
     const periodDates = []
 
-    const yearlySeriesIds = yearlySeriesRes.metaData.dimensions[peId]
+    const yearlySeriesIds = yearlySeriesRes.metaData.dimensions[periodId]
         .slice()
         .sort()
         .reverse()
@@ -154,7 +154,7 @@ const prepareRequestsForRelativeWeeks = async ({
     // 2. extract the last week number of the LAST_x_WEEKS period
     //    special handling for the week 53 case as not all years have 53 weeks
     const referenceWeekPeriod = referencePeriodRes.metaData.dimensions[
-        peId
+        periodId
     ].pop()
     const [referenceWeekYear, referenceWeekNumber] = referenceWeekPeriod.split(
         'W'
@@ -190,7 +190,7 @@ const prepareRequestsForRelativeWeeks = async ({
         //    this is done by adding 1 day to the endDate of the week period obtained above
         const seenYears = []
 
-        weekPeriodsRes.metaData.dimensions[peId]
+        weekPeriodsRes.metaData.dimensions[periodId]
             .sort()
             .reverse()
             .forEach(period => {

--- a/packages/plugin/src/api/analytics.js
+++ b/packages/plugin/src/api/analytics.js
@@ -1,6 +1,13 @@
-import { Analytics, VIS_TYPE_PIVOT_TABLE } from '@dhis2/analytics'
+import {
+    Analytics,
+    VIS_TYPE_PIVOT_TABLE,
+    layoutGetDimensionItems,
+    getRelativePeriodsOptionsById,
+    WEEKS,
+    DIMENSION_ID_PERIOD,
+} from '@dhis2/analytics'
 
-const peId = 'pe'
+const peId = DIMENSION_ID_PERIOD
 
 export const apiFetchAnalytics = async (dataEngine, visualization, options) => {
     const analyticsEngine = Analytics.getAnalytics(dataEngine)
@@ -38,28 +45,191 @@ export const apiFetchAnalyticsForYearOverYear = async (
         yearlySeriesReq
     )
 
-    const requests = []
+    const periodDates = []
     const yearlySeriesLabels = []
 
     const now = new Date()
     const currentDay = ('' + now.getDate()).padStart(2, 0)
     const currentMonth = ('' + (now.getMonth() + 1)).padStart(2, 0)
 
-    yearlySeriesRes.metaData.dimensions[peId].forEach(period => {
-        yearlySeriesLabels.push(yearlySeriesRes.metaData.items[period].name)
+    const peItems = layoutGetDimensionItems(visualization, peId)
+    console.log('pe items', peItems)
 
-        const startDate = `${period}-${currentMonth}-${currentDay}`
+    // relative week period in use
+    if (
+        getRelativePeriodsOptionsById(WEEKS)
+            .getPeriods()
+            .find(p => p.id === peItems[0].id)
+    ) {
+        console.log('relative weeks period in use')
+        const relativeWeeksData = await prepareRequestsForRelativeWeeks({
+            analyticsEngine,
+            visualization,
+            options,
+            yearlySeriesRes,
+            currentMonth,
+            currentDay,
+        })
 
+        periodDates.push(...relativeWeeksData.periodDates)
+        yearlySeriesLabels.push(...relativeWeeksData.yearlySeriesLabels)
+        // TODO
+        // relative day period in use
+        // similar to the above to handle the Feb 29 extra day
+    } else {
+        yearlySeriesRes.metaData.dimensions[peId]
+            .sort()
+            .reverse()
+            .forEach(year => {
+                yearlySeriesLabels.push(
+                    yearlySeriesRes.metaData.items[year].name
+                )
+
+                periodDates.push(`${year}-${currentMonth}-${currentDay}`)
+            })
+    }
+
+    console.log('periodDates', periodDates)
+
+    // request analytics data/metaData for each year in the serie with its own specific relativePeriodDate
+    const requests = periodDates.reduce((list, periodDate) => {
         const req = new analyticsEngine.request()
             .fromVisualization(visualization)
             .withParameters(options)
-            .withRelativePeriodDate(startDate)
+            .withRelativePeriodDate(periodDate)
 
-        requests.push(analyticsEngine.aggregate.get(req))
-    })
+        list.push(analyticsEngine.aggregate.get(req))
+
+        return list
+    }, [])
 
     return Promise.all(requests).then(responses => ({
         responses: responses.map(res => new analyticsEngine.response(res)),
         yearlySeriesLabels,
     }))
+}
+
+// special handling for when a relative weeks period is selected as category
+// this takes care of data alignment issues between different years when one of the years have 53 weeks
+// and more in general when the returned weeks for different years are not exactly the same range
+// and data points must be "shifted" in the right position
+// See https://jira.dhis2.org/browse/DHIS2-9729
+const prepareRequestsForRelativeWeeks = async ({
+    analyticsEngine,
+    visualization,
+    options,
+    yearlySeriesRes,
+    currentMonth,
+    currentDay,
+}) => {
+    const yearlySeriesLabels = []
+    const periodDates = []
+
+    const yearlySeriesIds = yearlySeriesRes.metaData.dimensions[peId]
+        .slice()
+        .sort()
+        .reverse()
+
+    // 1. request metadata of last year of the serie (with relativePeriodDate === today)
+    // 2. extract the last week number of the LAST_x_WEEKS period
+    // 3. request metadata for the same week number for each one of the other years of the serie
+    // 3. compute relativePeriodDate for each other year of the serie:
+    //    this is done by adding 1 day to the endDate of the week period obtained above
+    // 4. request analytics data/metaData for each year in the serie with its own specific relativePeriodDate
+    const referencePeriodYear = yearlySeriesIds.shift()
+    console.log('ref period year', referencePeriodYear)
+
+    yearlySeriesLabels.push(
+        yearlySeriesRes.metaData.items[referencePeriodYear].name
+    )
+
+    periodDates.push(`${referencePeriodYear}-${currentMonth}-${currentDay}`)
+
+    // 1. request metadata of last year of the serie (with relativePeriodDate === today)
+    const referencePeriodReq = new analyticsEngine.request()
+        .fromVisualization(visualization)
+        .withParameters(options)
+        .withRelativePeriodDate(
+            `${referencePeriodYear}-${currentMonth}-${currentDay}`
+        )
+        .withSkipData(true)
+        .withSkipMeta(false)
+
+    const referencePeriodRes = await analyticsEngine.aggregate.fetch(
+        referencePeriodReq
+    )
+
+    console.log('ref period res', referencePeriodRes)
+
+    // 2. extract the last week number of the LAST_x_WEEKS period
+    //    special handling for the week 53 case as not all years have 53 weeks
+    const referenceWeekPeriod = referencePeriodRes.metaData.dimensions[
+        peId
+    ].pop()
+    const [referenceWeekYear, referenceWeekNumber] = referenceWeekPeriod.split(
+        'W'
+    )
+    console.log('ref week number', referenceWeekNumber)
+    const referenceWeekYearDelta = referencePeriodYear - referenceWeekYear
+    console.log('ref week year delta', referenceWeekYearDelta)
+
+    const weekPeriods = yearlySeriesIds.reduce((periods, year) => {
+        yearlySeriesLabels.push(yearlySeriesRes.metaData.items[year].name)
+
+        periods.push(`${year - referenceWeekYearDelta}W${referenceWeekNumber}`)
+
+        // edge case for week 53, not all years have it, so request also week 52
+        if (referenceWeekNumber === '53') {
+            periods.push(`${year - referenceWeekYearDelta}W52`)
+        }
+
+        return periods
+    }, [])
+    console.log('week periods', weekPeriods)
+
+    if (weekPeriods.length) {
+        // 3. request metadata for the same week number for each one of the other years of the serie
+        const weekPeriodsReq = new analyticsEngine.request()
+            .addPeriodDimension(weekPeriods)
+            .withSkipData(true)
+            .withSkipMeta(false)
+            .withIncludeMetadataDetails(true)
+
+        const weekPeriodsRes = await analyticsEngine.aggregate.fetch(
+            weekPeriodsReq
+        )
+        console.log('res week periods', weekPeriodsRes)
+
+        // 3. compute relativePeriodDate for each other year of the serie:
+        //    this is done by adding 1 day to the endDate of the week period obtained above
+        const seenYears = []
+
+        weekPeriodsRes.metaData.dimensions[peId]
+            .sort()
+            .reverse()
+            .forEach(period => {
+                const year = period.substr(0, 4)
+
+                // make sure we only take W53 or W52 whichever is available
+                if (!seenYears.includes(year)) {
+                    const periodDate = new Date(
+                        weekPeriodsRes.metaData.items[period].endDate
+                    )
+                    periodDate.setDate(periodDate.getDate() + 1)
+
+                    periodDates.push(
+                        `${periodDate.getFullYear()}-${(
+                            '' +
+                            (periodDate.getMonth() + 1)
+                        ).padStart(2, 0)}-${(
+                            '' + periodDate.getDate()
+                        ).padStart(2, 0)}`
+                    )
+
+                    seenYears.unshift(year)
+                }
+            })
+    }
+
+    return { yearlySeriesLabels, periodDates }
 }

--- a/packages/plugin/src/modules/analytics.js
+++ b/packages/plugin/src/modules/analytics.js
@@ -9,44 +9,28 @@ export const computeYoYMatrix = (responses, relativePeriodTypeUsed) => {
 
     if (relativePeriodTypeUsed === WEEKS) {
         periodGroups.sort((a, b) => b[0].split('W')[1] - a[0].split('W')[1])
-        console.log('periodGroups', periodGroups)
 
         const periodKeyAxisIndexMatrix = periodGroups
             .shift()
             .map(periodId => [periodId])
 
-        console.log('xAxis map start', periodKeyAxisIndexMatrix)
         periodGroups.forEach(periodGroup => {
-            console.log('processing', periodGroup)
-
             periodGroup.forEach(periodId => {
                 const [year, week] = periodId.split('W')
 
-                console.log('period', year, week)
-
                 // find week number in 1st "serie"
                 const xAxisIndexForPeriod = periodKeyAxisIndexMatrix.findIndex(
-                    periodKeys => {
-                        console.log(
-                            `lookup for same week (W${week}) in`,
-                            periodKeys
-                        )
-                        return periodKeys[0].split('W')[1] === week
-                    }
+                    periodKeys => periodKeys[0].split('W')[1] === week
                 )
 
                 if (xAxisIndexForPeriod !== -1) {
                     periodKeyAxisIndexMatrix[xAxisIndexForPeriod].push(periodId)
                 } else if (week === '1') {
                     const indexForW2 = periodKeyAxisIndexMatrix.findIndex(
-                        periodKeys => {
-                            console.log('lookup for W2 in ', periodKeys)
-                            return (
-                                periodKeys.findIndex(periodKey => {
-                                    return /W2$/.test(periodKey)
-                                }) !== -1
-                            )
-                        }
+                        periodKeys =>
+                            periodKeys.findIndex(periodKey =>
+                                /W2$/.test(periodKey)
+                            ) !== -1
                     )
 
                     if (indexForW2 !== -1) {
@@ -57,20 +41,10 @@ export const computeYoYMatrix = (responses, relativePeriodTypeUsed) => {
                 } else {
                     // find the right spot considering also the year
                     const indexForPrevWeekInYear = periodKeyAxisIndexMatrix.findIndex(
-                        periodKeys => {
-                            console.log(
-                                `lookup for prev week (W${
-                                    week - 1
-                                }) of year ${year} in`,
-                                periodKeys
-                            )
-                            return (
-                                periodKeys.findIndex(periodKey => {
-                                    console.log('pk', periodKey)
-                                    return periodKey === `${year}W${week - 1}`
-                                }) !== -1
-                            )
-                        }
+                        periodKeys =>
+                            periodKeys.findIndex(
+                                periodKey => periodKey === `${year}W${week - 1}`
+                            ) !== -1
                     )
 
                     periodKeyAxisIndexMatrix.splice(
@@ -82,15 +56,9 @@ export const computeYoYMatrix = (responses, relativePeriodTypeUsed) => {
             })
         })
 
-        console.log('periodKeyAxisIndexMatrix', periodKeyAxisIndexMatrix)
         return periodKeyAxisIndexMatrix
         // TODO daily case (Feb 29th)
     } else {
-        console.log('non week-day relative periods')
-        console.log(
-            'assuming all period groups having the same amount of values'
-        )
-
         const periodKeyAxisIndexMatrix = periodGroups.reduce(
             (list, periodGroup) => {
                 periodGroup.forEach((periodId, index) => {
@@ -102,7 +70,6 @@ export const computeYoYMatrix = (responses, relativePeriodTypeUsed) => {
             Array.from({ length: periodGroups[0].length }, () => [])
         )
 
-        console.log('periodKeyAxisIndexMatrix', periodKeyAxisIndexMatrix)
         return periodKeyAxisIndexMatrix
     }
 }

--- a/packages/plugin/src/modules/analytics.js
+++ b/packages/plugin/src/modules/analytics.js
@@ -19,7 +19,7 @@ export const computeYoYMatrix = (responses, relativePeriodTypeUsed) => {
         periodGroups.forEach(periodGroup => {
             console.log('processing', periodGroup)
 
-            periodGroup.forEach((periodId, index) => {
+            periodGroup.forEach(periodId => {
                 const [year, week] = periodId.split('W')
 
                 console.log('period', year, week)
@@ -50,7 +50,7 @@ export const computeYoYMatrix = (responses, relativePeriodTypeUsed) => {
                     )
 
                     if (indexForW2 !== -1) {
-                        periodKeyAxisMatrix[indexForW2].push(periodId)
+                        periodKeyAxisIndexMatrix[indexForW2].push(periodId)
                     } else {
                         periodKeyAxisIndexMatrix.push([periodId])
                     }

--- a/packages/plugin/src/modules/analytics.js
+++ b/packages/plugin/src/modules/analytics.js
@@ -1,15 +1,13 @@
-export const computeYoYMatrix = (
-    responses,
-    usesRelativeWeeksPeriod,
-    usesRelativeDaysPeriod
-) => {
+import { getRelativePeriodsOptionsById, WEEKS, DAYS } from '@dhis2/analytics'
+
+export const computeYoYMatrix = (responses, relativePeriodTypeUsed) => {
     const periodGroups = responses.reduce((list, res) => {
         list.push(res.metaData.dimensions.pe)
 
         return list
     }, [])
 
-    if (usesRelativeWeeksPeriod) {
+    if (relativePeriodTypeUsed === WEEKS) {
         periodGroups.sort((a, b) => b[0].split('W')[1] - a[0].split('W')[1])
         console.log('periodGroups', periodGroups)
 
@@ -111,23 +109,23 @@ export const computeYoYMatrix = (
 
 export const computeGenericPeriodNamesFromMatrix = (
     periodKeyAxisIndexMatrix,
-    usesRelativeWeeksPeriod,
-    usesRelativeDaysPeriod
+    relativePeriodTypeUsed
 ) => {
-    if (usesRelativeWeeksPeriod) {
-        return (
-            periodKeyAxisIndexMatrix
-                // remove year, return "Wnn"
-                .map(periodKeys => periodKeys[0].substr(4))
-                .flat()
-        )
-    } else if (usesRelativeDaysPeriod) {
-        return periodKeyAxisIndexMatrix
-            .map(periodKeys =>
-                // remove year, return "dd-mm"
-                periodKeys[0].substr(4).replace(/(\d{2})(\d{2})/, '$2-$1')
+    switch (relativePeriodTypeUsed) {
+        case WEEKS:
+            return (
+                periodKeyAxisIndexMatrix
+                    // remove year, return "Wnn"
+                    .map(periodKeys => periodKeys[0].substr(4))
+                    .flat()
             )
-            .flat()
+        case DAYS:
+            return periodKeyAxisIndexMatrix
+                .map(periodKeys =>
+                    // remove year, return "dd-mm"
+                    periodKeys[0].substr(4).replace(/(\d{2})(\d{2})/, '$2-$1')
+                )
+                .flat()
     }
 }
 
@@ -159,4 +157,20 @@ export const computeGenericPeriodNames = responses => {
 
         return genericPeriodNames
     }, [])
+}
+
+export const getRelativePeriodTypeUsed = peItems => {
+    if (
+        getRelativePeriodsOptionsById(WEEKS)
+            .getPeriods()
+            .find(p => p.id === peItems[0].id)
+    ) {
+        return WEEKS
+    } else if (
+        getRelativePeriodsOptionsById(DAYS)
+            .getPeriods()
+            .find(p => p.id === peItems[0].id)
+    ) {
+        return DAYS
+    }
 }

--- a/packages/plugin/src/modules/analytics.js
+++ b/packages/plugin/src/modules/analytics.js
@@ -126,17 +126,17 @@ export const computeGenericPeriodNames = responses => {
     }, [])
 }
 
-export const getRelativePeriodTypeUsed = peItems => {
+export const getRelativePeriodTypeUsed = periodItems => {
     if (
         getRelativePeriodsOptionsById(WEEKS)
             .getPeriods()
-            .find(p => p.id === peItems[0].id)
+            .find(period => period.id === periodItems[0].id)
     ) {
         return WEEKS
     } else if (
         getRelativePeriodsOptionsById(DAYS)
             .getPeriods()
-            .find(p => p.id === peItems[0].id)
+            .find(period => period.id === periodItems[0].id)
     ) {
         return DAYS
     }

--- a/packages/plugin/src/modules/analytics.js
+++ b/packages/plugin/src/modules/analytics.js
@@ -1,3 +1,136 @@
+export const computeYoYMatrix = (
+    responses,
+    usesRelativeWeeksPeriod,
+    usesRelativeDaysPeriod
+) => {
+    const periodGroups = responses.reduce((list, res) => {
+        list.push(res.metaData.dimensions.pe)
+
+        return list
+    }, [])
+
+    if (usesRelativeWeeksPeriod) {
+        periodGroups.sort((a, b) => b[0].split('W')[1] - a[0].split('W')[1])
+        console.log('periodGroups', periodGroups)
+
+        const periodKeyAxisIndexMatrix = periodGroups
+            .shift()
+            .map(periodId => [periodId])
+
+        console.log('xAxis map start', periodKeyAxisIndexMatrix)
+        periodGroups.forEach(periodGroup => {
+            console.log('processing', periodGroup)
+
+            periodGroup.forEach((periodId, index) => {
+                const [year, week] = periodId.split('W')
+
+                console.log('period', year, week)
+
+                // find week number in 1st "serie"
+                const xAxisIndexForPeriod = periodKeyAxisIndexMatrix.findIndex(
+                    periodKeys => {
+                        console.log(
+                            `lookup for same week (W${week}) in`,
+                            periodKeys
+                        )
+                        return periodKeys[0].split('W')[1] === week
+                    }
+                )
+
+                if (xAxisIndexForPeriod !== -1) {
+                    periodKeyAxisIndexMatrix[xAxisIndexForPeriod].push(periodId)
+                } else if (week === '1') {
+                    const indexForW2 = periodKeyAxisIndexMatrix.findIndex(
+                        periodKeys => {
+                            console.log('lookup for W2 in ', periodKeys)
+                            return (
+                                periodKeys.findIndex(periodKey => {
+                                    return /W2$/.test(periodKey)
+                                }) !== -1
+                            )
+                        }
+                    )
+
+                    if (indexForW2 !== -1) {
+                        periodKeyAxisMatrix[indexForW2].push(periodId)
+                    } else {
+                        periodKeyAxisIndexMatrix.push([periodId])
+                    }
+                } else {
+                    // find the right spot considering also the year
+                    const indexForPrevWeekInYear = periodKeyAxisIndexMatrix.findIndex(
+                        periodKeys => {
+                            console.log(
+                                `lookup for prev week (W${
+                                    week - 1
+                                }) of year ${year} in`,
+                                periodKeys
+                            )
+                            return (
+                                periodKeys.findIndex(periodKey => {
+                                    console.log('pk', periodKey)
+                                    return periodKey === `${year}W${week - 1}`
+                                }) !== -1
+                            )
+                        }
+                    )
+
+                    periodKeyAxisIndexMatrix.splice(
+                        indexForPrevWeekInYear + 1,
+                        0,
+                        [periodId]
+                    )
+                }
+            })
+        })
+
+        console.log('periodKeyAxisIndexMatrix', periodKeyAxisIndexMatrix)
+        return periodKeyAxisIndexMatrix
+        // TODO daily case (Feb 29th)
+    } else {
+        console.log('non week-day relative periods')
+        console.log(
+            'assuming all period groups having the same amount of values'
+        )
+
+        const periodKeyAxisIndexMatrix = periodGroups.reduce(
+            (list, periodGroup) => {
+                periodGroup.forEach((periodId, index) => {
+                    list[index].push(periodId)
+                })
+
+                return list
+            },
+            Array.from({ length: periodGroups[0].length }, () => [])
+        )
+
+        console.log('periodKeyAxisIndexMatrix', periodKeyAxisIndexMatrix)
+        return periodKeyAxisIndexMatrix
+    }
+}
+
+export const computeGenericPeriodNamesFromMatrix = (
+    periodKeyAxisIndexMatrix,
+    usesRelativeWeeksPeriod,
+    usesRelativeDaysPeriod
+) => {
+    if (usesRelativeWeeksPeriod) {
+        return (
+            periodKeyAxisIndexMatrix
+                // remove year, return "Wnn"
+                .map(periodKeys => periodKeys[0].substr(4))
+                .flat()
+        )
+    } else if (usesRelativeDaysPeriod) {
+        return periodKeyAxisIndexMatrix
+            .map(periodKeys =>
+                // remove year, return "dd-mm"
+                periodKeys[0].substr(4).replace(/(\d{2})(\d{2})/, '$2-$1')
+            )
+            .flat()
+    }
+}
+
 export const computeGenericPeriodNames = responses => {
     const xAxisRes = responses.reduce((out, res) => {
         if (out.metaData) {

--- a/packages/plugin/src/modules/fetchData.js
+++ b/packages/plugin/src/modules/fetchData.js
@@ -1,9 +1,20 @@
-import { isYearOverYear } from '@dhis2/analytics'
+import {
+    isYearOverYear,
+    getRelativePeriodsOptionsById,
+    WEEKS,
+    DAYS,
+    DIMENSION_ID_PERIOD,
+    layoutGetDimensionItems,
+} from '@dhis2/analytics'
 import {
     apiFetchAnalyticsForYearOverYear,
     apiFetchAnalytics,
 } from '../api/analytics'
-import { computeGenericPeriodNames } from './analytics'
+import {
+    computeGenericPeriodNames,
+    computeYoYMatrix,
+    computeGenericPeriodNamesFromMatrix,
+} from './analytics'
 import { getRequestOptions } from './getRequestOptions'
 
 export const fetchData = async ({
@@ -28,12 +39,48 @@ export const fetchData = async ({
             options
         )
 
+        const peItems = layoutGetDimensionItems(
+            visualization,
+            DIMENSION_ID_PERIOD
+        )
+        const usesRelativeWeeksPeriod = getRelativePeriodsOptionsById(WEEKS)
+            .getPeriods()
+            .find(p => p.id === peItems[0].id)
+        const usesRelativeDaysPeriod = getRelativePeriodsOptionsById(DAYS)
+            .getPeriods()
+            .find(p => p.id === peItems[0].id)
+
+        const periodKeyAxisIndexMatrix = computeYoYMatrix(
+            responses,
+            usesRelativeWeeksPeriod,
+            usesRelativeDaysPeriod
+        )
+        const periodKeyAxisIndexMap = periodKeyAxisIndexMatrix.reduce(
+            (map, periodKeys, index) => {
+                periodKeys.forEach(periodKey => (map[periodKey] = index))
+
+                return map
+            },
+            {}
+        )
+        console.log('periodKeyAxisIndexMap', periodKeyAxisIndexMap)
+
+        const xAxisLabels =
+            usesRelativeWeeksPeriod || usesRelativeDaysPeriod
+                ? computeGenericPeriodNamesFromMatrix(
+                      periodKeyAxisIndexMatrix,
+                      usesRelativeWeeksPeriod,
+                      usesRelativeDaysPeriod
+                  )
+                : computeGenericPeriodNames(responses)
+
         return {
             responses,
             extraOptions: {
                 ...extraOptions,
                 yearlySeries: yearlySeriesLabels,
-                xAxisLabels: computeGenericPeriodNames(responses),
+                xAxisLabels,
+                periodKeyAxisIndexMap,
             },
         }
     }

--- a/packages/plugin/src/modules/fetchData.js
+++ b/packages/plugin/src/modules/fetchData.js
@@ -1,8 +1,5 @@
 import {
     isYearOverYear,
-    getRelativePeriodsOptionsById,
-    WEEKS,
-    DAYS,
     DIMENSION_ID_PERIOD,
     layoutGetDimensionItems,
 } from '@dhis2/analytics'
@@ -14,6 +11,7 @@ import {
     computeGenericPeriodNames,
     computeYoYMatrix,
     computeGenericPeriodNamesFromMatrix,
+    getRelativePeriodTypeUsed,
 } from './analytics'
 import { getRequestOptions } from './getRequestOptions'
 
@@ -43,17 +41,12 @@ export const fetchData = async ({
             visualization,
             DIMENSION_ID_PERIOD
         )
-        const usesRelativeWeeksPeriod = getRelativePeriodsOptionsById(WEEKS)
-            .getPeriods()
-            .find(p => p.id === peItems[0].id)
-        const usesRelativeDaysPeriod = getRelativePeriodsOptionsById(DAYS)
-            .getPeriods()
-            .find(p => p.id === peItems[0].id)
+
+        const relativePeriodTypeUsed = getRelativePeriodTypeUsed(peItems)
 
         const periodKeyAxisIndexMatrix = computeYoYMatrix(
             responses,
-            usesRelativeWeeksPeriod,
-            usesRelativeDaysPeriod
+            relativePeriodTypeUsed
         )
         const periodKeyAxisIndexMap = periodKeyAxisIndexMatrix.reduce(
             (map, periodKeys, index) => {
@@ -65,14 +58,12 @@ export const fetchData = async ({
         )
         console.log('periodKeyAxisIndexMap', periodKeyAxisIndexMap)
 
-        const xAxisLabels =
-            usesRelativeWeeksPeriod || usesRelativeDaysPeriod
-                ? computeGenericPeriodNamesFromMatrix(
-                      periodKeyAxisIndexMatrix,
-                      usesRelativeWeeksPeriod,
-                      usesRelativeDaysPeriod
-                  )
-                : computeGenericPeriodNames(responses)
+        const xAxisLabels = relativePeriodTypeUsed
+            ? computeGenericPeriodNamesFromMatrix(
+                  periodKeyAxisIndexMatrix,
+                  relativePeriodTypeUsed
+              )
+            : computeGenericPeriodNames(responses)
 
         return {
             responses,

--- a/packages/plugin/src/modules/fetchData.js
+++ b/packages/plugin/src/modules/fetchData.js
@@ -56,7 +56,6 @@ export const fetchData = async ({
             },
             {}
         )
-        console.log('periodKeyAxisIndexMap', periodKeyAxisIndexMap)
 
         const xAxisLabels = relativePeriodTypeUsed
             ? computeGenericPeriodNamesFromMatrix(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1811,12 +1811,30 @@
   dependencies:
     prop-types "^15"
 
+"@dhis2/ui-constants@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-5.7.8.tgz#3356de03c5e9ddc0b5fac5087df8ccd97f0dc3c0"
+  integrity sha512-Ca9PvKP8s0jcWtqLl5tyAyhoy0F6rAohAiLvoJvRmx1M7lXzxwpHjLZnaQ4b1js3tn7BPB7HRdvv+SREqYY+PA==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+
 "@dhis2/ui-constants@6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-6.1.3.tgz#04f10f0e5439cea8d4db750d457ce0ed8d79f563"
   integrity sha512-7EzkkUiG62WKlrxGFi5DbQsF82JSFdGPXfnGCNv+P9Tw1c5cho2BBhIuYpkF5nkokMLmwwOvkp5u/P2KM44lNQ==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
+
+"@dhis2/ui-core@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-5.7.8.tgz#063f8a10e583803d8b85d168ddbfb52e1f72750b"
+  integrity sha512-ijmXT8QlBS6RjHsbPOsBzaAb9j5DOvQeoLkhFo5eQZswavug2gW+S/Vh2tgxfNP8gybZ0tHKaJXeXN3bkg7Xnw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@popperjs/core" "^2.5.3"
+    classnames "^2.2.6"
+    react-popper "^2.2.3"
+    resize-observer-polyfill "^1.5.1"
 
 "@dhis2/ui-core@6.1.3":
   version "6.1.3"
@@ -1829,6 +1847,16 @@
     react-popper "^2.2.3"
     resize-observer-polyfill "^1.5.1"
 
+"@dhis2/ui-forms@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-5.7.8.tgz#7b4489b796e2a79bebd1a24b8c1df59103e566c0"
+  integrity sha512-8c7IKJAqGL+IIZ7sjUbTrlwGHFpwX6KfF8eToDxXkkNONyyRIiFo7uVI43+rHii7+WmFwEhacWWjeYhfVBICfg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    classnames "^2.2.6"
+    final-form "^4.20.1"
+    react-final-form "^6.5.1"
+
 "@dhis2/ui-forms@6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-6.1.3.tgz#02e843e51b6d27fb1ec351b42d91fa510f15b481"
@@ -1839,12 +1867,27 @@
     final-form "^4.20.1"
     react-final-form "^6.5.1"
 
+"@dhis2/ui-icons@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-5.7.8.tgz#cb18c1bfbbcf49b2dae4c2b3ff7a3aeff46aa7f2"
+  integrity sha512-3P/Ptsf6HEdi0q8q6ba4Hcr8yuK+Y29PJn1Z56IZNZ+sZmFYiU7vxk5aMwA+s1EnjcPWQjrdwLzqqBAJE2W3Qg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+
 "@dhis2/ui-icons@6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-6.1.3.tgz#c813fe5adfa8306943431f5ed7c60def06c25d54"
   integrity sha512-0whrQPCaEVB5V1GVNl3GO0m3oE1RAIuTHxF38ZVwcOy20NX2+wcwvPUUxAcm4RvIkhfc/eACEmCYTajLt/BpjA==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
+
+"@dhis2/ui-widgets@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-5.7.8.tgz#77318381dd92848f9ab2cbc5414a2b57599309fe"
+  integrity sha512-QVLOdB836uUXBRw4OT6x/z1WR7j2ykxpMyat4g9sOXngj6t9+2UXZUO7Zegudj/HsZjTMDiN9A285zwxsd+khQ==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    classnames "^2.2.6"
 
 "@dhis2/ui-widgets@6.1.3":
   version "6.1.3"
@@ -1854,7 +1897,18 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.7.2", "@dhis2/ui@^6.1.3":
+"@dhis2/ui@^5.7.2":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.7.8.tgz#17604580d02cd4a7756552154a089e730a0fdf02"
+  integrity sha512-FHyTP6geAkR/jwX1/xG8yl8PvGaNhms8zUmaNiBLQ0mUmD9oJb47U8YXhJ5nVd0SFJnmuckOWgAWMt3meZGJTA==
+  dependencies:
+    "@dhis2/ui-constants" "5.7.8"
+    "@dhis2/ui-core" "5.7.8"
+    "@dhis2/ui-forms" "5.7.8"
+    "@dhis2/ui-icons" "5.7.8"
+    "@dhis2/ui-widgets" "5.7.8"
+
+"@dhis2/ui@^6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.1.3.tgz#b5b319dfae64d1b136d0d226bda42b5322b6e5f2"
   integrity sha512-aibDs4p2RaIPOQcAAYMej19rGmayQPBLeG0PaFfikSPHYFszG5BN+83uQEk7I7S9bv1cP/sI9YYghlw0V15L/g==
@@ -2435,7 +2489,7 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.6.0":
+"@popperjs/core@^2.5.3", "@popperjs/core@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.6.0.tgz#f022195afdfc942e088ee2101285a1d31c7d727f"
   integrity sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1811,30 +1811,12 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-constants@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-5.7.8.tgz#3356de03c5e9ddc0b5fac5087df8ccd97f0dc3c0"
-  integrity sha512-Ca9PvKP8s0jcWtqLl5tyAyhoy0F6rAohAiLvoJvRmx1M7lXzxwpHjLZnaQ4b1js3tn7BPB7HRdvv+SREqYY+PA==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-
 "@dhis2/ui-constants@6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-6.1.3.tgz#04f10f0e5439cea8d4db750d457ce0ed8d79f563"
   integrity sha512-7EzkkUiG62WKlrxGFi5DbQsF82JSFdGPXfnGCNv+P9Tw1c5cho2BBhIuYpkF5nkokMLmwwOvkp5u/P2KM44lNQ==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
-
-"@dhis2/ui-core@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-5.7.8.tgz#063f8a10e583803d8b85d168ddbfb52e1f72750b"
-  integrity sha512-ijmXT8QlBS6RjHsbPOsBzaAb9j5DOvQeoLkhFo5eQZswavug2gW+S/Vh2tgxfNP8gybZ0tHKaJXeXN3bkg7Xnw==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-    "@popperjs/core" "^2.5.3"
-    classnames "^2.2.6"
-    react-popper "^2.2.3"
-    resize-observer-polyfill "^1.5.1"
 
 "@dhis2/ui-core@6.1.3":
   version "6.1.3"
@@ -1847,16 +1829,6 @@
     react-popper "^2.2.3"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/ui-forms@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-5.7.8.tgz#7b4489b796e2a79bebd1a24b8c1df59103e566c0"
-  integrity sha512-8c7IKJAqGL+IIZ7sjUbTrlwGHFpwX6KfF8eToDxXkkNONyyRIiFo7uVI43+rHii7+WmFwEhacWWjeYhfVBICfg==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-    classnames "^2.2.6"
-    final-form "^4.20.1"
-    react-final-form "^6.5.1"
-
 "@dhis2/ui-forms@6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-6.1.3.tgz#02e843e51b6d27fb1ec351b42d91fa510f15b481"
@@ -1867,27 +1839,12 @@
     final-form "^4.20.1"
     react-final-form "^6.5.1"
 
-"@dhis2/ui-icons@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-5.7.8.tgz#cb18c1bfbbcf49b2dae4c2b3ff7a3aeff46aa7f2"
-  integrity sha512-3P/Ptsf6HEdi0q8q6ba4Hcr8yuK+Y29PJn1Z56IZNZ+sZmFYiU7vxk5aMwA+s1EnjcPWQjrdwLzqqBAJE2W3Qg==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-
 "@dhis2/ui-icons@6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-6.1.3.tgz#c813fe5adfa8306943431f5ed7c60def06c25d54"
   integrity sha512-0whrQPCaEVB5V1GVNl3GO0m3oE1RAIuTHxF38ZVwcOy20NX2+wcwvPUUxAcm4RvIkhfc/eACEmCYTajLt/BpjA==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
-
-"@dhis2/ui-widgets@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-5.7.8.tgz#77318381dd92848f9ab2cbc5414a2b57599309fe"
-  integrity sha512-QVLOdB836uUXBRw4OT6x/z1WR7j2ykxpMyat4g9sOXngj6t9+2UXZUO7Zegudj/HsZjTMDiN9A285zwxsd+khQ==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-    classnames "^2.2.6"
 
 "@dhis2/ui-widgets@6.1.3":
   version "6.1.3"
@@ -1897,18 +1854,7 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.7.2":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.7.8.tgz#17604580d02cd4a7756552154a089e730a0fdf02"
-  integrity sha512-FHyTP6geAkR/jwX1/xG8yl8PvGaNhms8zUmaNiBLQ0mUmD9oJb47U8YXhJ5nVd0SFJnmuckOWgAWMt3meZGJTA==
-  dependencies:
-    "@dhis2/ui-constants" "5.7.8"
-    "@dhis2/ui-core" "5.7.8"
-    "@dhis2/ui-forms" "5.7.8"
-    "@dhis2/ui-icons" "5.7.8"
-    "@dhis2/ui-widgets" "5.7.8"
-
-"@dhis2/ui@^6.1.3":
+"@dhis2/ui@^5.7.2", "@dhis2/ui@^6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.1.3.tgz#b5b319dfae64d1b136d0d226bda42b5322b6e5f2"
   integrity sha512-aibDs4p2RaIPOQcAAYMej19rGmayQPBLeG0PaFfikSPHYFszG5BN+83uQEk7I7S9bv1cP/sI9YYghlw0V15L/g==
@@ -2489,7 +2435,7 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.5.3", "@popperjs/core@^2.6.0":
+"@popperjs/core@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.6.0.tgz#f022195afdfc942e088ee2101285a1d31c7d727f"
   integrity sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==


### PR DESCRIPTION
Fixes [DHIS2-9729](https://jira.dhis2.org/browse/DHIS2-9279)

**Requires https://github.com/dhis2/analytics/pull/758**

---

### Description

Reworked the way data series for YOY charts which uses relative week periods are generated.
To avoid the problems described in the JIRA ticket, where data points are not correctly aligned when comparing week ranges of different years, the logic is now based on a matrix of xAxis index and period ids, which is generated from the analytics responses in the DV plugin.
From the matrix a map object is computed, and used to get the correct xAxis position where to plot a value based on the period id.
This solves both the problem of week 53 that some years have, and the problem of different week ranges for different years when using a relativePeriodDate.

Requesting the last 4 weeks from today this is what happens:

1. a metaData request is fired against the analytics api for the most recent year in the series (2021) passing *today* as relativePeriodDate
2. from the response, the last period is considered: W1
3. for all the other years in the series (2019 and 2020) a metaData request is made for getting information about W1 of each of those years
4. in the responses, the endDate of the week + 1 day is used as relativePeriodDate for each year (needed in the next step)
5. for each year in series, analytics data + metaData requests are made using the correct relativePeriodDate
6. the responses are used to build the matrix and the map, adding the "extra" week(s) where necessary and adding a null value for the years which don't have those weeks

---

### TODO

-   a similar issue happens when using relative day period and Feb 29 falls within the dates range

---

### Screenshots

This example is explained as follows:
- last 4 weeks for 2019 are: 2019W1, 2018W52, 2018W51, 2018W50 *no data for these*
- last 4 weeks for 2021 are: 2021W1 (no analytics data for 2021 yet), 2020W53, 2020W52, 2020W51
- last 4 weeks for 2020 are: 2020W1, 2019W52, 2019W51, 2019W50

The X axis gets then 5 labels, from W50 to W1 including W53
The line for 2020 has a gap corresponding to W53
The line for 2021 starts 1 week "later" compared to 2020, and has a value for week 53

![Screenshot 2021-01-13 at 11 55 54](https://user-images.githubusercontent.com/150978/104443192-61406e80-5596-11eb-9915-ed273ba0b6bf.png)

