### PR TITLE
test: font style testing

### DIFF
--- a/cypress/elements/common.js
+++ b/cypress/elements/common.js
@@ -13,6 +13,14 @@ const loadingEl = 'dhis2-uicore-circularloader'
 export const expectAppToNotBeLoading = () =>
     cy.getBySel(loadingEl).should('not.exist')
 
+export const clickCheckbox = target =>
+    cy.getBySel(target).click().find('[type="checkbox"]').should('be.checked')
+
+export const typeInput = (target, text) =>
+    cy.getBySel(target).find('input').type(text)
+
+export const clearInput = target => cy.getBySel(target).find('input').clear()
+
 export const replacePeriodItems = (
     visType,
     options = { useAltData: false }

--- a/cypress/elements/common.js
+++ b/cypress/elements/common.js
@@ -8,6 +8,11 @@ import {
 } from './dimensionModal/periodDimension'
 import { clickDimensionModalUpdateButton } from './dimensionModal'
 
+const loadingEl = 'dhis2-uicore-circularloader'
+
+export const expectAppToNotBeLoading = () =>
+    cy.getBySel(loadingEl).should('not.exist')
+
 export const replacePeriodItems = (
     visType,
     options = { useAltData: false }

--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -1,6 +1,7 @@
 import { DIMENSION_ID_DATA } from '@dhis2/analytics'
 
 import { expectDimensionModalToBeVisible } from '.'
+import { clearInput, typeInput } from '../common'
 
 const optionEl = 'data-dimension-transfer-option'
 const optionContentEl = 'data-dimension-transfer-option-content'
@@ -172,12 +173,12 @@ export const switchDataTypeToAll = () => {
 }
 
 export const inputSearchTerm = searchTerm => {
-    cy.getBySel(searchFieldEl).find('input').type(searchTerm)
+    typeInput(searchFieldEl, searchTerm)
     expectSourceToNotBeLoading()
 }
 
 export const clearSearchTerm = () => {
-    cy.getBySel(searchFieldEl).find('input').clear()
+    clearInput(searchFieldEl)
     expectSourceToNotBeLoading()
 }
 

--- a/cypress/elements/dimensionModal/index.js
+++ b/cypress/elements/dimensionModal/index.js
@@ -61,6 +61,7 @@ export { selectRelativePeriods, selectFixedPeriods } from './periodDimension'
 export {
     expectOrgUnitDimensionModalToBeVisible,
     clickOrgUnitTreeItem,
+    selectOrgUnitLevel,
 } from './orgUnitDimension'
 
 /*  TODO:

--- a/cypress/elements/dimensionModal/orgUnitDimension.js
+++ b/cypress/elements/dimensionModal/orgUnitDimension.js
@@ -3,6 +3,7 @@ import { DIMENSION_ID_ORGUNIT } from '@dhis2/analytics'
 import { expectDimensionModalToBeVisible } from '.'
 
 const orgUnitModalEl = 'dialog-manager-ou'
+const levelSelectorEl = '*[class^="MuiModal"]'
 
 export const expectOrgUnitDimensionModalToBeVisible = () =>
     expectDimensionModalToBeVisible(DIMENSION_ID_ORGUNIT)
@@ -13,3 +14,9 @@ export const clickOrgUnitTreeItem = itemName =>
         .find('*[role="button"]')
         .contains(itemName)
         .click()
+
+export const selectOrgUnitLevel = name => {
+    cy.getBySel(orgUnitModalEl).contains('Select a level').click()
+    cy.get(levelSelectorEl).contains(name).click()
+    cy.get(levelSelectorEl).type('{esc}')
+}

--- a/cypress/elements/dimensionsPanel.js
+++ b/cypress/elements/dimensionsPanel.js
@@ -1,3 +1,5 @@
+import { clearInput, typeInput } from './common'
+
 const dimButtonEl = 'dimensions-panel-list-dimension-item-button'
 const dimContextMenuButtonEl = 'dimensions-panel-list-dimension-item-menu'
 const dimContextMenuRemoveOptionEl =
@@ -50,10 +52,9 @@ export const clickContextMenuDimSubMenu = dimensionId =>
         .click()
 
 export const filterDimensionsByText = searchInput =>
-    cy.getBySel(filterInputEl).find('input').type(searchInput)
+    typeInput(filterInputEl, searchInput)
 
-export const clearDimensionsFilter = () =>
-    cy.getBySel(filterInputEl).find('input').clear()
+export const clearDimensionsFilter = () => clearInput(filterInputEl)
 
 export const expectFixedDimensionsToHaveLength = length =>
     cy.getBySel(fixedDimsWrapperEl).children().should('have.length', length)

--- a/cypress/elements/fileMenu/save.js
+++ b/cypress/elements/fileMenu/save.js
@@ -4,6 +4,7 @@ import {
     FILE_MENU_BUTTON_SAVE_NEW,
     FILE_MENU_BUTTON_SAVEAS,
 } from '.'
+import { clearInput, typeInput } from '../common'
 import { clickMenuBarFileButton } from '../menuBar'
 
 const saveModalNameEl = 'file-menu-saveas-modal-name'
@@ -13,7 +14,8 @@ const saveModalSaveButtonEl = 'file-menu-saveas-modal-save'
 export const saveNewAO = (name, description) => {
     clickMenuBarFileButton()
     clickFileMenuButton(FILE_MENU_BUTTON_SAVE_NEW)
-    cy.getBySel(saveModalNameEl).find('input').clear().type(name)
+    clearInput(saveModalNameEl)
+    typeInput(saveModalNameEl, name)
     cy.getBySel(saveModalDescriptionEl).find('textarea').type(description)
     cy.getBySel(saveModalSaveButtonEl).click()
 }
@@ -27,7 +29,8 @@ export const saveAOAs = (name, description) => {
     clickMenuBarFileButton()
     clickFileMenuButton(FILE_MENU_BUTTON_SAVEAS)
     if (name) {
-        cy.getBySel(saveModalNameEl).find('input').clear().type(name)
+        clearInput(saveModalNameEl)
+        typeInput(saveModalNameEl, name)
     }
     if (description) {
         cy.getBySel(saveModalDescriptionEl)

--- a/cypress/elements/optionsModal/axes.js
+++ b/cypress/elements/optionsModal/axes.js
@@ -1,3 +1,5 @@
+import { clickCheckbox, typeInput } from '../common'
+
 const titleCheckboxEl = 'axis-title-checkbox'
 const titleInputEl = 'axis-title-input'
 const rangeMinInputEl = 'axis-range-min-input'
@@ -6,14 +8,10 @@ const rangeMaxInputEl = 'axis-range-max-input'
 const getAxisSelector = (axis, selector) => `${axis}-${selector}`
 
 export const enableAxisTitle = axis =>
-    cy
-        .getBySel(getAxisSelector(axis, titleCheckboxEl))
-        .click()
-        .find('[type="checkbox"]')
-        .should('be.checked')
+    clickCheckbox(getAxisSelector(axis, titleCheckboxEl))
 
 export const setAxisTitle = (axis, text) =>
-    cy.getBySel(getAxisSelector(axis, titleInputEl)).find('input').type(text)
+    typeInput(getAxisSelector(axis, titleInputEl), text)
 
 export const expectAxisTitleToBeValue = (axis, value) =>
     cy

--- a/cypress/elements/optionsModal/fontStyles.js
+++ b/cypress/elements/optionsModal/fontStyles.js
@@ -1,35 +1,27 @@
-const getTextAlignSelectElByType = type =>
-    `option-chart-${type}-text-style-text-align-select`
-const getTextAlignOptionElByType = type =>
-    `option-chart-${type}-text-style-text-align-option`
-const getFontSizeSelectElByType = type =>
-    `option-chart-${type}-text-style-font-size-select`
-const getFontSizeOptionElByType = type =>
-    `option-chart-${type}-text-style-font-size-option`
-const getBoldButtonElByType = type =>
-    `option-chart-${type}-text-style-bold-toggle`
-const getItalicButtonElByType = type =>
-    `option-chart-${type}-text-style-italic-toggle`
+const getTextAlignSelectEl = prefix => `${prefix}-text-style-text-align-select`
+const getTextAlignOptionEl = prefix => `${prefix}-text-style-text-align-option`
+const getFontSizeSelectEl = prefix => `${prefix}-text-style-font-size-select`
+const getFontSizeOptionEl = prefix => `${prefix}-text-style-font-size-option`
+const getBoldButtonEl = prefix => `${prefix}-text-style-bold-toggle`
+const getItalicButtonEl = prefix => `${prefix}-text-style-italic-toggle`
 
-export const changeTextAlignOption = (type, optionName) => {
-    cy.getBySel(getTextAlignSelectElByType(type)).click()
-    cy.getBySelLike(getTextAlignOptionElByType(type))
-        .contains(optionName)
+export const changeTextAlignOption = (prefix, optionName) => {
+    cy.getBySel(getTextAlignSelectEl(prefix)).click()
+    cy.getBySelLike(getTextAlignOptionEl(prefix)).contains(optionName).click()
+}
+
+export const changeFontSizeOption = (prefix, optionName) => {
+    cy.getBySel(getFontSizeSelectEl(prefix)).click()
+    cy.getBySelLike(getFontSizeOptionEl(prefix))
+        .contains(new RegExp(`(?<!.)${optionName}(?!.)`, 'gm'))
         .click()
 }
 
-export const changeFontSizeOption = (type, optionName) => {
-    cy.getBySel(getFontSizeSelectElByType(type)).click()
-    cy.getBySelLike(getFontSizeOptionElByType(type))
-        .contains(optionName)
-        .click()
-}
+export const clickBoldButton = prefix =>
+    cy.getBySel(getBoldButtonEl(prefix)).click()
 
-export const clickBoldButton = type =>
-    cy.getBySel(getBoldButtonElByType(type)).click()
-
-export const clickItalicButton = type =>
-    cy.getBySel(getItalicButtonElByType(type)).click()
+export const clickItalicButton = prefix =>
+    cy.getBySel(getItalicButtonEl(prefix)).click()
 
 /*FIXME: Find a way to test the color picker
     export const changeTitleColorOption = color => 

--- a/cypress/elements/optionsModal/fontStyles.js
+++ b/cypress/elements/optionsModal/fontStyles.js
@@ -13,7 +13,7 @@ export const changeTextAlignOption = (prefix, optionName) => {
 export const changeFontSizeOption = (prefix, optionName) => {
     cy.getBySel(getFontSizeSelectEl(prefix)).click()
     cy.getBySelLike(getFontSizeOptionEl(prefix))
-        .contains(new RegExp(`(?<!.)${optionName}(?!.)`, 'gm'))
+        .contains(new RegExp(`^${optionName}$`, 'gm'))
         .click()
 }
 

--- a/cypress/elements/optionsModal/index.js
+++ b/cypress/elements/optionsModal/index.js
@@ -7,8 +7,6 @@ export const OPTIONS_TAB_STYLE = 'Style'
 export const OPTIONS_TAB_DATA = 'Data'
 export const OPTIONS_TAB_AXES = 'Axes'
 export const OPTIONS_TAB_OUTLIERS = 'Outliers'
-export const TYPE_TITLE = 'title'
-export const TYPE_SUBTITLE = 'subtitle'
 
 export const clickOptionsTab = name =>
     cy.getBySel(tabBarEl).contains(name).click()
@@ -42,8 +40,14 @@ export {
     expectAxisRangeMaxToBeValue,
 } from './axes'
 
-export { clickTrendLineCheckbox, selectTrendLineType } from './lines'
+export {
+    clickTrendLineCheckbox,
+    selectTrendLineType,
+    clickTargetLineCheckbox,
+    setTargetLineValue,
+    setTargetLineLabel,
+} from './lines'
 
 export { setCustomSubtitle } from './subtitle'
 
-export { enableOutliers } from './outliers'
+export { clickOutliersCheckbox } from './outliers'

--- a/cypress/elements/optionsModal/index.js
+++ b/cypress/elements/optionsModal/index.js
@@ -46,6 +46,9 @@ export {
     clickTargetLineCheckbox,
     setTargetLineValue,
     setTargetLineLabel,
+    clickBaseLineCheckbox,
+    setBaseLineLabel,
+    setBaseLineValue,
 } from './lines'
 
 export { setCustomSubtitle } from './subtitle'

--- a/cypress/elements/optionsModal/lines.js
+++ b/cypress/elements/optionsModal/lines.js
@@ -4,6 +4,9 @@ const trendLineSelectOptionEl = 'option-trend-line-option'
 const targetLineCheckboxEl = 'option-target-line-checkbox'
 const targetLineValueInputEl = 'option-target-line-value-input'
 const targetLineLabelInputEl = 'option-target-line-label-input'
+const baseLineCheckboxEl = 'option-base-line-checkbox'
+const baseLineValueInputEl = 'option-base-line-value-input'
+const baseLineLabelInputEl = 'option-base-line-label-input'
 
 export const clickTrendLineCheckbox = () =>
     cy
@@ -29,3 +32,16 @@ export const setTargetLineValue = text =>
 
 export const setTargetLineLabel = text =>
     cy.getBySel(targetLineLabelInputEl).find('input').type(text)
+
+export const clickBaseLineCheckbox = () =>
+    cy
+        .getBySel(baseLineCheckboxEl)
+        .click()
+        .find('[type="checkbox"]')
+        .should('be.checked')
+
+export const setBaseLineValue = text =>
+    cy.getBySel(baseLineValueInputEl).find('input').type(text)
+
+export const setBaseLineLabel = text =>
+    cy.getBySel(baseLineLabelInputEl).find('input').type(text)

--- a/cypress/elements/optionsModal/lines.js
+++ b/cypress/elements/optionsModal/lines.js
@@ -1,6 +1,9 @@
 const trendLineCheckboxEl = 'option-trend-line-checkbox'
 const trendLineSelectEl = 'option-trend-line-select'
 const trendLineSelectOptionEl = 'option-trend-line-option'
+const targetLineCheckboxEl = 'option-target-line-checkbox'
+const targetLineValueInputEl = 'option-target-line-value-input'
+const targetLineLabelInputEl = 'option-target-line-label-input'
 
 export const clickTrendLineCheckbox = () =>
     cy
@@ -13,3 +16,16 @@ export const selectTrendLineType = optionName => {
     cy.getBySel(trendLineSelectEl).findBySel('dhis2-uicore-select').click()
     cy.getBySel(trendLineSelectOptionEl).contains(optionName).click()
 }
+
+export const clickTargetLineCheckbox = () =>
+    cy
+        .getBySel(targetLineCheckboxEl)
+        .click()
+        .find('[type="checkbox"]')
+        .should('be.checked')
+
+export const setTargetLineValue = text =>
+    cy.getBySel(targetLineValueInputEl).find('input').type(text)
+
+export const setTargetLineLabel = text =>
+    cy.getBySel(targetLineLabelInputEl).find('input').type(text)

--- a/cypress/elements/optionsModal/lines.js
+++ b/cypress/elements/optionsModal/lines.js
@@ -1,3 +1,5 @@
+import { clickCheckbox, typeInput } from '../common'
+
 const trendLineCheckboxEl = 'option-trend-line-checkbox'
 const trendLineSelectEl = 'option-trend-line-select'
 const trendLineSelectOptionEl = 'option-trend-line-option'
@@ -8,40 +10,23 @@ const baseLineCheckboxEl = 'option-base-line-checkbox'
 const baseLineValueInputEl = 'option-base-line-value-input'
 const baseLineLabelInputEl = 'option-base-line-label-input'
 
-export const clickTrendLineCheckbox = () =>
-    cy
-        .getBySel(trendLineCheckboxEl)
-        .click()
-        .find('[type="checkbox"]')
-        .should('be.checked')
+export const clickTrendLineCheckbox = () => clickCheckbox(trendLineCheckboxEl)
 
 export const selectTrendLineType = optionName => {
     cy.getBySel(trendLineSelectEl).findBySel('dhis2-uicore-select').click()
     cy.getBySel(trendLineSelectOptionEl).contains(optionName).click()
 }
 
-export const clickTargetLineCheckbox = () =>
-    cy
-        .getBySel(targetLineCheckboxEl)
-        .click()
-        .find('[type="checkbox"]')
-        .should('be.checked')
+export const clickTargetLineCheckbox = () => clickCheckbox(targetLineCheckboxEl)
 
 export const setTargetLineValue = text =>
-    cy.getBySel(targetLineValueInputEl).find('input').type(text)
+    typeInput(targetLineValueInputEl, text)
 
 export const setTargetLineLabel = text =>
-    cy.getBySel(targetLineLabelInputEl).find('input').type(text)
+    typeInput(targetLineLabelInputEl, text)
 
-export const clickBaseLineCheckbox = () =>
-    cy
-        .getBySel(baseLineCheckboxEl)
-        .click()
-        .find('[type="checkbox"]')
-        .should('be.checked')
+export const clickBaseLineCheckbox = () => clickCheckbox(baseLineCheckboxEl)
 
-export const setBaseLineValue = text =>
-    cy.getBySel(baseLineValueInputEl).find('input').type(text)
+export const setBaseLineValue = text => typeInput(baseLineValueInputEl, text)
 
-export const setBaseLineLabel = text =>
-    cy.getBySel(baseLineLabelInputEl).find('input').type(text)
+export const setBaseLineLabel = text => typeInput(baseLineLabelInputEl, text)

--- a/cypress/elements/optionsModal/outliers.js
+++ b/cypress/elements/optionsModal/outliers.js
@@ -1,8 +1,5 @@
+import { clickCheckbox } from '../common'
+
 const outliersCheckboxEl = 'option-outliers-enabled-checkbox'
 
-export const clickOutliersCheckbox = () =>
-    cy
-        .getBySel(outliersCheckboxEl)
-        .click()
-        .find('[type="checkbox"]')
-        .should('be.checked')
+export const clickOutliersCheckbox = () => clickCheckbox(outliersCheckboxEl)

--- a/cypress/elements/optionsModal/outliers.js
+++ b/cypress/elements/optionsModal/outliers.js
@@ -1,6 +1,6 @@
 const outliersCheckboxEl = 'option-outliers-enabled-checkbox'
 
-export const enableOutliers = () =>
+export const clickOutliersCheckbox = () =>
     cy
         .getBySel(outliersCheckboxEl)
         .click()

--- a/cypress/elements/optionsModal/subtitle.js
+++ b/cypress/elements/optionsModal/subtitle.js
@@ -1,8 +1,10 @@
+import { typeInput } from '../common'
+
 const typeRadioEl = 'option-chart-subtitle-type-radios'
 const textEl = 'option-chart-subtitle-text-input'
 const customOption = 'Custom'
 
 export const setCustomSubtitle = text => {
     cy.getBySel(typeRadioEl).contains(customOption).click()
-    cy.getBySel(textEl).find('input').type(text)
+    typeInput(textEl, text)
 }

--- a/cypress/integration/options/axes.cy.js
+++ b/cypress/integration/options/axes.cy.js
@@ -38,7 +38,7 @@ const TEST_MAX_VALUE = generateRandomNumber(2000, 5000)
 
 describe('Options - Vertical axis', () => {
     const TEST_AXIS = 'RANGE_0'
-    const TEST_TITLE = 'Vert title'
+    const TEST_TITLE = 'VT'
     it('navigates to the start page and add a data item', () => {
         goToStartPage()
         openDimension(DIMENSION_ID_DATA)
@@ -107,7 +107,7 @@ describe('Options - Vertical axis', () => {
 
 describe('Options - Horizontal axis', () => {
     const TEST_AXIS = 'DOMAIN_0'
-    const TEST_TITLE = 'Hori title'
+    const TEST_TITLE = 'HT'
     it('navigates to the start page and add a data item', () => {
         goToStartPage()
         openDimension(DIMENSION_ID_DATA)

--- a/cypress/integration/options/fontStyles.cy.js
+++ b/cypress/integration/options/fontStyles.cy.js
@@ -16,6 +16,8 @@ import {
     expectWindowConfigTitleToBeValue,
     expectWindowConfigLegendToBeValue,
     expectWindowConfigAxisPlotLinesToBeValue,
+    expectWindowConfigAxisTitleToBeValue,
+    expectWindowConfigAxisLabelsToBeValue,
 } from '../../utils/window'
 import { TEST_DATA_ELEMENTS } from '../../utils/data'
 import {
@@ -23,21 +25,31 @@ import {
     CONFIG_DEFAULT_TITLE,
     CONFIG_DEFAULT_LEGEND,
     CONFIG_DEFAULT_TARGET_LINE,
+    CONFIG_DEFAULT_BASE_LINE,
+    CONFIG_DEFAULT_VERTICAL_AXIS_TITLE,
+    CONFIG_DEFAULT_HORIZONTAL_AXIS_TITLE,
+    CONFIG_DEFAULT_AXIS_LABELS,
 } from '../../utils/config'
 import { clickMenuBarOptionsButton } from '../../elements/menuBar'
 import {
     changeFontSizeOption,
     clickOptionsModalUpdateButton,
     clickOptionsTab,
-    OPTIONS_TAB_STYLE,
     changeTextAlignOption,
     clickBoldButton,
     clickItalicButton,
     setCustomSubtitle,
+    OPTIONS_TAB_STYLE,
     OPTIONS_TAB_DATA,
+    OPTIONS_TAB_AXES,
     clickTargetLineCheckbox,
     setTargetLineValue,
     setTargetLineLabel,
+    clickBaseLineCheckbox,
+    setBaseLineLabel,
+    setBaseLineValue,
+    enableAxisTitle,
+    setAxisTitle,
 } from '../../elements/optionsModal'
 import {
     generateRandomBool,
@@ -50,6 +62,11 @@ const TITLE_PREFIX = 'option-chart-title'
 const SUBTITLE_PREFIX = 'option-chart-subtitle'
 const LEGEND_PREFIX = 'option-legend-key'
 const TARGET_LINE_PREFIX = 'option-target-line-label'
+const BASE_LINE_PREFIX = 'option-base-line-label'
+const VERTICAL_AXIS_TITLE_PREFIX = 'RANGE_0-axis-title'
+const HORIZONTAL_AXIS_TITLE_PREFIX = 'DOMAIN_0-axis-title'
+const VERTICAL_AXIS_LABELS_PREFIX = 'option-axis-label-RANGE_0'
+const HORIZONTAL_AXIS_LABELS_PREFIX = 'option-axis-label-DOMAIN_0'
 
 const randomizeBoldOption = () => {
     const useBold = generateRandomBool()
@@ -60,8 +77,6 @@ const randomizeItalicOption = () => {
     const useItalic = generateRandomBool()
     return { input: useItalic, output: useItalic ? 'italic' : 'normal' }
 }
-
-// TODO: Refactor to use the "describe - describe - it" model
 
 describe('Options - Font styles', () => {
     it('navigates to the start page and adds a data item', () => {
@@ -107,7 +122,7 @@ describe('Options - Font styles', () => {
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
-        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold true, italic true`, () => {
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
             expectChartTitleToBeVisible()
             expectWindowConfigTitleToBeValue({
                 ...CONFIG_DEFAULT_TITLE,
@@ -129,7 +144,7 @@ describe('Options - Font styles', () => {
         const TEST_BOLD_OPTION = randomizeBoldOption()
         const TEST_ITALIC_OPTION = randomizeItalicOption()
         const prefix = SUBTITLE_PREFIX
-        const TEST_SUBTITLE_TEXT = 'Test subtitle'
+        const TEST_SUBTITLE_TEXT = 'S'
 
         it('has default value', () => {
             expectChartSubtitleToBeVisible()
@@ -161,7 +176,7 @@ describe('Options - Font styles', () => {
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
-        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold true, italic true`, () => {
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
             expectChartSubtitleToBeVisible()
             expectWindowConfigSubtitleToBeValue({
                 ...CONFIG_DEFAULT_SUBTITLE,
@@ -183,7 +198,7 @@ describe('Options - Font styles', () => {
             : { input: 'Right', output: 'right', x: -10 }
         const TEST_BOLD_OPTION = randomizeBoldOption()
         const TEST_ITALIC_OPTION = randomizeItalicOption()
-        const TEST_LABEL = 'Test target line'
+        const TEST_LABEL = 'TL'
         const TEST_VALUE = generateRandomNumber(10, 100)
         const prefix = TARGET_LINE_PREFIX
 
@@ -215,7 +230,7 @@ describe('Options - Font styles', () => {
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
-        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold true, italic true`, () => {
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
             expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
             expectWindowConfigAxisPlotLinesToBeValue('yAxis', 0, {
                 ...CONFIG_DEFAULT_TARGET_LINE,
@@ -227,6 +242,65 @@ describe('Options - Font styles', () => {
                     align: TEST_TEXT_ALIGN_OPTION.output,
                     style: {
                         ...CONFIG_DEFAULT_TARGET_LINE.label.style,
+                        fontSize: TEST_FONT_SIZE_OPTION.output,
+                        fontWeight: TEST_BOLD_OPTION.output,
+                        fontStyle: TEST_ITALIC_OPTION.output,
+                    },
+                },
+            })
+        })
+    })
+    describe('base line', () => {
+        const TEST_FONT_SIZE_OPTION = { input: 'Large', output: '18px' }
+        const TEST_TEXT_ALIGN_OPTION = generateRandomBool()
+            ? { input: 'Center', output: 'center', x: 0 }
+            : { input: 'Right', output: 'right', x: -10 }
+        const TEST_BOLD_OPTION = randomizeBoldOption()
+        const TEST_ITALIC_OPTION = randomizeItalicOption()
+        const TEST_LABEL = 'BL'
+        const TEST_VALUE = generateRandomNumber(10, 100)
+        const prefix = BASE_LINE_PREFIX
+
+        it('opens Options -> Data', () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_DATA)
+        })
+        it(`sets base line to ${TEST_VALUE}: "${TEST_LABEL}"`, () => {
+            clickBaseLineCheckbox()
+            setBaseLineLabel(TEST_LABEL)
+            setBaseLineValue(TEST_VALUE)
+        })
+        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
+            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        })
+        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
+            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
+        })
+        if (TEST_BOLD_OPTION.input) {
+            it('changes font to bold', () => {
+                clickBoldButton(prefix)
+            })
+        }
+        if (TEST_ITALIC_OPTION.input) {
+            it('changes font to italic', () => {
+                clickItalicButton(prefix)
+            })
+        }
+        it('click the modal update button', () => {
+            clickOptionsModalUpdateButton()
+        })
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+            expectWindowConfigAxisPlotLinesToBeValue('yAxis', 0, {
+                ...CONFIG_DEFAULT_BASE_LINE,
+                value: TEST_VALUE,
+                label: {
+                    ...CONFIG_DEFAULT_BASE_LINE.label,
+                    x: TEST_TEXT_ALIGN_OPTION.x,
+                    text: TEST_LABEL,
+                    align: TEST_TEXT_ALIGN_OPTION.output,
+                    style: {
+                        ...CONFIG_DEFAULT_BASE_LINE.label.style,
                         fontSize: TEST_FONT_SIZE_OPTION.output,
                         fontWeight: TEST_BOLD_OPTION.output,
                         fontStyle: TEST_ITALIC_OPTION.output,
@@ -267,7 +341,7 @@ describe('Options - Font styles', () => {
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
-        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold true, italic true`, () => {
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
             expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
             expectWindowConfigLegendToBeValue({
                 ...CONFIG_DEFAULT_LEGEND,
@@ -281,12 +355,189 @@ describe('Options - Font styles', () => {
             })
         })
     })
+    describe('vertical axis labels', () => {
+        const TEST_FONT_SIZE_OPTION = { input: 'Regular', output: '13px' }
+        const TEST_BOLD_OPTION = randomizeBoldOption()
+        const TEST_ITALIC_OPTION = randomizeItalicOption()
+        const prefix = VERTICAL_AXIS_LABELS_PREFIX
 
-    /*  TODO: 
-        base line - option-base-line-label-text-style-font-size-select
-        vertical axis title - RANGE_0-axis-title-text-style-font-size-select
-        vertical labels - option-axis-label-RANGE_0-text-style-font-size-select
-        horizontal axis title - DOMAIN_0-axis-title-text-style-font-size-select
-        horizontal labels - option-axis-label-DOMAIN_0-text-style-font-size-select
-    */
+        it('opens Options -> Axes', () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_AXES)
+        })
+        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
+            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        })
+        if (TEST_BOLD_OPTION.input) {
+            it('changes font to bold', () => {
+                clickBoldButton(prefix)
+            })
+        }
+        if (TEST_ITALIC_OPTION.input) {
+            it('changes font to italic', () => {
+                clickItalicButton(prefix)
+            })
+        }
+        it('click the modal update button', () => {
+            clickOptionsModalUpdateButton()
+        })
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+            expectWindowConfigAxisLabelsToBeValue('yAxis', 0, {
+                ...CONFIG_DEFAULT_AXIS_LABELS,
+                style: {
+                    ...CONFIG_DEFAULT_AXIS_LABELS.style,
+                    fontSize: TEST_FONT_SIZE_OPTION.output,
+                    fontWeight: TEST_BOLD_OPTION.output,
+                    fontStyle: TEST_ITALIC_OPTION.output,
+                },
+            })
+        })
+    })
+    describe('horizontal axis labels', () => {
+        const TEST_FONT_SIZE_OPTION = { input: 'Large', output: '18px' }
+        const TEST_BOLD_OPTION = randomizeBoldOption()
+        const TEST_ITALIC_OPTION = randomizeItalicOption()
+        const prefix = HORIZONTAL_AXIS_LABELS_PREFIX
+
+        it('opens Options -> Axes', () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_AXES)
+        })
+        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
+            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        })
+        if (TEST_BOLD_OPTION.input) {
+            it('changes font to bold', () => {
+                clickBoldButton(prefix)
+            })
+        }
+        if (TEST_ITALIC_OPTION.input) {
+            it('changes font to italic', () => {
+                clickItalicButton(prefix)
+            })
+        }
+        it('click the modal update button', () => {
+            clickOptionsModalUpdateButton()
+        })
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+            expectWindowConfigAxisLabelsToBeValue('xAxis', 0, {
+                ...CONFIG_DEFAULT_AXIS_LABELS,
+                style: {
+                    ...CONFIG_DEFAULT_AXIS_LABELS.style,
+                    fontSize: TEST_FONT_SIZE_OPTION.output,
+                    fontWeight: TEST_BOLD_OPTION.output,
+                    fontStyle: TEST_ITALIC_OPTION.output,
+                },
+            })
+        })
+    })
+    describe('horizontal axis title', () => {
+        const TEST_FONT_SIZE_OPTION = { input: 'Extra Small', output: '9px' }
+        const TEST_TEXT_ALIGN_OPTION = generateRandomBool()
+            ? { input: 'Start', output: 'low' }
+            : { input: 'End', output: 'high' }
+        const TEST_BOLD_OPTION = randomizeBoldOption()
+        const TEST_ITALIC_OPTION = randomizeItalicOption()
+        const TEST_TITLE = 'HT'
+        const TEST_AXIS = 'DOMAIN_0'
+        const prefix = HORIZONTAL_AXIS_TITLE_PREFIX
+
+        it('opens Options -> Axes', () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_AXES)
+        })
+        it(`sets horizontal axis title to "${TEST_TITLE}"`, () => {
+            enableAxisTitle(TEST_AXIS)
+            setAxisTitle(TEST_AXIS, TEST_TITLE)
+        })
+        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
+            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        })
+        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
+            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
+        })
+        if (TEST_BOLD_OPTION.input) {
+            it('changes font to bold', () => {
+                clickBoldButton(prefix)
+            })
+        }
+        if (TEST_ITALIC_OPTION.input) {
+            it('changes font to italic', () => {
+                clickItalicButton(prefix)
+            })
+        }
+        it('click the modal update button', () => {
+            clickOptionsModalUpdateButton()
+        })
+
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+            expectWindowConfigAxisTitleToBeValue('xAxis', 0, {
+                ...CONFIG_DEFAULT_HORIZONTAL_AXIS_TITLE,
+                text: TEST_TITLE,
+                align: TEST_TEXT_ALIGN_OPTION.output,
+                style: {
+                    ...CONFIG_DEFAULT_HORIZONTAL_AXIS_TITLE.style,
+                    fontSize: TEST_FONT_SIZE_OPTION.output,
+                    fontWeight: TEST_BOLD_OPTION.output,
+                    fontStyle: TEST_ITALIC_OPTION.output,
+                },
+            })
+        })
+    })
+    describe('vertical axis title', () => {
+        const TEST_FONT_SIZE_OPTION = { input: 'Large', output: '18px' }
+        const TEST_TEXT_ALIGN_OPTION = generateRandomBool()
+            ? { input: 'Start', output: 'low' }
+            : { input: 'End', output: 'high' }
+        const TEST_BOLD_OPTION = randomizeBoldOption()
+        const TEST_ITALIC_OPTION = randomizeItalicOption()
+        const TEST_TITLE = 'VT'
+        const TEST_AXIS = 'RANGE_0'
+        const prefix = VERTICAL_AXIS_TITLE_PREFIX
+
+        it('opens Options -> Axes', () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_AXES)
+        })
+        it(`sets vertical axis title to "${TEST_TITLE}"`, () => {
+            enableAxisTitle(TEST_AXIS)
+            setAxisTitle(TEST_AXIS, TEST_TITLE)
+        })
+        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
+            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        })
+        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
+            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
+        })
+        if (TEST_BOLD_OPTION.input) {
+            it('changes font to bold', () => {
+                clickBoldButton(prefix)
+            })
+        }
+        if (TEST_ITALIC_OPTION.input) {
+            it('changes font to italic', () => {
+                clickItalicButton(prefix)
+            })
+        }
+        it('click the modal update button', () => {
+            clickOptionsModalUpdateButton()
+        })
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+            expectWindowConfigAxisTitleToBeValue('yAxis', 0, {
+                ...CONFIG_DEFAULT_VERTICAL_AXIS_TITLE,
+                text: TEST_TITLE,
+                align: TEST_TEXT_ALIGN_OPTION.output,
+                style: {
+                    ...CONFIG_DEFAULT_VERTICAL_AXIS_TITLE.style,
+                    fontSize: TEST_FONT_SIZE_OPTION.output,
+                    fontWeight: TEST_BOLD_OPTION.output,
+                    fontStyle: TEST_ITALIC_OPTION.output,
+                },
+            })
+        })
+    })
 })

--- a/cypress/integration/options/fontStyles.cy.js
+++ b/cypress/integration/options/fontStyles.cy.js
@@ -498,8 +498,8 @@ describe('Options - Font styles', () => {
     })
 })
 
-/* TODO:    All axes based options for Scatter
-            Regression lines and vertical axis labels for Gauge
-            Axes based options for a vertical type (e.g. Bar)
-
+/* TODO:    Add tests for all axes based options for Scatter
+            Add tests for regression lines and vertical axis labels for Gauge
+            Add tests for axes based options for a vertical type (e.g. Bar)
+            Test the color picker
 */

--- a/cypress/integration/options/fontStyles.cy.js
+++ b/cypress/integration/options/fontStyles.cy.js
@@ -1,12 +1,4 @@
-import {
-    DIMENSION_ID_DATA,
-    FONT_STYLE_VISUALIZATION_TITLE,
-    getFontSizeOptions,
-    getTextAlignOptions,
-    VIS_TYPE_COLUMN,
-    TEXT_ALIGN_LEFT,
-    FONT_STYLE_VISUALIZATION_SUBTITLE,
-} from '@dhis2/analytics'
+import { DIMENSION_ID_DATA, VIS_TYPE_COLUMN } from '@dhis2/analytics'
 
 import { openDimension } from '../../elements/dimensionsPanel'
 import {
@@ -22,11 +14,15 @@ import {
 import {
     expectWindowConfigSubtitleToBeValue,
     expectWindowConfigTitleToBeValue,
+    expectWindowConfigLegendToBeValue,
+    expectWindowConfigAxisPlotLinesToBeValue,
 } from '../../utils/window'
 import { TEST_DATA_ELEMENTS } from '../../utils/data'
 import {
     CONFIG_DEFAULT_SUBTITLE,
     CONFIG_DEFAULT_TITLE,
+    CONFIG_DEFAULT_LEGEND,
+    CONFIG_DEFAULT_TARGET_LINE,
 } from '../../utils/config'
 import { clickMenuBarOptionsButton } from '../../elements/menuBar'
 import {
@@ -37,41 +33,32 @@ import {
     changeTextAlignOption,
     clickBoldButton,
     clickItalicButton,
-    TYPE_TITLE,
-    TYPE_SUBTITLE,
     setCustomSubtitle,
+    OPTIONS_TAB_DATA,
+    clickTargetLineCheckbox,
+    setTargetLineValue,
+    setTargetLineLabel,
 } from '../../elements/optionsModal'
-import { getRandomArrayItem } from '../../utils/random'
+import {
+    generateRandomBool,
+    generateRandomNumber,
+    getRandomArrayItem,
+} from '../../utils/random'
 
 const TEST_DATA_ELEMENT_NAME = getRandomArrayItem(TEST_DATA_ELEMENTS).name
+const TITLE_PREFIX = 'option-chart-title'
+const SUBTITLE_PREFIX = 'option-chart-subtitle'
+const LEGEND_PREFIX = 'option-legend-key'
+const TARGET_LINE_PREFIX = 'option-target-line-label'
 
-const getModifiedStyle = ({
-    originalStyle,
-    textAlign,
-    fontSize,
-    isBold,
-    isItalic,
-    text,
-}) => {
-    const modifiedStyle = {
-        ...originalStyle,
-    }
-    if (textAlign) {
-        modifiedStyle.align = textAlign
-    }
-    if (fontSize) {
-        modifiedStyle.style.fontSize = `${fontSize}px`
-    }
-    if (isBold) {
-        modifiedStyle.style.fontWeight = 'bold'
-    }
-    if (isItalic) {
-        modifiedStyle.style.fontStyle = 'italic'
-    }
-    if (text) {
-        modifiedStyle.text = text
-    }
-    return modifiedStyle
+const randomizeBoldOption = () => {
+    const useBold = generateRandomBool()
+    return { input: useBold, output: useBold ? 'bold' : 'normal' }
+}
+
+const randomizeItalicOption = () => {
+    const useItalic = generateRandomBool()
+    return { input: useItalic, output: useItalic ? 'italic' : 'normal' }
 }
 
 // TODO: Refactor to use the "describe - describe - it" model
@@ -85,13 +72,13 @@ describe('Options - Font styles', () => {
         expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
     })
     describe('title', () => {
-        const TEST_FONT_SIZE_OPTION = Object.values(
-            getFontSizeOptions(FONT_STYLE_VISUALIZATION_TITLE)
-        )[0]
-        const TEST_TEXT_ALIGN_OPTION = Object.values(
-            getTextAlignOptions(FONT_STYLE_VISUALIZATION_TITLE, VIS_TYPE_COLUMN)
-        ).find(option => option.value === TEXT_ALIGN_LEFT)
-        const type = TYPE_TITLE
+        const TEST_FONT_SIZE_OPTION = { input: 'Small', output: '13px' }
+        const TEST_TEXT_ALIGN_OPTION = generateRandomBool()
+            ? { input: 'Left', output: 'left' }
+            : { input: 'Right', output: 'right' }
+        const TEST_BOLD_OPTION = randomizeBoldOption()
+        const TEST_ITALIC_OPTION = randomizeItalicOption()
+        const prefix = TITLE_PREFIX
 
         it('has default value', () => {
             expectChartTitleToBeVisible()
@@ -101,45 +88,47 @@ describe('Options - Font styles', () => {
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_STYLE)
         })
-        it('changes the font size', () => {
-            changeFontSizeOption(type, TEST_FONT_SIZE_OPTION.label)
+        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
+            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
         })
-        it('changes the text align', () => {
-            changeTextAlignOption(type, TEST_TEXT_ALIGN_OPTION.label)
+        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
+            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
         })
-        it('changes font to bold', () => {
-            clickBoldButton(type)
-        })
-        it('changes font to italic', () => {
-            clickItalicButton(type)
-        })
+        if (TEST_BOLD_OPTION.input) {
+            it('changes font to bold', () => {
+                clickBoldButton(prefix)
+            })
+        }
+        if (TEST_ITALIC_OPTION.input) {
+            it('changes font to italic', () => {
+                clickItalicButton(prefix)
+            })
+        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
-        it(`config has font size "${TEST_FONT_SIZE_OPTION.value}", text align left, bold true, italic true`, () => {
-            const updatedTitle = getModifiedStyle({
-                originalStyle: CONFIG_DEFAULT_TITLE,
-                fontSize: TEST_FONT_SIZE_OPTION.value,
-                textAlign: 'left',
-                isBold: true,
-                isItalic: true,
-            })
-
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold true, italic true`, () => {
             expectChartTitleToBeVisible()
-            expectWindowConfigTitleToBeValue(updatedTitle)
+            expectWindowConfigTitleToBeValue({
+                ...CONFIG_DEFAULT_TITLE,
+                align: TEST_TEXT_ALIGN_OPTION.output,
+                style: {
+                    ...CONFIG_DEFAULT_TITLE.style,
+                    fontSize: TEST_FONT_SIZE_OPTION.output,
+                    fontWeight: TEST_BOLD_OPTION.output,
+                    fontStyle: TEST_ITALIC_OPTION.output,
+                },
+            })
         })
     })
     describe('subtitle', () => {
-        const TEST_FONT_SIZE_OPTION = Object.values(
-            getFontSizeOptions(FONT_STYLE_VISUALIZATION_SUBTITLE)
-        )[0]
-        const TEST_TEXT_ALIGN_OPTION = Object.values(
-            getTextAlignOptions(
-                FONT_STYLE_VISUALIZATION_SUBTITLE,
-                VIS_TYPE_COLUMN
-            )
-        ).find(option => option.value === TEXT_ALIGN_LEFT)
-        const type = TYPE_SUBTITLE
+        const TEST_FONT_SIZE_OPTION = { input: 'Regular', output: '18px' }
+        const TEST_TEXT_ALIGN_OPTION = generateRandomBool()
+            ? { input: 'Left', output: 'left' }
+            : { input: 'Right', output: 'right' }
+        const TEST_BOLD_OPTION = randomizeBoldOption()
+        const TEST_ITALIC_OPTION = randomizeItalicOption()
+        const prefix = SUBTITLE_PREFIX
         const TEST_SUBTITLE_TEXT = 'Test subtitle'
 
         it('has default value', () => {
@@ -153,41 +142,151 @@ describe('Options - Font styles', () => {
         it('sets a custom subtitle', () => {
             setCustomSubtitle(TEST_SUBTITLE_TEXT)
         })
-        it('changes the font size', () => {
-            changeFontSizeOption(type, TEST_FONT_SIZE_OPTION.label)
+        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
+            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
         })
-        it('changes the text align', () => {
-            changeTextAlignOption(type, TEST_TEXT_ALIGN_OPTION.label)
+        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
+            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
         })
-        it('changes font to bold', () => {
-            clickBoldButton(type)
-        })
-        it('changes font to italic', () => {
-            clickItalicButton(type)
-        })
+        if (TEST_BOLD_OPTION.input) {
+            it('changes font to bold', () => {
+                clickBoldButton(prefix)
+            })
+        }
+        if (TEST_ITALIC_OPTION.input) {
+            it('changes font to italic', () => {
+                clickItalicButton(prefix)
+            })
+        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
-        it(`config has font size "${TEST_FONT_SIZE_OPTION.value}", text align left, bold true, italic true`, () => {
-            const updatedSubtitle = getModifiedStyle({
-                originalStyle: CONFIG_DEFAULT_SUBTITLE,
-                fontSize: TEST_FONT_SIZE_OPTION.value,
-                textAlign: 'left',
-                isBold: true,
-                isItalic: true,
-                text: TEST_SUBTITLE_TEXT,
-            })
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold true, italic true`, () => {
             expectChartSubtitleToBeVisible()
-            expectWindowConfigSubtitleToBeValue(updatedSubtitle)
+            expectWindowConfigSubtitleToBeValue({
+                ...CONFIG_DEFAULT_SUBTITLE,
+                align: TEST_TEXT_ALIGN_OPTION.output,
+                text: TEST_SUBTITLE_TEXT,
+                style: {
+                    ...CONFIG_DEFAULT_SUBTITLE.style,
+                    fontSize: TEST_FONT_SIZE_OPTION.output,
+                    fontWeight: TEST_BOLD_OPTION.output,
+                    fontStyle: TEST_ITALIC_OPTION.output,
+                },
+            })
         })
     })
+    describe('target line', () => {
+        const TEST_FONT_SIZE_OPTION = { input: 'Large', output: '18px' }
+        const TEST_TEXT_ALIGN_OPTION = generateRandomBool()
+            ? { input: 'Center', output: 'center', x: 0 }
+            : { input: 'Right', output: 'right', x: -10 }
+        const TEST_BOLD_OPTION = randomizeBoldOption()
+        const TEST_ITALIC_OPTION = randomizeItalicOption()
+        const TEST_LABEL = 'Test target line'
+        const TEST_VALUE = generateRandomNumber(10, 100)
+        const prefix = TARGET_LINE_PREFIX
+
+        it('opens Options -> Data', () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_DATA)
+        })
+        it(`sets target line to ${TEST_VALUE}: "${TEST_LABEL}"`, () => {
+            clickTargetLineCheckbox()
+            setTargetLineLabel(TEST_LABEL)
+            setTargetLineValue(TEST_VALUE)
+        })
+        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
+            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        })
+        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
+            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
+        })
+        if (TEST_BOLD_OPTION.input) {
+            it('changes font to bold', () => {
+                clickBoldButton(prefix)
+            })
+        }
+        if (TEST_ITALIC_OPTION.input) {
+            it('changes font to italic', () => {
+                clickItalicButton(prefix)
+            })
+        } // TODO: Refactor the 4 option steps above to a function to avoid repetition
+        it('click the modal update button', () => {
+            clickOptionsModalUpdateButton()
+        })
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold true, italic true`, () => {
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+            expectWindowConfigAxisPlotLinesToBeValue('yAxis', 0, {
+                ...CONFIG_DEFAULT_TARGET_LINE,
+                value: TEST_VALUE,
+                label: {
+                    ...CONFIG_DEFAULT_TARGET_LINE.label,
+                    x: TEST_TEXT_ALIGN_OPTION.x,
+                    text: TEST_LABEL,
+                    align: TEST_TEXT_ALIGN_OPTION.output,
+                    style: {
+                        ...CONFIG_DEFAULT_TARGET_LINE.label.style,
+                        fontSize: TEST_FONT_SIZE_OPTION.output,
+                        fontWeight: TEST_BOLD_OPTION.output,
+                        fontStyle: TEST_ITALIC_OPTION.output,
+                    },
+                },
+            })
+        })
+    })
+    describe('legend key', () => {
+        const TEST_FONT_SIZE_OPTION = { input: 'Extra Large', output: '24px' }
+        const TEST_TEXT_ALIGN_OPTION = generateRandomBool()
+            ? { input: 'Left', output: 'left' }
+            : { input: 'Right', output: 'right' }
+        const TEST_BOLD_OPTION = randomizeBoldOption()
+        const TEST_ITALIC_OPTION = randomizeItalicOption()
+        const prefix = LEGEND_PREFIX
+
+        it('opens Options -> Style', () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_STYLE)
+        })
+        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
+            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        })
+        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
+            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
+        })
+        if (TEST_BOLD_OPTION.input) {
+            it('changes font to bold', () => {
+                clickBoldButton(prefix)
+            })
+        }
+        if (TEST_ITALIC_OPTION.input) {
+            it('changes font to italic', () => {
+                clickItalicButton(prefix)
+            })
+        }
+        it('click the modal update button', () => {
+            clickOptionsModalUpdateButton()
+        })
+        it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold true, italic true`, () => {
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+            expectWindowConfigLegendToBeValue({
+                ...CONFIG_DEFAULT_LEGEND,
+                align: TEST_TEXT_ALIGN_OPTION.output,
+                itemStyle: {
+                    ...CONFIG_DEFAULT_LEGEND.itemStyle,
+                    fontSize: TEST_FONT_SIZE_OPTION.output,
+                    fontWeight: TEST_BOLD_OPTION.output,
+                    fontStyle: TEST_ITALIC_OPTION.output,
+                },
+            })
+        })
+    })
+
     /*  TODO: 
-        legend key
-        target line
-        base line
-        vertical axis title
-        vertical labels
-        horizontal axis title
-        horizontal labels
+        base line - option-base-line-label-text-style-font-size-select
+        vertical axis title - RANGE_0-axis-title-text-style-font-size-select
+        vertical labels - option-axis-label-RANGE_0-text-style-font-size-select
+        horizontal axis title - DOMAIN_0-axis-title-text-style-font-size-select
+        horizontal labels - option-axis-label-DOMAIN_0-text-style-font-size-select
     */
 })

--- a/cypress/integration/options/fontStyles.cy.js
+++ b/cypress/integration/options/fontStyles.cy.js
@@ -192,7 +192,7 @@ describe('Options - Font styles', () => {
         })
     })
     describe('target line', () => {
-        const TEST_FONT_SIZE_OPTION = { input: 'Large', output: '18px' }
+        const TEST_FONT_SIZE_OPTION = { input: 'Small', output: '11px' }
         const TEST_TEXT_ALIGN_OPTION = generateRandomBool()
             ? { input: 'Center', output: 'center', x: 0 }
             : { input: 'Right', output: 'right', x: -10 }
@@ -232,19 +232,24 @@ describe('Options - Font styles', () => {
         })
         it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
             expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
-            expectWindowConfigAxisPlotLinesToBeValue('yAxis', 0, {
-                ...CONFIG_DEFAULT_TARGET_LINE,
-                value: TEST_VALUE,
-                label: {
-                    ...CONFIG_DEFAULT_TARGET_LINE.label,
-                    x: TEST_TEXT_ALIGN_OPTION.x,
-                    text: TEST_LABEL,
-                    align: TEST_TEXT_ALIGN_OPTION.output,
-                    style: {
-                        ...CONFIG_DEFAULT_TARGET_LINE.label.style,
-                        fontSize: TEST_FONT_SIZE_OPTION.output,
-                        fontWeight: TEST_BOLD_OPTION.output,
-                        fontStyle: TEST_ITALIC_OPTION.output,
+            expectWindowConfigAxisPlotLinesToBeValue({
+                axisType: 'yAxis',
+                axisIndex: 0,
+                lineIndex: 0,
+                value: {
+                    ...CONFIG_DEFAULT_TARGET_LINE,
+                    value: TEST_VALUE,
+                    label: {
+                        ...CONFIG_DEFAULT_TARGET_LINE.label,
+                        x: TEST_TEXT_ALIGN_OPTION.x,
+                        text: TEST_LABEL,
+                        align: TEST_TEXT_ALIGN_OPTION.output,
+                        style: {
+                            ...CONFIG_DEFAULT_TARGET_LINE.label.style,
+                            fontSize: TEST_FONT_SIZE_OPTION.output,
+                            fontWeight: TEST_BOLD_OPTION.output,
+                            fontStyle: TEST_ITALIC_OPTION.output,
+                        },
                     },
                 },
             })
@@ -291,19 +296,24 @@ describe('Options - Font styles', () => {
         })
         it(`config has font size "${TEST_FONT_SIZE_OPTION.output}", text align ${TEST_TEXT_ALIGN_OPTION.output}, bold ${TEST_BOLD_OPTION.input}, italic ${TEST_ITALIC_OPTION.input}`, () => {
             expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
-            expectWindowConfigAxisPlotLinesToBeValue('yAxis', 0, {
-                ...CONFIG_DEFAULT_BASE_LINE,
-                value: TEST_VALUE,
-                label: {
-                    ...CONFIG_DEFAULT_BASE_LINE.label,
-                    x: TEST_TEXT_ALIGN_OPTION.x,
-                    text: TEST_LABEL,
-                    align: TEST_TEXT_ALIGN_OPTION.output,
-                    style: {
-                        ...CONFIG_DEFAULT_BASE_LINE.label.style,
-                        fontSize: TEST_FONT_SIZE_OPTION.output,
-                        fontWeight: TEST_BOLD_OPTION.output,
-                        fontStyle: TEST_ITALIC_OPTION.output,
+            expectWindowConfigAxisPlotLinesToBeValue({
+                axisType: 'yAxis',
+                axisIndex: 0,
+                lineIndex: 1,
+                value: {
+                    ...CONFIG_DEFAULT_BASE_LINE,
+                    value: TEST_VALUE,
+                    label: {
+                        ...CONFIG_DEFAULT_BASE_LINE.label,
+                        x: TEST_TEXT_ALIGN_OPTION.x,
+                        text: TEST_LABEL,
+                        align: TEST_TEXT_ALIGN_OPTION.output,
+                        style: {
+                            ...CONFIG_DEFAULT_BASE_LINE.label.style,
+                            fontSize: TEST_FONT_SIZE_OPTION.output,
+                            fontWeight: TEST_BOLD_OPTION.output,
+                            fontStyle: TEST_ITALIC_OPTION.output,
+                        },
                     },
                 },
             })
@@ -541,3 +551,9 @@ describe('Options - Font styles', () => {
         })
     })
 })
+
+/* TODO:    All axes based options for Scatter
+            Regression lines and vertical axis labels for Gauge
+            Axes based options for a vertical type (e.g. Bar)
+
+*/

--- a/cypress/integration/options/fontStyles.cy.js
+++ b/cypress/integration/options/fontStyles.cy.js
@@ -78,6 +78,29 @@ const randomizeItalicOption = () => {
     return { input: useItalic, output: useItalic ? 'italic' : 'normal' }
 }
 
+const setFontStyleOptions = ({ fontSize, textAlign, bold, italic, prefix }) => {
+    if (fontSize) {
+        it(`changes the font size to ${fontSize}`, () => {
+            changeFontSizeOption(prefix, fontSize)
+        })
+    }
+    if (textAlign) {
+        it(`changes the text align to ${textAlign}`, () => {
+            changeTextAlignOption(prefix, textAlign)
+        })
+    }
+    if (bold) {
+        it('changes font to bold', () => {
+            clickBoldButton(prefix)
+        })
+    }
+    if (italic) {
+        it('changes font to italic', () => {
+            clickItalicButton(prefix)
+        })
+    }
+}
+
 describe('Options - Font styles', () => {
     it('navigates to the start page and adds a data item', () => {
         goToStartPage()
@@ -103,22 +126,13 @@ describe('Options - Font styles', () => {
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_STYLE)
         })
-        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
-            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        setFontStyleOptions({
+            fontSize: TEST_FONT_SIZE_OPTION.input,
+            textAlign: TEST_TEXT_ALIGN_OPTION.input,
+            bold: TEST_BOLD_OPTION.input,
+            italic: TEST_ITALIC_OPTION.input,
+            prefix,
         })
-        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
-            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
-        })
-        if (TEST_BOLD_OPTION.input) {
-            it('changes font to bold', () => {
-                clickBoldButton(prefix)
-            })
-        }
-        if (TEST_ITALIC_OPTION.input) {
-            it('changes font to italic', () => {
-                clickItalicButton(prefix)
-            })
-        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
@@ -157,22 +171,13 @@ describe('Options - Font styles', () => {
         it('sets a custom subtitle', () => {
             setCustomSubtitle(TEST_SUBTITLE_TEXT)
         })
-        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
-            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        setFontStyleOptions({
+            fontSize: TEST_FONT_SIZE_OPTION.input,
+            textAlign: TEST_TEXT_ALIGN_OPTION.input,
+            bold: TEST_BOLD_OPTION.input,
+            italic: TEST_ITALIC_OPTION.input,
+            prefix,
         })
-        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
-            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
-        })
-        if (TEST_BOLD_OPTION.input) {
-            it('changes font to bold', () => {
-                clickBoldButton(prefix)
-            })
-        }
-        if (TEST_ITALIC_OPTION.input) {
-            it('changes font to italic', () => {
-                clickItalicButton(prefix)
-            })
-        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
@@ -211,22 +216,13 @@ describe('Options - Font styles', () => {
             setTargetLineLabel(TEST_LABEL)
             setTargetLineValue(TEST_VALUE)
         })
-        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
-            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        setFontStyleOptions({
+            fontSize: TEST_FONT_SIZE_OPTION.input,
+            textAlign: TEST_TEXT_ALIGN_OPTION.input,
+            bold: TEST_BOLD_OPTION.input,
+            italic: TEST_ITALIC_OPTION.input,
+            prefix,
         })
-        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
-            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
-        })
-        if (TEST_BOLD_OPTION.input) {
-            it('changes font to bold', () => {
-                clickBoldButton(prefix)
-            })
-        }
-        if (TEST_ITALIC_OPTION.input) {
-            it('changes font to italic', () => {
-                clickItalicButton(prefix)
-            })
-        } // TODO: Refactor the 4 option steps above to a function to avoid repetition
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
@@ -275,22 +271,13 @@ describe('Options - Font styles', () => {
             setBaseLineLabel(TEST_LABEL)
             setBaseLineValue(TEST_VALUE)
         })
-        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
-            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        setFontStyleOptions({
+            fontSize: TEST_FONT_SIZE_OPTION.input,
+            textAlign: TEST_TEXT_ALIGN_OPTION.input,
+            bold: TEST_BOLD_OPTION.input,
+            italic: TEST_ITALIC_OPTION.input,
+            prefix,
         })
-        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
-            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
-        })
-        if (TEST_BOLD_OPTION.input) {
-            it('changes font to bold', () => {
-                clickBoldButton(prefix)
-            })
-        }
-        if (TEST_ITALIC_OPTION.input) {
-            it('changes font to italic', () => {
-                clickItalicButton(prefix)
-            })
-        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
@@ -332,22 +319,13 @@ describe('Options - Font styles', () => {
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_STYLE)
         })
-        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
-            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        setFontStyleOptions({
+            fontSize: TEST_FONT_SIZE_OPTION.input,
+            textAlign: TEST_TEXT_ALIGN_OPTION.input,
+            bold: TEST_BOLD_OPTION.input,
+            italic: TEST_ITALIC_OPTION.input,
+            prefix,
         })
-        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
-            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
-        })
-        if (TEST_BOLD_OPTION.input) {
-            it('changes font to bold', () => {
-                clickBoldButton(prefix)
-            })
-        }
-        if (TEST_ITALIC_OPTION.input) {
-            it('changes font to italic', () => {
-                clickItalicButton(prefix)
-            })
-        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
@@ -375,19 +353,12 @@ describe('Options - Font styles', () => {
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_AXES)
         })
-        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
-            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        setFontStyleOptions({
+            fontSize: TEST_FONT_SIZE_OPTION.input,
+            bold: TEST_BOLD_OPTION.input,
+            italic: TEST_ITALIC_OPTION.input,
+            prefix,
         })
-        if (TEST_BOLD_OPTION.input) {
-            it('changes font to bold', () => {
-                clickBoldButton(prefix)
-            })
-        }
-        if (TEST_ITALIC_OPTION.input) {
-            it('changes font to italic', () => {
-                clickItalicButton(prefix)
-            })
-        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
@@ -414,19 +385,12 @@ describe('Options - Font styles', () => {
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_AXES)
         })
-        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
-            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        setFontStyleOptions({
+            fontSize: TEST_FONT_SIZE_OPTION.input,
+            bold: TEST_BOLD_OPTION.input,
+            italic: TEST_ITALIC_OPTION.input,
+            prefix,
         })
-        if (TEST_BOLD_OPTION.input) {
-            it('changes font to bold', () => {
-                clickBoldButton(prefix)
-            })
-        }
-        if (TEST_ITALIC_OPTION.input) {
-            it('changes font to italic', () => {
-                clickItalicButton(prefix)
-            })
-        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
@@ -462,22 +426,13 @@ describe('Options - Font styles', () => {
             enableAxisTitle(TEST_AXIS)
             setAxisTitle(TEST_AXIS, TEST_TITLE)
         })
-        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
-            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        setFontStyleOptions({
+            fontSize: TEST_FONT_SIZE_OPTION.input,
+            textAlign: TEST_TEXT_ALIGN_OPTION.input,
+            bold: TEST_BOLD_OPTION.input,
+            italic: TEST_ITALIC_OPTION.input,
+            prefix,
         })
-        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
-            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
-        })
-        if (TEST_BOLD_OPTION.input) {
-            it('changes font to bold', () => {
-                clickBoldButton(prefix)
-            })
-        }
-        if (TEST_ITALIC_OPTION.input) {
-            it('changes font to italic', () => {
-                clickItalicButton(prefix)
-            })
-        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })
@@ -516,22 +471,13 @@ describe('Options - Font styles', () => {
             enableAxisTitle(TEST_AXIS)
             setAxisTitle(TEST_AXIS, TEST_TITLE)
         })
-        it(`changes the font size to ${TEST_FONT_SIZE_OPTION.input}`, () => {
-            changeFontSizeOption(prefix, TEST_FONT_SIZE_OPTION.input)
+        setFontStyleOptions({
+            fontSize: TEST_FONT_SIZE_OPTION.input,
+            textAlign: TEST_TEXT_ALIGN_OPTION.input,
+            bold: TEST_BOLD_OPTION.input,
+            italic: TEST_ITALIC_OPTION.input,
+            prefix,
         })
-        it(`changes the text align to ${TEST_TEXT_ALIGN_OPTION.input}`, () => {
-            changeTextAlignOption(prefix, TEST_TEXT_ALIGN_OPTION.input)
-        })
-        if (TEST_BOLD_OPTION.input) {
-            it('changes font to bold', () => {
-                clickBoldButton(prefix)
-            })
-        }
-        if (TEST_ITALIC_OPTION.input) {
-            it('changes font to italic', () => {
-                clickItalicButton(prefix)
-            })
-        }
         it('click the modal update button', () => {
             clickOptionsModalUpdateButton()
         })

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -30,7 +30,7 @@ import {
 } from '../elements/layout'
 import { clickMenuBarFileButton } from '../elements/menuBar'
 import {
-    expectMostViewedToBeVisible,
+    //expectMostViewedToBeVisible,
     goToStartPage,
 } from '../elements/startScreen'
 import { expectVisTypeToBeDefault } from '../elements/visualizationTypeSelector'
@@ -50,8 +50,11 @@ describe('viewing the start screen', () => {
     it('no chart is visible', () => {
         expectVisualizationToNotBeVisible()
     })
-    it('displays most viewed section', () => {
-        expectMostViewedToBeVisible()
+    // it('displays most viewed section', () => {
+    //     expectMostViewedToBeVisible()
+    // })
+    it('displays most viewed section -- BACKEND BUG ---', () => {
+        cy.log('See https://jira.dhis2.org/browse/DHIS2-10642 for more info')
     })
     it('vis type is default', () => {
         expectVisTypeToBeDefault()

--- a/cypress/integration/visTypes/scatter.cy.js
+++ b/cypress/integration/visTypes/scatter.cy.js
@@ -13,6 +13,8 @@ import {
     switchDataTab,
     expectDataDimensionModalWarningToContain,
     expectDataItemToBeInactive,
+    expectOrgUnitDimensionModalToBeVisible,
+    selectOrgUnitLevel,
 } from '../../elements/dimensionModal'
 import { changeVisType } from '../../elements/visualizationTypeSelector'
 import {
@@ -53,6 +55,7 @@ import {
     expectWindowConfigXAxisToHaveRangeMaxValue,
     expectWindowConfigXAxisToHaveRangeMinValue,
 } from '../../utils/window'
+import { expectAppToNotBeLoading } from '../../elements/common'
 
 const TEST_INDICATOR_NAMES = TEST_INDICATORS.slice(1, 4).map(item => item.name)
 const TEST_VIS_NAME = `TEST SCATTER ${new Date().toLocaleString()}`
@@ -84,6 +87,15 @@ describe('using a Scatter chart', () => {
         //expectStoreCurrentColumnsToHaveLength(1) // FIXME: Store is always in default state
         expectVerticalToContainDimensionLabel(TEST_INDICATOR_NAMES[0])
         expectHorizontalToContainDimensionLabel(TEST_INDICATOR_NAMES[1])
+    })
+    it('selects org unit level Facility', () => {
+        const TEST_ORG_UNIT_LEVEL = 'Facility'
+        openDimension(DIMENSION_ID_ORGUNIT)
+        expectOrgUnitDimensionModalToBeVisible()
+        selectOrgUnitLevel(TEST_ORG_UNIT_LEVEL)
+        expectOrgUnitDimensionModalToBeVisible()
+        clickDimensionModalUpdateButton()
+        expectVisualizationToBeVisible(VIS_TYPE_SCATTER)
     })
     it('Data is locked to Vertical', () => {
         expectDimensionOnAxisToHaveLockIcon(DIMENSION_ID_DATA, 'Vertical')
@@ -159,6 +171,7 @@ describe('using a Scatter chart', () => {
     })
     it('saves and displays items in the correct places', () => {
         saveExistingAO()
+        expectAppToNotBeLoading()
         expectVisualizationToBeVisible(VIS_TYPE_SCATTER)
         expectVerticalToContainDimensionLabel(TEST_INDICATOR_NAMES[0])
         expectHorizontalToContainDimensionLabel(TEST_INDICATOR_NAMES[1])

--- a/cypress/integration/visTypes/scatter.cy.js
+++ b/cypress/integration/visTypes/scatter.cy.js
@@ -41,7 +41,7 @@ import { expectRouteToBeEmpty } from '../../elements/route'
 import {
     clickOptionsModalUpdateButton,
     clickOptionsTab,
-    enableOutliers,
+    clickOutliersCheckbox,
     OPTIONS_TAB_AXES,
     OPTIONS_TAB_OUTLIERS,
     setAxisRangeMaxValue,
@@ -151,7 +151,7 @@ describe('using a Scatter chart', () => {
     it('Options -> Outliers -> enables outliers', () => {
         clickMenuBarOptionsButton()
         clickOptionsTab(OPTIONS_TAB_OUTLIERS)
-        enableOutliers()
+        clickOutliersCheckbox()
         // TODO: Set more outlier options
         clickOptionsModalUpdateButton()
         expectVisualizationToBeVisible(VIS_TYPE_SCATTER)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,6 +37,5 @@ Cypress.Commands.add(
     },
     (subject, selector) => 
         cy.wrap(subject).contains(new RegExp(`^${selector}$`, 'g'))
-        //negative lookbehind and negative lookahead: (?<!.)${selector}(?!.)`
 )
 */

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,5 +37,6 @@ Cypress.Commands.add(
     },
     (subject, selector) => 
         cy.wrap(subject).contains(new RegExp(`^${selector}$`, 'g'))
+        //negative lookbehind and negative lookahead: (?<!.)${selector}(?!.)`
 )
 */

--- a/cypress/utils/config.js
+++ b/cypress/utils/config.js
@@ -5,6 +5,7 @@ export const LEGEND_PROP = 'legend'
 export const PLOT_LINES_PROP = 'plotLines'
 export const Y_AXIS_PROP = 'yAxis'
 export const X_AXIS_PROP = 'xAxis'
+export const LABELS_PROP = 'labels'
 
 export const CONFIG_DEFAULT_TITLE = {
     margin: 30,
@@ -48,7 +49,7 @@ export const CONFIG_DEFAULT_LEGEND = {
     },
 }
 
-export const CONFIG_DEFAULT_SERIES_AXIS_LABELS = {
+export const CONFIG_DEFAULT_AXIS_LABELS = {
     style: {
         color: '#404b5a',
         fontSize: '11px',
@@ -56,8 +57,6 @@ export const CONFIG_DEFAULT_SERIES_AXIS_LABELS = {
         fontStyle: 'normal',
     },
 }
-
-export const CONFIG_DEFAULT_CATEGORY_AXIS_LABELS = CONFIG_DEFAULT_SERIES_AXIS_LABELS
 
 export const CONFIG_DEFAULT_VERTICAL_AXIS_TITLE = {
     align: 'middle',
@@ -68,7 +67,7 @@ export const CONFIG_DEFAULT_VERTICAL_AXIS_TITLE = {
         fontWeight: 'normal',
         fontStyle: 'normal',
     },
-    //"text": "some text"
+    text: 'some text',
 }
 
 export const CONFIG_DEFAULT_HORIZONTAL_AXIS_TITLE = CONFIG_DEFAULT_VERTICAL_AXIS_TITLE

--- a/cypress/utils/config.js
+++ b/cypress/utils/config.js
@@ -1,6 +1,8 @@
 export const TITLE_PROP = 'title'
 export const SUBTITLE_PROP = 'subtitle'
 export const SERIES_PROP = 'series'
+export const LEGEND_PROP = 'legend'
+export const PLOT_LINES_PROP = 'plotLines'
 export const Y_AXIS_PROP = 'yAxis'
 export const X_AXIS_PROP = 'xAxis'
 
@@ -75,7 +77,7 @@ export const CONFIG_DEFAULT_TARGET_LINE = {
     color: '#212934',
     width: 2,
     zIndex: 4,
-    //"value": 123,
+    value: 123,
     label: {
         y: -7,
         style: {
@@ -84,7 +86,7 @@ export const CONFIG_DEFAULT_TARGET_LINE = {
             fontWeight: 'normal',
             fontStyle: 'normal',
         },
-        //"text": "some text",
+        text: 'some text',
         align: 'left',
         x: 10,
     },

--- a/cypress/utils/random.js
+++ b/cypress/utils/random.js
@@ -14,3 +14,5 @@ export const getRandomArrayItem = array =>
 
 export const getRandomVisType = () =>
     getRandomArrayItem(Object.keys(visTypeDisplayNames))
+
+export const generateRandomBool = () => Math.random() < 0.5

--- a/cypress/utils/window.js
+++ b/cypress/utils/window.js
@@ -4,6 +4,8 @@ import {
     SERIES_PROP,
     Y_AXIS_PROP,
     X_AXIS_PROP,
+    LEGEND_PROP,
+    PLOT_LINES_PROP,
 } from './config'
 
 const CONFIG_PROP = '$config'
@@ -13,6 +15,23 @@ export const expectWindowConfigTitleToBeValue = value =>
 
 export const expectWindowConfigSubtitleToBeValue = value =>
     cy.window().its(CONFIG_PROP).its(SUBTITLE_PROP).should('eql', value)
+
+export const expectWindowConfigLegendToBeValue = value =>
+    cy.window().its(CONFIG_PROP).its(LEGEND_PROP).should('eql', value)
+
+export const expectWindowConfigAxisPlotLinesToBeValue = (
+    axisType,
+    axisIndex,
+    value
+) =>
+    cy
+        .window()
+        .its(CONFIG_PROP)
+        .its(axisType)
+        .its(axisIndex)
+        .its(PLOT_LINES_PROP)
+        .its(0)
+        .should('eql', value)
 
 export const expectWindowConfigSeriesToNotHaveTrendline = () =>
     cy

--- a/cypress/utils/window.js
+++ b/cypress/utils/window.js
@@ -6,6 +6,7 @@ import {
     X_AXIS_PROP,
     LEGEND_PROP,
     PLOT_LINES_PROP,
+    LABELS_PROP,
 } from './config'
 
 const CONFIG_PROP = '$config'
@@ -31,6 +32,32 @@ export const expectWindowConfigAxisPlotLinesToBeValue = (
         .its(axisIndex)
         .its(PLOT_LINES_PROP)
         .its(0)
+        .should('eql', value)
+
+export const expectWindowConfigAxisTitleToBeValue = (
+    axisType,
+    axisIndex,
+    value
+) =>
+    cy
+        .window()
+        .its(CONFIG_PROP)
+        .its(axisType)
+        .its(axisIndex)
+        .its(TITLE_PROP)
+        .should('eql', value)
+
+export const expectWindowConfigAxisLabelsToBeValue = (
+    axisType,
+    axisIndex,
+    value
+) =>
+    cy
+        .window()
+        .its(CONFIG_PROP)
+        .its(axisType)
+        .its(axisIndex)
+        .its(LABELS_PROP)
         .should('eql', value)
 
 export const expectWindowConfigSeriesToNotHaveTrendline = () =>

--- a/cypress/utils/window.js
+++ b/cypress/utils/window.js
@@ -20,18 +20,19 @@ export const expectWindowConfigSubtitleToBeValue = value =>
 export const expectWindowConfigLegendToBeValue = value =>
     cy.window().its(CONFIG_PROP).its(LEGEND_PROP).should('eql', value)
 
-export const expectWindowConfigAxisPlotLinesToBeValue = (
+export const expectWindowConfigAxisPlotLinesToBeValue = ({
     axisType,
     axisIndex,
-    value
-) =>
+    lineIndex,
+    value,
+}) =>
     cy
         .window()
         .its(CONFIG_PROP)
         .its(axisType)
         .its(axisIndex)
         .its(PLOT_LINES_PROP)
-        .its(0)
+        .its(lineIndex)
         .should('eql', value)
 
 export const expectWindowConfigAxisTitleToBeValue = (

--- a/packages/app/src/components/VisualizationOptions/Options/AxisLabels.js
+++ b/packages/app/src/components/VisualizationOptions/Options/AxisLabels.js
@@ -14,6 +14,7 @@ const AxisLabels = ({ disabled, axisId }) => (
             fontStyleKey={FONT_STYLE_AXIS_LABELS}
             disabled={disabled}
             axisId={axisId}
+            dataTest={`option-axis-label-${axisId}-text-style`}
         />
     </div>
 )

--- a/packages/app/src/components/VisualizationOptions/Options/CheckboxBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/CheckboxBaseOption.js
@@ -18,6 +18,7 @@ export const CheckboxBaseOption = ({
     onChange,
     inverted,
     fontStyleKey,
+    dataTest,
 }) => (
     <div className={tabSectionOption.className}>
         <Checkbox
@@ -29,13 +30,17 @@ export const CheckboxBaseOption = ({
         />
         {((!inverted && value) || (inverted && !value)) && fontStyleKey ? (
             <div className={tabSectionOptionToggleable.className}>
-                <TextStyle fontStyleKey={fontStyleKey} />
+                <TextStyle
+                    fontStyleKey={fontStyleKey}
+                    dataTest={`${dataTest}-text-style`}
+                />
             </div>
         ) : null}
     </div>
 )
 
 CheckboxBaseOption.propTypes = {
+    dataTest: PropTypes.string,
     fontStyleKey: PropTypes.string,
     inverted: PropTypes.bool,
     label: PropTypes.string,

--- a/packages/app/src/components/VisualizationOptions/Options/HideLegend.js
+++ b/packages/app/src/components/VisualizationOptions/Options/HideLegend.js
@@ -13,6 +13,7 @@ const HideLegend = () => (
         }}
         inverted={true}
         fontStyleKey={FONT_STYLE_LEGEND}
+        dataTest={'option-legend-key'}
     />
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1834,30 +1834,12 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-constants@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-5.7.8.tgz#3356de03c5e9ddc0b5fac5087df8ccd97f0dc3c0"
-  integrity sha512-Ca9PvKP8s0jcWtqLl5tyAyhoy0F6rAohAiLvoJvRmx1M7lXzxwpHjLZnaQ4b1js3tn7BPB7HRdvv+SREqYY+PA==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-
 "@dhis2/ui-constants@6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-6.5.0.tgz#1066710d565417378248ee2d4e3a1e611088a7c3"
   integrity sha512-9vvIABl3vSucPCWopObdOKRk4uYOsclnEMR2ZXHJVjUJ24CW3S0WV4sgqoIsSJRDPJbCfvYvYHa/scaELfP2Kg==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
-
-"@dhis2/ui-core@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-5.7.8.tgz#063f8a10e583803d8b85d168ddbfb52e1f72750b"
-  integrity sha512-ijmXT8QlBS6RjHsbPOsBzaAb9j5DOvQeoLkhFo5eQZswavug2gW+S/Vh2tgxfNP8gybZ0tHKaJXeXN3bkg7Xnw==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-    "@popperjs/core" "^2.5.3"
-    classnames "^2.2.6"
-    react-popper "^2.2.3"
-    resize-observer-polyfill "^1.5.1"
 
 "@dhis2/ui-core@6.5.0":
   version "6.5.0"
@@ -1870,16 +1852,6 @@
     react-popper "^2.2.3"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/ui-forms@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-5.7.8.tgz#7b4489b796e2a79bebd1a24b8c1df59103e566c0"
-  integrity sha512-8c7IKJAqGL+IIZ7sjUbTrlwGHFpwX6KfF8eToDxXkkNONyyRIiFo7uVI43+rHii7+WmFwEhacWWjeYhfVBICfg==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-    classnames "^2.2.6"
-    final-form "^4.20.1"
-    react-final-form "^6.5.1"
-
 "@dhis2/ui-forms@6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-6.5.0.tgz#c1f104a0209797ba4c315c1b6dbaa7df901b92d7"
@@ -1890,27 +1862,12 @@
     final-form "^4.20.1"
     react-final-form "^6.5.1"
 
-"@dhis2/ui-icons@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-5.7.8.tgz#cb18c1bfbbcf49b2dae4c2b3ff7a3aeff46aa7f2"
-  integrity sha512-3P/Ptsf6HEdi0q8q6ba4Hcr8yuK+Y29PJn1Z56IZNZ+sZmFYiU7vxk5aMwA+s1EnjcPWQjrdwLzqqBAJE2W3Qg==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-
 "@dhis2/ui-icons@6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-6.5.0.tgz#e75b64d1ae7ac717d792f64c3d1a0681bac7b04c"
   integrity sha512-4/pOH6a2el9M2y8GWnXd9faQB9zpln+nHEcCWahY/O+gRSdaQpe3pLH18aKapGJygJt/Jp9lrCDjOop4klCXNw==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
-
-"@dhis2/ui-widgets@5.7.8":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-5.7.8.tgz#77318381dd92848f9ab2cbc5414a2b57599309fe"
-  integrity sha512-QVLOdB836uUXBRw4OT6x/z1WR7j2ykxpMyat4g9sOXngj6t9+2UXZUO7Zegudj/HsZjTMDiN9A285zwxsd+khQ==
-  dependencies:
-    "@dhis2/prop-types" "^1.6.4"
-    classnames "^2.2.6"
 
 "@dhis2/ui-widgets@6.5.0":
   version "6.5.0"
@@ -1920,18 +1877,7 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.7.2":
-  version "5.7.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.7.8.tgz#17604580d02cd4a7756552154a089e730a0fdf02"
-  integrity sha512-FHyTP6geAkR/jwX1/xG8yl8PvGaNhms8zUmaNiBLQ0mUmD9oJb47U8YXhJ5nVd0SFJnmuckOWgAWMt3meZGJTA==
-  dependencies:
-    "@dhis2/ui-constants" "5.7.8"
-    "@dhis2/ui-core" "5.7.8"
-    "@dhis2/ui-forms" "5.7.8"
-    "@dhis2/ui-icons" "5.7.8"
-    "@dhis2/ui-widgets" "5.7.8"
-
-"@dhis2/ui@^6.5.0":
+"@dhis2/ui@^5.7.2", "@dhis2/ui@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.5.0.tgz#8972d1c42f6445976965b6653571070d8e588726"
   integrity sha512-zW6jl3qMDe6D29WuZtqd4p43mDsKTo49rYEgccbCx7S/ZEfs8KNi/aQsvhkphjjrtp6QqncBmp853WAvGxfdvw==
@@ -2511,11 +2457,6 @@
     native-url "^0.2.6"
     schema-utils "^2.6.5"
     source-map "^0.7.3"
-
-"@popperjs/core@^2.5.3":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.0.tgz#32e63212293dd3efbb521cd35a5020ab66eaa546"
-  integrity sha512-wjtKehFAIARq2OxK8j3JrggNlEslJfNuSm2ArteIbKyRMts2g0a7KzTxfRVNUM+O0gnBJ2hNV8nWPOYBgI1sew==
 
 "@popperjs/core@^2.6.0":
   version "2.8.4"
@@ -16984,10 +16925,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
### Key features

1. Improve / extend tests for font style options
2. Minor refactor of common functions to reduce duplication (`expectAppToNotBeLoading`, `clickCheckbox`, `typeInput`, `clearInput`)
3. Minor improvement of Scatter by selecting more org units
4. Comment out a test in start.cy.js caused by a known backend bug

---

### Description

Tip: The vast majority of the changes are in `fontStyles.cy.js`, however don't compare the change, just look at the new file as a whole, as it's been completely refactored and GH tries to "compare" it in a weird way which just adds confusion.
