### PR TITLE
fix: store metadata also when no data is returned

### DIFF
--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -74,11 +74,6 @@ export class Visualization extends Component {
 
     onResponsesReceived = responses => {
         const forMetadata = {}
-        if (
-            !responses.some(response => response.rows && response.rows.length)
-        ) {
-            throw new EmptyResponseError()
-        }
         responses.forEach(response => {
             Object.entries(response.metaData.items).forEach(([id, item]) => {
                 forMetadata[id] = {
@@ -91,6 +86,12 @@ export class Visualization extends Component {
         })
 
         this.props.addMetadata(forMetadata)
+
+        if (
+            !responses.some(response => response.rows && response.rows.length)
+        ) {
+            throw new EmptyResponseError()
+        }
     }
 
     onDrill = drillData => {


### PR DESCRIPTION
### Key features

1. fix bug which caused dimension ids instead of names to be shown in the layout chip tooltips

---

### Description

See attached screenshots.
The bug only happens for saved visualizations when no data is returned.
Metadata is always present in the response, but when there is no data to show, the `EmptyResponseError` was thrown before storing the metadata for the dimension selection.
The fix makes sure the metadata in the Redux store is always updated, and any error is thrown afterwards.

### Screenshots

Before:
![Screenshot 2021-02-25 at 12 12 48](https://user-images.githubusercontent.com/150978/109146486-2c623280-7764-11eb-9ce8-34fe088932b1.png)

After:
![Screenshot 2021-02-25 at 12 13 03](https://user-images.githubusercontent.com/150978/109146503-2ff5b980-7764-11eb-972a-a5c7ac504d8a.png)

