### PR TITLE
fix: add missing name for legend sets

### DIFF
--- a/packages/plugin/src/api/legendSets.js
+++ b/packages/plugin/src/api/legendSets.js
@@ -2,7 +2,7 @@ const legendSetsQuery = {
     resource: 'legendSets',
     params: ({ ids }) => ({
         fields:
-            'id,legends[id,displayName~rename(name),startValue,endValue,color]',
+            'id,displayName~rename(name),legends[id,displayName~rename(name),startValue,endValue,color]',
         filter: `id:in:[${ids.join(',')}]`,
     }),
 }


### PR DESCRIPTION
[No JIRA] - extends https://github.com/dhis2/data-visualizer-app/pull/1369

### Key features

1. Add missing name for legend sets

---

### Description

https://github.com/dhis2/data-visualizer-app/pull/1369 introduced a change to the fetching of legend sets from the API which removed the name for the legend sets themselves. This PR adds back the missing name.

---

### Screenshots

_before this fix, legend set name missing_
![image](https://user-images.githubusercontent.com/12590483/104455287-5d691800-55a7-11eb-8a2d-4e1d63d0c48c.png)

_with this fix, legend set name working again_
![image](https://user-images.githubusercontent.com/12590483/104455298-60fc9f00-55a7-11eb-91a1-d77a4f686b54.png)

