### PR TITLE
fix: download menu - double border, ui icons, esc for closing

### DIFF
--- a/packages/app/src/components/DownloadMenu/DownloadMenu.js
+++ b/packages/app/src/components/DownloadMenu/DownloadMenu.js
@@ -3,16 +3,16 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { createSelector } from 'reselect'
 import i18n from '@dhis2/d2-i18n'
-import ImageIcon from '@material-ui/icons/Image'
-import PictureAsPdfIcon from '@material-ui/icons/PictureAsPdf'
-import ListIcon from '@material-ui/icons/List'
-import ListAltIcon from '@material-ui/icons/ListAlt'
 import { useConfig, useDataEngine } from '@dhis2/app-runtime'
 import {
     FlyoutMenu,
+    Layer,
     MenuSectionHeader,
     MenuItem,
-    Popover,
+    Popper,
+    IconImage24,
+    IconFileDocument24,
+    IconMore24,
     colors,
 } from '@dhis2/ui'
 import { VIS_TYPE_PIVOT_TABLE } from '@dhis2/analytics'
@@ -30,14 +30,9 @@ import {
     apiDownloadTable,
 } from '../../api/analytics'
 import MenuButton from '../MenuButton/MenuButton'
-import MoreHorizontalIcon from '../../assets/MoreHorizontalIcon'
 
 const DenseMenuItem = ({ Icon, children, ...rest }) => (
-    <MenuItem
-        dense
-        icon={Icon && <Icon style={{ color: colors.grey600 }} />}
-        {...rest}
-    >
+    <MenuItem dense icon={Icon && <Icon color={colors.grey600} />} {...rest}>
         {children}
     </MenuItem>
 )
@@ -119,12 +114,12 @@ export const DownloadMenu = ({
         React.Children.toArray([
             <MenuSectionHeader label={i18n.t('Graphics')} />,
             <DenseMenuItem
-                Icon={ImageIcon}
+                Icon={IconImage24}
                 label={i18n.t('Image (.png)')}
                 onClick={downloadImage('png')}
             />,
             <DenseMenuItem
-                Icon={PictureAsPdfIcon}
+                Icon={IconFileDocument24}
                 label={i18n.t('PDF (.pdf)')}
                 onClick={downloadImage('pdf')}
             />,
@@ -134,17 +129,14 @@ export const DownloadMenu = ({
         React.Children.toArray([
             <MenuSectionHeader label={i18n.t('Table layout')} />,
             <DenseMenuItem
-                Icon={ListAltIcon}
                 label={i18n.t('Excel (.xls)')}
                 onClick={downloadTable('xls')}
             />,
             <DenseMenuItem
-                Icon={ListAltIcon}
                 label={i18n.t('CSV (.csv)')}
                 onClick={downloadTable('csv')}
             />,
             <DenseMenuItem
-                Icon={ListAltIcon}
                 label={i18n.t('HTML (.html)')}
                 onClick={downloadTable('html')}
             />,
@@ -178,68 +170,69 @@ export const DownloadMenu = ({
                 </MenuButton>
             </div>
             {dialogIsOpen && (
-                <Popover
-                    arrow={false}
-                    reference={buttonRef}
-                    placement="bottom-start"
-                    onClickOutside={toggleMenu}
-                >
-                    <FlyoutMenu>
-                        {visType === VIS_TYPE_PIVOT_TABLE
-                            ? tableMenuSection()
-                            : graphicsMenuSection()}
-                        <MenuSectionHeader
-                            label={i18n.t('Plain data source')}
-                        />
-                        <DenseMenuItem Icon={ListIcon} label={i18n.t('JSON')}>
-                            {plainDataSourceSubLevel('json')}
-                        </DenseMenuItem>
-                        <DenseMenuItem Icon={ListIcon} label={i18n.t('XML')}>
-                            {plainDataSourceSubLevel('xml')}
-                        </DenseMenuItem>
-                        <DenseMenuItem Icon={ListIcon} label={i18n.t('Excel')}>
-                            {plainDataSourceSubLevel('xls')}
-                        </DenseMenuItem>
-                        <DenseMenuItem Icon={ListIcon} label={i18n.t('CSV')}>
-                            {plainDataSourceSubLevel('csv')}
-                        </DenseMenuItem>
-                        <DenseMenuItem
-                            Icon={MoreHorizontalIcon}
-                            label={i18n.t('Advanced')}
-                        >
+                <Layer position="fixed" level={2000} onClick={toggleMenu}>
+                    <Popper reference={buttonRef} placement="bottom-start">
+                        <FlyoutMenu>
+                            {visType === VIS_TYPE_PIVOT_TABLE
+                                ? tableMenuSection()
+                                : graphicsMenuSection()}
                             <MenuSectionHeader
-                                label={i18n.t('Data value set')}
+                                label={i18n.t('Plain data source')}
                             />
+                            <DenseMenuItem label={i18n.t('JSON')}>
+                                {plainDataSourceSubLevel('json')}
+                            </DenseMenuItem>
+                            <DenseMenuItem label={i18n.t('XML')}>
+                                {plainDataSourceSubLevel('xml')}
+                            </DenseMenuItem>
+                            <DenseMenuItem label={i18n.t('Excel')}>
+                                {plainDataSourceSubLevel('xls')}
+                            </DenseMenuItem>
+                            <DenseMenuItem label={i18n.t('CSV')}>
+                                {plainDataSourceSubLevel('csv')}
+                            </DenseMenuItem>
                             <DenseMenuItem
-                                label={i18n.t('JSON')}
-                                onClick={downloadData(
-                                    'json',
-                                    null,
-                                    'dataValueSet'
-                                )}
-                            />
-                            <DenseMenuItem
-                                label={i18n.t('XML')}
-                                onClick={downloadData(
-                                    'xml',
-                                    null,
-                                    'dataValueSet'
-                                )}
-                            />
-                            <MenuSectionHeader
-                                label={i18n.t('Other formats')}
-                            />
-                            <DenseMenuItem
-                                label={i18n.t('JRXML')}
-                                onClick={downloadData('jrxml')}
-                            />
-                            <DenseMenuItem
-                                label={i18n.t('Raw data SQL')}
-                                onClick={downloadData('sql', null, 'debug/sql')}
-                            />
-                        </DenseMenuItem>
-                    </FlyoutMenu>
-                </Popover>
+                                Icon={IconMore24}
+                                label={i18n.t('Advanced')}
+                            >
+                                <MenuSectionHeader
+                                    label={i18n.t('Data value set')}
+                                />
+                                <DenseMenuItem
+                                    label={i18n.t('JSON')}
+                                    onClick={downloadData(
+                                        'json',
+                                        null,
+                                        'dataValueSet'
+                                    )}
+                                />
+                                <DenseMenuItem
+                                    label={i18n.t('XML')}
+                                    onClick={downloadData(
+                                        'xml',
+                                        null,
+                                        'dataValueSet'
+                                    )}
+                                />
+                                <MenuSectionHeader
+                                    label={i18n.t('Other formats')}
+                                />
+                                <DenseMenuItem
+                                    label={i18n.t('JRXML')}
+                                    onClick={downloadData('jrxml')}
+                                />
+                                <DenseMenuItem
+                                    label={i18n.t('Raw data SQL')}
+                                    onClick={downloadData(
+                                        'sql',
+                                        null,
+                                        'debug/sql'
+                                    )}
+                                />
+                            </DenseMenuItem>
+                        </FlyoutMenu>
+                    </Popper>
+                </Layer>
             )}
         </>
     )

--- a/packages/app/src/components/DownloadMenu/DownloadMenu.js
+++ b/packages/app/src/components/DownloadMenu/DownloadMenu.js
@@ -52,9 +52,15 @@ export const DownloadMenu = ({
 }) => {
     const dataEngine = useDataEngine()
     const { baseUrl } = useConfig()
-    const [dialogIsOpen, setDialogIsOpen] = useState(false)
+    const [menuIsOpen, setMenuIsOpen] = useState(false)
 
-    const toggleMenu = () => setDialogIsOpen(!dialogIsOpen)
+    const onKeyDown = e => {
+        if (e?.keyCode === 27) {
+            setMenuIsOpen(false)
+        }
+    }
+
+    const toggleMenu = () => setMenuIsOpen(!menuIsOpen)
 
     const downloadImage = format => async () => {
         const formData = new URLSearchParams()
@@ -163,13 +169,13 @@ export const DownloadMenu = ({
     const buttonRef = createRef()
 
     return (
-        <>
+        <div onKeyDown={onKeyDown}>
             <div ref={buttonRef}>
                 <MenuButton onClick={toggleMenu} disabled={!current}>
                     {i18n.t('Download')}
                 </MenuButton>
             </div>
-            {dialogIsOpen && (
+            {menuIsOpen && (
                 <Layer position="fixed" level={2000} onClick={toggleMenu}>
                     <Popper reference={buttonRef} placement="bottom-start">
                         <FlyoutMenu>
@@ -234,7 +240,7 @@ export const DownloadMenu = ({
                     </Popper>
                 </Layer>
             )}
-        </>
+        </div>
     )
 }
 

--- a/packages/app/src/components/DownloadMenu/DownloadMenu.js
+++ b/packages/app/src/components/DownloadMenu/DownloadMenu.js
@@ -12,7 +12,6 @@ import {
     Popper,
     IconImage24,
     IconFileDocument24,
-    IconMore24,
     colors,
 } from '@dhis2/ui'
 import { VIS_TYPE_PIVOT_TABLE } from '@dhis2/analytics'
@@ -197,10 +196,7 @@ export const DownloadMenu = ({
                             <DenseMenuItem label={i18n.t('CSV')}>
                                 {plainDataSourceSubLevel('csv')}
                             </DenseMenuItem>
-                            <DenseMenuItem
-                                Icon={IconMore24}
-                                label={i18n.t('Advanced')}
-                            >
+                            <DenseMenuItem label={i18n.t('Advanced')}>
                                 <MenuSectionHeader
                                     label={i18n.t('Data value set')}
                                 />

--- a/packages/app/src/components/MenuButton/styles/MenuButton.module.css
+++ b/packages/app/src/components/MenuButton/styles/MenuButton.module.css
@@ -1,5 +1,3 @@
-/* TODO: Fetch the colors from ui-core, once the same is done for the FileMenu (@dhis2/d2-ui-file-menu)  */
-
 .menuButton {
     display: inline-flex;
     position: relative;
@@ -9,7 +7,7 @@
     font-weight: 400;
     text-transform: none;
     padding: 6px 8px;
-    color: #000000; /* var(--colors-grey900) */
+    color: var(--colors-grey900);
     min-width: 64px;
     box-sizing: border-box;
     line-height: 1.75;
@@ -20,11 +18,11 @@
 }
 
 .menuButton:hover:enabled {
-    background-color: rgba(0, 0, 0, 0.08); /* var(--colors-grey300) */
+    background-color: var(--colors-grey300);
 }
 
 .menuButton:disabled {
-    color: #e0e0e0; /* var(--colors-grey400); */
+    color: var(--colors-grey400);
 }
 .menuButton:focus {
     outline: none;


### PR DESCRIPTION
### Key features

1. remove the bottom double border
2. use icons from `ui`
3. enable the Escape key for closing the menu

---

### Description

Solved the double bottom border issue in the menu, due to wrong use of `ui` components.
The Escape key closes the menu, this functionality was lost after replacing MUI with `ui`.

---

### Screenshots

![Screenshot 2021-02-08 at 12 13 40](https://user-images.githubusercontent.com/150978/107212366-27cd1880-6a07-11eb-8d6d-162d642e613e.png)