### PR TITLE
fix: avoid double border in contextual menu DHIS2-10514

### DIFF
--- a/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
@@ -30,16 +30,16 @@ export const Dimensions = ({
     ui,
     onDimensionClick,
 }) => {
-    const [dialogIsOpen, setDialogIsOpen] = useState(false)
+    const [menuIsOpen, setMenuIsOpen] = useState(false)
     const [dimensionId, setDimensionId] = useState(null)
     const [ref, setRef] = useState()
 
     const toggleMenu = () => {
-        if (dialogIsOpen) {
+        if (menuIsOpen) {
             setDimensionId(null)
             setRef(null)
         }
-        setDialogIsOpen(!dialogIsOpen)
+        setMenuIsOpen(!menuIsOpen)
     }
 
     const openOptionsMenuForDimension = (event, id, ref) => {
@@ -65,7 +65,7 @@ export const Dimensions = ({
                 onDimensionClick={openDimensionModal}
                 onDimensionOptionsClick={openOptionsMenuForDimension}
             />
-            {dialogIsOpen && dimensionId && ref && (
+            {menuIsOpen && dimensionId && ref && (
                 <Layer position="fixed" level={2000} onClick={toggleMenu}>
                     <Popper reference={ref} placement="bottom-start">
                         <DimensionMenu

--- a/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/packages/app/src/components/DimensionsPanel/DimensionsPanel.js
@@ -7,7 +7,7 @@ import {
     DIMENSION_ID_DATA,
     VIS_TYPE_SCATTER,
 } from '@dhis2/analytics'
-import { Popover } from '@dhis2/ui'
+import { Layer, Popper } from '@dhis2/ui'
 
 import DialogManager from './Dialogs/DialogManager'
 import DndDimensionsPanel from './DndDimensionsPanel'
@@ -66,32 +66,29 @@ export const Dimensions = ({
                 onDimensionOptionsClick={openOptionsMenuForDimension}
             />
             {dialogIsOpen && dimensionId && ref && (
-                <Popover
-                    reference={ref}
-                    placement="bottom-start"
-                    onClickOutside={toggleMenu}
-                    arrow={false}
-                >
-                    <DimensionMenu
-                        dimensionId={dimensionId}
-                        currentAxisId={getCurrentAxisId(dimensionId)}
-                        visType={ui.type}
-                        numberOfDimensionItems={getNumberOfDimensionItems()}
-                        isAssignedCategoriesInLayout={
-                            layoutHasAssignedCategories
-                        }
-                        assignedCategoriesItemHandler={destination =>
-                            assignedCategoriesItemHandler(
-                                layoutHasAssignedCategories,
-                                destination
-                            )
-                        }
-                        axisItemHandler={axisItemHandler}
-                        removeItemHandler={removeItemHandler}
-                        onClose={toggleMenu}
-                        dataTest={'dimensions-panel-dimension-menu'}
-                    />
-                </Popover>
+                <Layer position="fixed" level={2000} onClick={toggleMenu}>
+                    <Popper reference={ref} placement="bottom-start">
+                        <DimensionMenu
+                            dimensionId={dimensionId}
+                            currentAxisId={getCurrentAxisId(dimensionId)}
+                            visType={ui.type}
+                            numberOfDimensionItems={getNumberOfDimensionItems()}
+                            isAssignedCategoriesInLayout={
+                                layoutHasAssignedCategories
+                            }
+                            assignedCategoriesItemHandler={destination =>
+                                assignedCategoriesItemHandler(
+                                    layoutHasAssignedCategories,
+                                    destination
+                                )
+                            }
+                            axisItemHandler={axisItemHandler}
+                            removeItemHandler={removeItemHandler}
+                            onClose={toggleMenu}
+                            dataTest={'dimensions-panel-dimension-menu'}
+                        />
+                    </Popper>
+                </Layer>
             )}
             <DialogManager />
         </div>

--- a/packages/app/src/components/Layout/ChipMenu.js
+++ b/packages/app/src/components/Layout/ChipMenu.js
@@ -28,9 +28,9 @@ const ChipMenu = ({
     visType,
 }) => {
     const buttonRef = useRef()
-    const [dialogIsOpen, setDialogIsOpen] = useState(false)
+    const [menuIsOpen, setMenuIsOpen] = useState(false)
 
-    const toggleMenu = () => setDialogIsOpen(!dialogIsOpen)
+    const toggleMenu = () => setMenuIsOpen(!menuIsOpen)
 
     const getMenuId = () => `menu-for-${id}`
 
@@ -38,7 +38,7 @@ const ChipMenu = ({
         <>
             <div ref={buttonRef}>
                 <IconButton
-                    ariaOwns={dialogIsOpen ? getMenuId() : null}
+                    ariaOwns={menuIsOpen ? getMenuId() : null}
                     ariaHaspopup={true}
                     onClick={toggleMenu}
                     style={styles.icon}
@@ -48,7 +48,7 @@ const ChipMenu = ({
                 </IconButton>
             </div>
             {/* TODO: Fix bug with the first menu item getting selected when the menu is opened */}
-            {dialogIsOpen && (
+            {menuIsOpen && (
                 <Layer position="fixed" level={2000} onClick={toggleMenu}>
                     <Popper reference={buttonRef} placement="bottom-start">
                         <DimensionMenu

--- a/packages/app/src/components/Layout/ChipMenu.js
+++ b/packages/app/src/components/Layout/ChipMenu.js
@@ -5,7 +5,7 @@ import {
     DimensionMenu,
     DIMENSION_ID_ASSIGNED_CATEGORIES,
 } from '@dhis2/analytics'
-import { Popover } from '@dhis2/ui'
+import { Layer, Popper } from '@dhis2/ui'
 
 import * as fromReducers from '../../reducers'
 import MoreHorizontalIcon from '../../assets/MoreHorizontalIcon'
@@ -49,32 +49,29 @@ const ChipMenu = ({
             </div>
             {/* TODO: Fix bug with the first menu item getting selected when the menu is opened */}
             {dialogIsOpen && (
-                <Popover
-                    reference={buttonRef}
-                    placement="bottom-start"
-                    onClickOutside={toggleMenu}
-                    arrow={false}
-                >
-                    <DimensionMenu
-                        dimensionId={dimensionId}
-                        currentAxisId={currentAxisId}
-                        visType={visType}
-                        numberOfDimensionItems={numberOfDimensionItems}
-                        isAssignedCategoriesInLayout={
-                            layoutHasAssignedCategories
-                        }
-                        assignedCategoriesItemHandler={destination =>
-                            assignedCategoriesItemHandler(
-                                layoutHasAssignedCategories,
-                                destination
-                            )
-                        }
-                        axisItemHandler={axisItemHandler}
-                        removeItemHandler={removeItemHandler}
-                        onClose={toggleMenu}
-                        dataTest={'layout-chip-menu-dimension-menu'}
-                    />
-                </Popover>
+                <Layer position="fixed" level={2000} onClick={toggleMenu}>
+                    <Popper reference={buttonRef} placement="bottom-start">
+                        <DimensionMenu
+                            dimensionId={dimensionId}
+                            currentAxisId={currentAxisId}
+                            visType={visType}
+                            numberOfDimensionItems={numberOfDimensionItems}
+                            isAssignedCategoriesInLayout={
+                                layoutHasAssignedCategories
+                            }
+                            assignedCategoriesItemHandler={destination =>
+                                assignedCategoriesItemHandler(
+                                    layoutHasAssignedCategories,
+                                    destination
+                                )
+                            }
+                            axisItemHandler={axisItemHandler}
+                            removeItemHandler={removeItemHandler}
+                            onClose={toggleMenu}
+                            dataTest={'layout-chip-menu-dimension-menu'}
+                        />
+                    </Popper>
+                </Layer>
             )}
         </>
     )


### PR DESCRIPTION
Implements [DHIS2-10514](https://jira.dhis2.org/browse/DHIS2-10514)

---

### Key features

1. removes double border in contextual menus

---

### Description

The double bottom border in menus is a known issue that happens when using a `FlyoutMenu` inside a `Popover` component.
The proper way to do it is wrapping a `Popper` in a `Layer` (needed for attaching the click outside the menu callback).\
The same approach is used for FileMenu and DownloadMenu.

---

### Screenshots

Before:
![Screenshot 2021-02-17 at 16 57 15](https://user-images.githubusercontent.com/150978/108230762-62d6f680-7141-11eb-8a36-6df979f32a75.png)

After:
![Screenshot 2021-02-17 at 16 59 16](https://user-images.githubusercontent.com/150978/108230895-8306b580-7141-11eb-8177-4a7ffa6a6312.png)
![Screenshot 2021-02-17 at 16 59 25](https://user-images.githubusercontent.com/150978/108230892-826e1f00-7141-11eb-93bf-eb0f525fdc79.png)

