### PR TITLE
test: reenable delete tests and change period test data

### DIFF
--- a/cypress/elements/common.js
+++ b/cypress/elements/common.js
@@ -21,7 +21,9 @@ export const replacePeriodItems = (
         clickMenuBarUpdateButton()
     } else {
         const TEST_PERIOD_TYPE = !useAltData ? 'Six-months' : 'Quarters'
-        const TEST_PERIOD = !useAltData ? 'Last six-month' : 'Last quarter'
+        const TEST_PERIOD = !useAltData
+            ? 'Last 2 six-month'
+            : 'Quarters this year'
         openDimension(DIMENSION_ID_PERIOD)
         removeAllPeriodItems()
         selectRelativePeriods([TEST_PERIOD], TEST_PERIOD_TYPE)

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -136,8 +136,7 @@ describe('saving an AO', () => {
             expectAOTitleToBeValue(TEST_VIS_NAME)
             expectVisualizationToBeVisible(TEST_VIS_TYPE)
         })
-        it.skip('deletes AO', () => {
-            // FIXME: Unskip once https://jira.dhis2.org/browse/DHIS2-10140 is done
+        it('deletes AO', () => {
             deleteAO()
             expectRouteToBeEmpty()
             expectStartScreenToBeVisible()

--- a/cypress/integration/visTypes/scatter.cy.js
+++ b/cypress/integration/visTypes/scatter.cy.js
@@ -118,8 +118,7 @@ describe('using a Scatter chart', () => {
         expectVerticalToContainDimensionLabel(TEST_INDICATOR_NAMES[0])
         expectHorizontalToContainDimensionLabel(TEST_INDICATOR_NAMES[1])
     })
-    it.skip('deletes saved scatter AO', () => {
-        // FIXME: Unskip once https://jira.dhis2.org/browse/DHIS2-10140 is done
+    it('deletes saved scatter AO', () => {
         deleteAO()
         expectRouteToBeEmpty()
         expectStartScreenToBeVisible()


### PR DESCRIPTION
### Key features

1. Reenable delete tests
2. Change period test data

---

### Description

1. The delete tests were skipped because of the backend bug [DHIS2-10140](https://jira.dhis2.org/browse/DHIS2-10140), which has now been fixed. The tests have thus been reenabled again.
2. Some tests were failing because they were expecting a visualization to be shown when instead the "No data" warning message was displayed on screen. The period test data was using quarterly data, but as its now Q1 2021, which happens to not have any test data in the DB, it's safer to use `Quarters this year` which is more likely to have test data and not end up showing the warning.
