### PR TITLE
fix: set vertical before horizontal when swapping

### DIFF
--- a/packages/app/src/components/Layout/ScatterLayout/ScatterAxis.js
+++ b/packages/app/src/components/Layout/ScatterLayout/ScatterAxis.js
@@ -59,13 +59,13 @@ const Axis = ({
         )
         setItemAttributes(
             DIMENSION_ID_DATA,
-            verticalItems,
-            ITEM_ATTRIBUTE_HORIZONTAL
+            horizontalItems,
+            ITEM_ATTRIBUTE_VERTICAL
         )
         setItemAttributes(
             DIMENSION_ID_DATA,
-            horizontalItems,
-            ITEM_ATTRIBUTE_VERTICAL
+            verticalItems,
+            ITEM_ATTRIBUTE_HORIZONTAL
         )
     }
 


### PR DESCRIPTION
### Key features

1. Persist the order of the data items when swapping in scatter and changing vis type

---

### Screenshots

_before, swapping item1-item2 to item2-item1 shows up as item1-item2 in a column chart_

https://user-images.githubusercontent.com/12590483/110327164-ea65a600-8019-11eb-80c9-3767deeac885.mov

_after, swapping item1-item2 to item2-item1 is persisted as item2-item1 in a column chart_

https://user-images.githubusercontent.com/12590483/110327186-f18cb400-8019-11eb-83c5-b7839c5781d4.mov


