### PR TITLE
fix: avoid re-render after 1st resize

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -14,6 +14,7 @@ const ChartPlugin = ({
 }) => {
     const canvasRef = useRef(undefined)
     const prevStyle = useRef(style)
+    const prevRenderCounter = useRef(renderCounter)
 
     const renderVisualization = useCallback(
         animation => {
@@ -59,7 +60,10 @@ const ChartPlugin = ({
     }, [visualization, responses, extraOptions])
 
     useEffect(() => {
-        renderCounter !== null && renderVisualization(0)
+        if (renderCounter !== prevRenderCounter.current) {
+            renderVisualization(0)
+            prevRenderCounter.current = renderCounter
+        }
 
         /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, [renderCounter])


### PR DESCRIPTION
### Key features

1. Fix double rendering in DV after the window is resized

---

### Description

The check on `renderCounter` value different than `null` is not working after the window is resized.
The next time the check is performed, `renderCounter` maintained the value assigned and triggers a rerender because is always going to be different than `null`.
The fix is then to compare with the previous version. 