### PR TITLE
fix: get the errorCode for the analytics response in the right place

### DIFF
--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -42,7 +42,7 @@ export class Visualization extends Component {
     onError = response => {
         let error
         if (response) {
-            switch (response.details.errorCode) {
+            switch (response.details?.errorCode) {
                 case 'E7114':
                     error = new AssignedCategoriesDataElementsError()
                     break

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -42,7 +42,7 @@ export class Visualization extends Component {
     onError = response => {
         let error
         if (response) {
-            switch (response.errorCode) {
+            switch (response.details.errorCode) {
                 case 'E7114':
                     error = new AssignedCategoriesDataElementsError()
                     break


### PR DESCRIPTION
Implements [DHIS2-10329](https://jira.dhis2.org/browse/DHIS2-10329)

---

### Key features

1. fix regression where the custom error screens disappeared

---

### Description

The previous code expected the `errorCode` at the root level of the response object.
Now it is available under `details`.

---

### Screenshots

Before:
![Screenshot 2021-02-09 at 16 31 59](https://user-images.githubusercontent.com/150978/107386669-5c6ace00-6af4-11eb-81e1-62aa80b1c9bd.png)


After:
![Screenshot 2021-02-09 at 16 28 46](https://user-images.githubusercontent.com/150978/107386214-e9f9ee00-6af3-11eb-9a22-f1ff2d742cc3.png)
