### PR TITLE
fix: avoid visualization plugin double render

### DIFF
--- a/packages/app/src/actions/settings.js
+++ b/packages/app/src/actions/settings.js
@@ -1,11 +1,6 @@
-import { SET_SETTINGS, ADD_SETTINGS } from '../reducers/settings'
+import { ADD_SETTINGS } from '../reducers/settings'
 import { apiFetchSystemSettings } from '../api/settings'
 import { apiFetchOrganisationUnitRoots } from '@dhis2/analytics'
-
-export const acSetSettings = value => ({
-    type: SET_SETTINGS,
-    value,
-})
 
 export const acAddSettings = value => ({
     type: ADD_SETTINGS,

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -161,6 +161,7 @@ export class Visualization extends Component {
             userSettings,
             error,
             isLoading,
+            onLoadingComplete,
         } = this.props
         const { renderId } = this.state
 
@@ -178,7 +179,7 @@ export class Visualization extends Component {
                     visualization={visualization}
                     filters={visFilters}
                     onChartGenerated={this.onChartGenerated}
-                    onLoadingComplete={this.props.onLoadingComplete}
+                    onLoadingComplete={onLoadingComplete}
                     onResponsesReceived={this.onResponsesReceived}
                     onError={this.onError}
                     onDrill={this.onDrill}

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -155,14 +155,20 @@ export class Visualization extends Component {
     }
 
     render() {
-        const { visualization, visFilters, error } = this.props
+        const {
+            visualization,
+            visFilters,
+            userSettings,
+            error,
+            isLoading,
+        } = this.props
         const { renderId } = this.state
 
         return !visualization || error ? (
             <StartScreen />
         ) : (
             <Fragment>
-                {this.props.isLoading ? (
+                {isLoading ? (
                     <div style={styles.loadingCover}>
                         <LoadingMask />
                     </div>
@@ -177,9 +183,7 @@ export class Visualization extends Component {
                     onError={this.onError}
                     onDrill={this.onDrill}
                     style={styles.chartCanvas}
-                    userSettings={{
-                        displayProperty: this.props.displayProperty,
-                    }}
+                    userSettings={userSettings}
                 />
             </Fragment>
         )
@@ -189,7 +193,6 @@ export class Visualization extends Component {
 Visualization.propTypes = {
     addMetadata: PropTypes.func,
     addParentGraphMap: PropTypes.func,
-    displayProperty: PropTypes.string,
     error: PropTypes.object,
     isLoading: PropTypes.bool,
     rightSidebarOpen: PropTypes.bool,
@@ -197,6 +200,7 @@ Visualization.propTypes = {
     setCurrent: PropTypes.func,
     setLoadError: PropTypes.func,
     setUiItems: PropTypes.func,
+    userSettings: PropTypes.object,
     visFilters: PropTypes.object,
     visualization: PropTypes.object,
     onLoadingComplete: PropTypes.func,
@@ -216,13 +220,20 @@ export const visFiltersSelector = createSelector(
             : {}
 )
 
+export const userSettingsSelector = createSelector(
+    [sGetSettingsDisplayNameProperty],
+    displayProperty => ({
+        displayProperty,
+    })
+)
+
 const mapStateToProps = state => ({
     visualization: visualizationSelector(state),
     visFilters: visFiltersSelector(state),
     rightSidebarOpen: sGetUiRightSidebarOpen(state),
     error: sGetLoadError(state),
     isLoading: sGetIsPluginLoading(state),
-    displayProperty: sGetSettingsDisplayNameProperty(state),
+    userSettings: userSettingsSelector(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/app/src/reducers/__tests__/settings.spec.js
+++ b/packages/app/src/reducers/__tests__/settings.spec.js
@@ -1,8 +1,4 @@
-import reducer, {
-    DEFAULT_SETTINGS,
-    SET_SETTINGS,
-    ADD_SETTINGS,
-} from '../settings'
+import reducer, { DEFAULT_SETTINGS, ADD_SETTINGS } from '../settings'
 
 describe('reducer: settings', () => {
     const currentState = {
@@ -14,22 +10,6 @@ describe('reducer: settings', () => {
         const actualState = reducer(DEFAULT_SETTINGS, { type: 'NO_MATCH' })
 
         expect(actualState).toEqual(DEFAULT_SETTINGS)
-    })
-
-    it(`${SET_SETTINGS}: should set settings`, () => {
-        const stateToSet = {
-            keyAnalysisRelativePeriod: 'LAST_4_QUARTERS',
-            keyAnalysisDisplayProperty: 'shortName',
-        }
-
-        const actualState = reducer(currentState, {
-            type: SET_SETTINGS,
-            value: stateToSet,
-        })
-
-        const expectedState = stateToSet
-
-        expect(actualState).toEqual(expectedState)
     })
 
     it(`${ADD_SETTINGS}: should add settings`, () => {

--- a/packages/app/src/reducers/settings.js
+++ b/packages/app/src/reducers/settings.js
@@ -1,4 +1,3 @@
-export const SET_SETTINGS = 'SET_SETTINGS'
 export const ADD_SETTINGS = 'ADD_SETTINGS'
 
 export const DEFAULT_SETTINGS = {
@@ -13,9 +12,6 @@ export const DEFAULT_SETTINGS = {
 
 export default (state = DEFAULT_SETTINGS, action) => {
     switch (action.type) {
-        case SET_SETTINGS: {
-            return Object.assign({}, action.value)
-        }
         case ADD_SETTINGS: {
             return {
                 ...state,

--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -71,6 +71,7 @@ ChartPlugin.defaultProps = {
     filters: {},
     style: {},
     animation: 200,
+    id: null,
     onChartGenerated: Function.prototype,
 }
 


### PR DESCRIPTION
### Key features

1. avoid visualization plugin double render

---

### Description

The cause for it was the `userSettings` prop passed to `VisualizationPlugin`. The prop was a new object every time, causing unwanted re-render.
The fix prevents the Highcharts config generation to run multiple times.
