### PR TITLE
fix: use nameprop for dynamic dimensions and /analytics

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^15.1.2",
+        "@dhis2/analytics": "^16.0.0",
         "@dhis2/app-runtime": "*",
         "@dhis2/d2-i18n": "*",
         "@dhis2/d2-ui-interpretations": "^7.1.3",

--- a/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
+++ b/packages/app/src/components/DimensionsPanel/Dialogs/DialogManager.js
@@ -354,6 +354,7 @@ export class DialogManager extends Component {
                         dimensionId={dialogId}
                         onSelect={dimensionProps.onSelect}
                         dimensionTitle={this.props.dimensions[dialogId].name}
+                        displayNameProp={displayNameProperty}
                         // TODO: infoBoxMessage should ideally be implemented for all dimensions
                     />
                 )

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -29,6 +29,7 @@ import {
     CombinationDEGSRRError,
 } from '../../modules/error'
 import LoadingMask from '../../widgets/LoadingMask'
+import { sGetSettingsDisplayNameProperty } from '../../reducers/settings'
 
 export class Visualization extends Component {
     constructor(props) {
@@ -176,6 +177,9 @@ export class Visualization extends Component {
                     onError={this.onError}
                     onDrill={this.onDrill}
                     style={styles.chartCanvas}
+                    userSettings={{
+                        displayProperty: this.props.displayProperty,
+                    }}
                 />
             </Fragment>
         )
@@ -185,6 +189,7 @@ export class Visualization extends Component {
 Visualization.propTypes = {
     addMetadata: PropTypes.func,
     addParentGraphMap: PropTypes.func,
+    displayProperty: PropTypes.string,
     error: PropTypes.object,
     isLoading: PropTypes.bool,
     rightSidebarOpen: PropTypes.bool,
@@ -217,6 +222,7 @@ const mapStateToProps = state => ({
     rightSidebarOpen: sGetUiRightSidebarOpen(state),
     error: sGetLoadError(state),
     isLoading: sGetIsPluginLoading(state),
+    displayProperty: sGetSettingsDisplayNameProperty(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^15.1.2",
+        "@dhis2/analytics": "^16.0.0",
         "@dhis2/ui": "^6.5.0",
         "lodash-es": "^4.17.11"
     },

--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -24,6 +24,7 @@ export const VisualizationPlugin = ({
     visualization,
     filters,
     forDashboard,
+    userSettings,
     onError,
     onLoadingComplete,
     onResponsesReceived,
@@ -55,6 +56,7 @@ export const VisualizationPlugin = ({
             visualization,
             filters,
             forDashboard,
+            userSettings,
         })
 
         if (result.responses.length) {
@@ -62,7 +64,14 @@ export const VisualizationPlugin = ({
         }
 
         return result
-    }, [engine, filters, forDashboard, onResponsesReceived, visualization])
+    }, [
+        engine,
+        filters,
+        forDashboard,
+        userSettings,
+        onResponsesReceived,
+        visualization,
+    ])
 
     const doFetchLegendSets = useCallback(
         async legendSetIds => {
@@ -205,11 +214,13 @@ VisualizationPlugin.defaultProps = {
     onLoadingComplete: Function.prototype,
     onResponsesReceived: Function.prototype,
     visualization: {},
+    userSettings: {},
 }
 VisualizationPlugin.propTypes = {
     visualization: PropTypes.object.isRequired,
     filters: PropTypes.object,
     forDashboard: PropTypes.bool,
+    userSettings: PropTypes.object,
     onDrill: PropTypes.func,
     onError: PropTypes.func,
     onLoadingComplete: PropTypes.func,

--- a/packages/plugin/src/modules/fetchData.js
+++ b/packages/plugin/src/modules/fetchData.js
@@ -20,8 +20,9 @@ export const fetchData = async ({
     visualization,
     filters,
     forDashboard,
+    userSettings,
 }) => {
-    const options = getRequestOptions(visualization, filters)
+    const options = getRequestOptions(visualization, filters, userSettings)
 
     const extraOptions = {
         dashboard: forDashboard,

--- a/packages/plugin/src/modules/getRequestOptions.js
+++ b/packages/plugin/src/modules/getRequestOptions.js
@@ -1,6 +1,6 @@
 import { getOptionsForRequest } from './options'
 
-export const getRequestOptions = (visualization, filters) => {
+export const getRequestOptions = (visualization, filters, userSettings) => {
     const options = getOptionsForRequest().reduce((map, [option, props]) => {
         // only add parameter if value !== default
         if (
@@ -16,6 +16,17 @@ export const getRequestOptions = (visualization, filters) => {
     // interpretation filter
     if (filters.relativePeriodDate) {
         options.relativePeriodDate = filters.relativePeriodDate
+    }
+
+    if (userSettings?.displayProperty) {
+        switch (userSettings.displayProperty) {
+            case 'displayShortName':
+                options.displayProperty = 'SHORTNAME'
+                break
+            case 'displayName':
+                options.displayProperty = 'NAME'
+                break
+        }
     }
 
     // global filters

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,10 +1499,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^15.1.2":
-  version "15.1.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-15.1.2.tgz#ad491a7528acdaa352162a41517e69733f7c9945"
-  integrity sha512-7M4qKop2BjKNl5Arm3v/jNrrOgW8HXDov8M6cGFaqd/lc7KNvjDLIIEsOpq8HqDofFhn9n10OVd0/rnhM4CtEg==
+"@dhis2/analytics@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-16.0.0.tgz#0cdb90659f7ae5e13e42fae3528b2f3fb609e9ca"
+  integrity sha512-AGvxnyiB8qxL3+p2KEEPigej/DV9ulMmNjFyHr+bMzl7njPXwSxFmMp9GrUxJ3geP8VmJPaSUr8OwVCfR5sJbQ==
   dependencies:
     "@dhis2/d2-ui-favorites-dialog" "^7.1.3"
     "@dhis2/d2-ui-org-unit-dialog" "^7.1.3"


### PR DESCRIPTION
**Requires https://github.com/dhis2/analytics/pull/841**

---

### Key features

1. Pass `nameProp` to `DynamicDimension`
2. Pass `displayProperty` to `/analytics`

---

### Screenshots

_shortname now properly displayed for dynamic dimensions_ 

![image](https://user-images.githubusercontent.com/12590483/109675291-f106a000-7b77-11eb-91fc-f7ac124a7c19.png)


_shortname now properly displayed in places which rely on the metadata from /analytics_

![image](https://user-images.githubusercontent.com/12590483/109675362-04197000-7b78-11eb-9906-33498f6af34f.png)

