### PR TITLE
test: save and confirm leave flakey

### DIFF
--- a/cypress/integration/confirmLeave.cy.js
+++ b/cypress/integration/confirmLeave.cy.js
@@ -3,7 +3,6 @@ import {
     expectAOTitleToNotBeDirty,
     expectVisualizationToBeVisible,
     expectVisualizationToNotBeVisible,
-    expectChartTitleToBeVisible,
 } from '../elements/chart'
 import { replacePeriodItems } from '../elements/common'
 import {
@@ -24,7 +23,7 @@ describe('confirm leave modal', () => {
     it('navigates to the start page and loads a random saved AO', () => {
         goToStartPage()
         openAOByName(TEST_AO.name)
-        expectChartTitleToBeVisible()
+        expectVisualizationToBeVisible(TEST_AO.type)
         expectAOTitleToNotBeDirty()
     })
     it(`replaces the selected period`, () => {
@@ -38,7 +37,7 @@ describe('confirm leave modal', () => {
     })
     it('cancel leave', () => {
         confirmLeave(false)
-        expectChartTitleToBeVisible()
+        expectVisualizationToBeVisible(TEST_AO.type)
         expectAOTitleToBeDirty()
     })
     it('tries to open a new AO', () => {

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -125,6 +125,7 @@ describe('saving an AO', () => {
         it('navigates to the start page and opens a saved AO', () => {
             goToStartPage()
             openAOByName(TEST_VIS_NAME_UPDATED)
+            expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
         })
         it(`replaces the selected period`, () => {
             replacePeriodItems(TEST_VIS_TYPE, { useAltData: true })


### PR DESCRIPTION
### Key features

1. `confirmLeave` should check visualization instead of chart title
2. `start` should wait for AO to be loaded when opening


### Description

1. `confirmLeave` was checking the chart title (highcharts), but as its opening a random visualization, which could be a non-highcharts type (SV and PT), it was failing some times when it couldn't find the highcharts title. It now checks the visualization in general instead (which takes this in to account already).
2. `start` was opening an AO but didn't wait for it to load, causing it to sometimes be flakey depending on the output of the race condition.
