### PR TITLE
fix: use the download links for dataValueSet via analytics DHIS2-9789

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^13.0.0",
+        "@dhis2/analytics": "^13.0.5",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-file-menu": "^7.1.0",

--- a/packages/app/src/components/DownloadMenu/DownloadMenu.js
+++ b/packages/app/src/components/DownloadMenu/DownloadMenu.js
@@ -7,6 +7,7 @@ import ImageIcon from '@material-ui/icons/Image'
 import PictureAsPdfIcon from '@material-ui/icons/PictureAsPdf'
 import ListIcon from '@material-ui/icons/List'
 import ListAltIcon from '@material-ui/icons/ListAlt'
+import { useConfig, useDataEngine } from '@dhis2/app-runtime'
 import {
     FlyoutMenu,
     MenuSectionHeader,
@@ -54,6 +55,8 @@ export const DownloadMenu = ({
     relativePeriodDate,
     visType,
 }) => {
+    const dataEngine = useDataEngine()
+    const { baseUrl } = useConfig()
     const [dialogIsOpen, setDialogIsOpen] = useState(false)
 
     const toggleMenu = () => setDialogIsOpen(!dialogIsOpen)
@@ -67,7 +70,11 @@ export const DownloadMenu = ({
             formData.append('svg', chart)
         }
 
-        const blob = await apiDownloadImage(format, formData)
+        const blob = await apiDownloadImage({
+            baseUrl,
+            type: format,
+            formData,
+        })
         const url = URL.createObjectURL(blob)
 
         toggleMenu()
@@ -77,7 +84,9 @@ export const DownloadMenu = ({
 
     const downloadData = (format, idScheme, path) => async () => {
         const url = await apiDownloadData({
-            current,
+            baseUrl,
+            dataEngine,
+            visualization: current,
             format,
             options: { relativePeriodDate },
             idScheme,
@@ -91,7 +100,9 @@ export const DownloadMenu = ({
 
     const downloadTable = format => async () => {
         const url = await apiDownloadTable({
-            current,
+            baseUrl,
+            dataEngine,
+            visualization: current,
             format,
             options: { relativePeriodDate },
             rows,

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^13.0.0",
+        "@dhis2/analytics": "^13.0.5",
         "@dhis2/ui": "^6.1.3",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,10 +1499,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-13.0.0.tgz#8c7243908f9b8eb7b9bc5f238985662d30284d6c"
-  integrity sha512-rIJNTL1AJazFfRaXxO5RKW/DAePCdppSSyhPpPUqqjtj8SovY7DMxGQFINWdGc1IbGwViwQ2I7IEPVR17XOkCA==
+"@dhis2/analytics@^13.0.5":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-13.0.5.tgz#ac8fc0b50566ddaf3b0032f669db851b05eff2aa"
+  integrity sha512-3ziSWs9wFFhjbhLKGGny4VsvP7Wxh45PuqGghV4loMUBcvY6mRamebVrWzlzEvNitUp/RF/P2t+UB5EIgamgjw==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.1.3"
     "@dhis2/ui" "^6.1.3"
@@ -1844,12 +1844,30 @@
   dependencies:
     prop-types "^15"
 
+"@dhis2/ui-constants@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-5.7.8.tgz#3356de03c5e9ddc0b5fac5087df8ccd97f0dc3c0"
+  integrity sha512-Ca9PvKP8s0jcWtqLl5tyAyhoy0F6rAohAiLvoJvRmx1M7lXzxwpHjLZnaQ4b1js3tn7BPB7HRdvv+SREqYY+PA==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+
 "@dhis2/ui-constants@6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-6.1.3.tgz#04f10f0e5439cea8d4db750d457ce0ed8d79f563"
   integrity sha512-7EzkkUiG62WKlrxGFi5DbQsF82JSFdGPXfnGCNv+P9Tw1c5cho2BBhIuYpkF5nkokMLmwwOvkp5u/P2KM44lNQ==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
+
+"@dhis2/ui-core@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-5.7.8.tgz#063f8a10e583803d8b85d168ddbfb52e1f72750b"
+  integrity sha512-ijmXT8QlBS6RjHsbPOsBzaAb9j5DOvQeoLkhFo5eQZswavug2gW+S/Vh2tgxfNP8gybZ0tHKaJXeXN3bkg7Xnw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@popperjs/core" "^2.5.3"
+    classnames "^2.2.6"
+    react-popper "^2.2.3"
+    resize-observer-polyfill "^1.5.1"
 
 "@dhis2/ui-core@6.1.3":
   version "6.1.3"
@@ -1862,6 +1880,16 @@
     react-popper "^2.2.3"
     resize-observer-polyfill "^1.5.1"
 
+"@dhis2/ui-forms@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-5.7.8.tgz#7b4489b796e2a79bebd1a24b8c1df59103e566c0"
+  integrity sha512-8c7IKJAqGL+IIZ7sjUbTrlwGHFpwX6KfF8eToDxXkkNONyyRIiFo7uVI43+rHii7+WmFwEhacWWjeYhfVBICfg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    classnames "^2.2.6"
+    final-form "^4.20.1"
+    react-final-form "^6.5.1"
+
 "@dhis2/ui-forms@6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-6.1.3.tgz#02e843e51b6d27fb1ec351b42d91fa510f15b481"
@@ -1872,12 +1900,27 @@
     final-form "^4.20.1"
     react-final-form "^6.5.1"
 
+"@dhis2/ui-icons@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-5.7.8.tgz#cb18c1bfbbcf49b2dae4c2b3ff7a3aeff46aa7f2"
+  integrity sha512-3P/Ptsf6HEdi0q8q6ba4Hcr8yuK+Y29PJn1Z56IZNZ+sZmFYiU7vxk5aMwA+s1EnjcPWQjrdwLzqqBAJE2W3Qg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+
 "@dhis2/ui-icons@6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-6.1.3.tgz#c813fe5adfa8306943431f5ed7c60def06c25d54"
   integrity sha512-0whrQPCaEVB5V1GVNl3GO0m3oE1RAIuTHxF38ZVwcOy20NX2+wcwvPUUxAcm4RvIkhfc/eACEmCYTajLt/BpjA==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
+
+"@dhis2/ui-widgets@5.7.8":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-5.7.8.tgz#77318381dd92848f9ab2cbc5414a2b57599309fe"
+  integrity sha512-QVLOdB836uUXBRw4OT6x/z1WR7j2ykxpMyat4g9sOXngj6t9+2UXZUO7Zegudj/HsZjTMDiN9A285zwxsd+khQ==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    classnames "^2.2.6"
 
 "@dhis2/ui-widgets@6.1.3":
   version "6.1.3"
@@ -1887,7 +1930,18 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.7.2", "@dhis2/ui@^6.1.3":
+"@dhis2/ui@^5.7.2":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.7.8.tgz#17604580d02cd4a7756552154a089e730a0fdf02"
+  integrity sha512-FHyTP6geAkR/jwX1/xG8yl8PvGaNhms8zUmaNiBLQ0mUmD9oJb47U8YXhJ5nVd0SFJnmuckOWgAWMt3meZGJTA==
+  dependencies:
+    "@dhis2/ui-constants" "5.7.8"
+    "@dhis2/ui-core" "5.7.8"
+    "@dhis2/ui-forms" "5.7.8"
+    "@dhis2/ui-icons" "5.7.8"
+    "@dhis2/ui-widgets" "5.7.8"
+
+"@dhis2/ui@^6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.1.3.tgz#b5b319dfae64d1b136d0d226bda42b5322b6e5f2"
   integrity sha512-aibDs4p2RaIPOQcAAYMej19rGmayQPBLeG0PaFfikSPHYFszG5BN+83uQEk7I7S9bv1cP/sI9YYghlw0V15L/g==
@@ -2468,7 +2522,7 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.6.0":
+"@popperjs/core@^2.5.3", "@popperjs/core@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.6.0.tgz#f022195afdfc942e088ee2101285a1d31c7d727f"
   integrity sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==


### PR DESCRIPTION
See https://github.com/dhis2/analytics/pull/776.
Also, pass baseUrl from the useConfig hook instead of relying on d2.

The downloadImage still uses d2 as there isn't support for this type of
POST request yet, although there is an open PR
(https://github.com/dhis2/app-runtime/pull/753).

Fixes [DHIS2-9789](https://jira.dhis2.org/browse/DHIS2-9789)

**Requires https://github.com/dhis2/analytics/pull/776**
**Requires https://github.com/dhis2/analytics/pull/785**

---

### Key features

1. Fix download links for dataValueSet.

---

### Description

The actual fix is in the analytics library.

---

### Known issues

-   [ ] the download for image/pdf still uses `d2` because dataEngine does not support POST requests passing a custom Content-type header. Also, I'm not sure how to handle the response to get the blob used to build the download URL in the app.
