### PR TITLE
fix: include outlierAnalysis in AO request

### DIFF
--- a/packages/app/src/modules/fields/baseFields.js
+++ b/packages/app/src/modules/fields/baseFields.js
@@ -48,6 +48,7 @@ export const fieldsByType = {
         getFieldObject('regressionType', { option: true }),
         getFieldObject('series', { option: true }),
         getFieldObject('showData', { option: true }),
+        getFieldObject('outlierAnalysis', { option: true }),
         getFieldObject(BASE_FIELD_TYPE, { option: true }),
     ],
     eventReport_eventChart: [


### PR DESCRIPTION
### Key features

1. Enable outlier options to be fetched when requesting an AO

---

### Screenshots

_visualization has outliers when loaded_
![image](https://user-images.githubusercontent.com/12590483/110311948-c0ee4f80-8004-11eb-8a03-6469668be921.png)

_outlier options persisted after load_
![image](https://user-images.githubusercontent.com/12590483/110312069-e8ddb300-8004-11eb-9653-f67735eb02de.png)

