### PR TITLE
chore: update @dhis2/analytics dep for getting latest Highcharts

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^14.1.8",
+        "@dhis2/analytics": "^14.1.9",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-interpretations": "^7.1.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^14.1.8",
+        "@dhis2/analytics": "^14.1.9",
         "@dhis2/ui": "^6.1.3",
         "lodash-es": "^4.17.11"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,10 +1499,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^14.1.8":
-  version "14.1.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-14.1.8.tgz#95f7ca48c1e77ea94c7da08cc289eedc5dc387f2"
-  integrity sha512-N0ItcJrkF7PjozDSa2bQqMoYmNS4hrwEIlv6YvdjsjigT4YVXxVazcGRZP7PFFWy+ME+Qf2AphXzjK6VBqZmyA==
+"@dhis2/analytics@^14.1.9":
+  version "14.1.9"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-14.1.9.tgz#f720644b16f48a5d49d894179592ae9747358da0"
+  integrity sha512-rZqfJLs9fctEjWqy+6oAcMNvhuwzyZV24x/sp3GDIVrVAIMd4dlr3V8K/CNi3IqRbsIRKRdObhlrgFhVwNHw5g==
   dependencies:
     "@dhis2/app-runtime" "^2.6.1"
     "@dhis2/d2-ui-favorites-dialog" "^7.1.3"
@@ -1515,7 +1515,7 @@
     classnames "^2.2.6"
     d2-utilizr "^0.2.16"
     d3-color "^1.2.3"
-    highcharts "^8.2.2"
+    highcharts "^9.0.0"
     lodash "^4.17.20"
     react-beautiful-dnd "^10.1.1"
     resize-observer-polyfill "^1.5.1"
@@ -8333,10 +8333,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highcharts@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-8.2.2.tgz#3eb1a694cff013d3385c3ca8e58e69a27be52cab"
-  integrity sha512-F63TXO7RxsvTcpO/KOubQZWualYpCMyCTuKtoWbt7KCsfQ3Kl7Fr6HEyyJdjkYl+XlnmnKlSRi9d3HjLK9Q0wg==
+highcharts@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.0.0.tgz#2e5d382481f71c50ac7f086e7bdead394fab71d4"
+  integrity sha512-MJCtidFytGSQvsV3OEM+vFTLpjUcp7jmFpLn8h3oL4WKp0gxUOQg6Nw00sqMWGdiadst0gOZO4804zynTcYjZQ==
 
 history@^4.7.2:
   version "4.10.1"


### PR DESCRIPTION
Fixes [DHIS2-10289](https://jira.dhis2.org/browse/DHIS2-10289)

---

### Description

Highcharts 9.0.0 fixes the missing pattern preview, analytics dep has it already, bump dep in app.

### Screenshots

Before (regression):
![Screenshot 2021-02-15 at 12 29 49](https://user-images.githubusercontent.com/150978/107941142-8ce5b880-6f89-11eb-9724-022e4c65b163.png)

After:
![Screenshot 2021-02-15 at 12 30 53](https://user-images.githubusercontent.com/150978/107941221-adae0e00-6f89-11eb-865b-5a925fbc3798.png)

