### PR TITLE
fix: fix download links for dataValueSet DHIS2-9789 v35

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,7 +20,7 @@
         "@dhis2/data-visualizer-plugin": "35.12.25",
         "@dhis2/ui": "^5.6.1",
         "@material-ui/icons": "^3.0.1",
-        "d2": "^31.9.2",
+        "d2": "^31.9.3",
         "history": "^4.7.2",
         "lodash-es": "^4.17.11",
         "prop-types": "^15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4856,10 +4856,10 @@ d2-utilizr@^0.2.15, d2-utilizr@^0.2.16:
     lodash.isset "^4.3.0"
     lodash.isstring "^4.0.1"
 
-d2@^31.9.2:
-  version "31.9.2"
-  resolved "https://registry.yarnpkg.com/d2/-/d2-31.9.2.tgz#17062e6b7d166f1166f9011eb6f8d4112ad66c90"
-  integrity sha512-Bwa7kBkKVUe3adGf8plP2RY/0f9cOk474ApkgclGesMjSJkuz2F+YlUmErF7FUAF80ZyirCRYMaSYHPqkE0MLg==
+d2@^31.9.3:
+  version "31.9.3"
+  resolved "https://registry.yarnpkg.com/d2/-/d2-31.9.3.tgz#c9632fce71f4f001d77b463519d452841863a4f7"
+  integrity sha512-xfILD6PckZHv2WT8puhE5A+SIVhLyCGahWLZpmceXNe9SZfH+gYrEcb6L4nT6UR/jrvIigXH4l3WhwvMdT0Nbw==
   dependencies:
     isomorphic-fetch "^2.2.1"
 


### PR DESCRIPTION
Fixes [DHIS2-9789](https://jira.dhis2.org/browse/DHIS2-9789)

"Backport" via `d2` which is used here for the analytics requests.