### PR TITLE
refactor: remove MUI icons

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^17.0.0",
+        "@dhis2/analytics": "^17.0.3",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/d2-ui-interpretations": "^7.1.6",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,7 +19,6 @@
         "@dhis2/d2-ui-interpretations": "^7.1.6",
         "@dhis2/data-visualizer-plugin": "37.0.0",
         "@dhis2/ui": "^6.5.5",
-        "@material-ui/icons": "^3.0.1",
         "d2": "^31.9.1",
         "history": "^4.7.2",
         "lodash-es": "^4.17.11",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^16.0.15",
+        "@dhis2/analytics": "^17.0.0",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/d2-ui-interpretations": "^7.1.6",

--- a/packages/app/src/assets/ArrowDown.js
+++ b/packages/app/src/assets/ArrowDown.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const ArrowDown = ({ style = { width: 16, height: 16 } }) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        version="1.1"
+        style={style}
+    >
+        <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+            <path
+                d="M7.29289,11.7071 C7.68342,12.0976 8.31658,12.0976 8.70711,11.7071 L13.7071,6.70711 C14.0976,6.31658 14.0976,5.68342 13.7071,5.29289 C13.3166,4.90237 12.6834,4.90237 12.2929,5.29289 L8,9.58579 L3.70711,5.29289 C3.31658,4.90237 2.68342,4.90237 2.29289,5.29289 C1.90237,5.68342 1.90237,6.31658 2.29289,6.70711 L7.29289,11.7071 Z"
+                fill="#4A5768"
+            ></path>
+        </g>
+    </svg>
+)
+
+ArrowDown.propTypes = {
+    style: PropTypes.object,
+}
+
+export default ArrowDown

--- a/packages/app/src/components/Interpretations/InterpretationsButton.js
+++ b/packages/app/src/components/Interpretations/InterpretationsButton.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft'
-import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight'
+import { IconChevronRight24, IconChevronLeft24 } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
 
 import { sGetUiRightSidebarOpen } from '../../reducers/ui'
@@ -14,9 +13,13 @@ import styles from './styles/InterpretationsButton.module.css'
 export const InterpretationsButton = props => (
     <MenuButton disabled={!props.id} onClick={props.onClick}>
         {props.rightSidebarOpen ? (
-            <KeyboardArrowRightIcon className={styles.icon} />
+            <div className={styles.iconWrapper}>
+                <IconChevronRight24 />
+            </div>
         ) : (
-            <KeyboardArrowLeftIcon className={styles.icon} />
+            <div className={styles.iconWrapper}>
+                <IconChevronLeft24 />
+            </div>
         )}
         {i18n.t('Interpretations')}
     </MenuButton>

--- a/packages/app/src/components/Interpretations/__tests__/IterpretationsButton.spec.js
+++ b/packages/app/src/components/Interpretations/__tests__/IterpretationsButton.spec.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
+import { IconChevronRight24, IconChevronLeft24 } from '@dhis2/ui'
 import { InterpretationsButton } from '../InterpretationsButton'
-import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft'
-import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight'
 import MenuButton from '../../MenuButton/MenuButton'
 
 describe('InterpretationsButton component', () => {
@@ -53,7 +52,7 @@ describe('InterpretationsButton component', () => {
 
     it('uses the correct arrow icon based on props', () => {
         expect(
-            interpretationsButton().find(KeyboardArrowLeftIcon).first().length
+            interpretationsButton().find(IconChevronLeft24).first().length
         ).toEqual(1)
     })
 
@@ -61,7 +60,7 @@ describe('InterpretationsButton component', () => {
         props.rightSidebarOpen = true
 
         expect(
-            interpretationsButton().find(KeyboardArrowRightIcon).first().length
+            interpretationsButton().find(IconChevronRight24).first().length
         ).toEqual(1)
     })
 })

--- a/packages/app/src/components/Interpretations/styles/InterpretationsButton.module.css
+++ b/packages/app/src/components/Interpretations/styles/InterpretationsButton.module.css
@@ -1,4 +1,4 @@
-.icon {
+.iconWrapper {
+    display: flex;
     margin-right: var(--spacers-dp8);
-    margin-top: 2px;
 }

--- a/packages/app/src/components/Layout/Chip.js
+++ b/packages/app/src/components/Layout/Chip.js
@@ -3,10 +3,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
-import WarningIcon from '@material-ui/icons/Warning'
-import LockIcon from '@material-ui/icons/Lock'
-
-import { Tooltip } from '@dhis2/ui'
+import { Tooltip, IconLock16, IconWarningFilled16 } from '@dhis2/ui'
 
 import i18n from '@dhis2/d2-i18n'
 import {
@@ -47,17 +44,20 @@ const Chip = ({
     const dataTest = `layout-chip-${dimensionId}`
 
     const LockIconWrapper = (
-        <div style={styles.lockIconWrapper} data-test={`${dataTest}-lock-icon`}>
-            <LockIcon style={styles.lockIcon} />
+        <div
+            style={styles.rightIconWrapper}
+            data-test={`${dataTest}-lock-icon`}
+        >
+            <IconLock16 />
         </div>
     )
 
     const WarningIconWrapper = (
         <div
-            style={styles.warningIconWrapper}
+            style={styles.rightIconWrapper}
             data-test={`${dataTest}-warning-icon`}
         >
-            <WarningIcon style={styles.warningIcon} />
+            <IconWarningFilled16 />
         </div>
     )
 
@@ -143,7 +143,7 @@ const Chip = ({
 
     const renderChipContent = () => (
         <>
-            <div style={styles.iconWrapper}>{renderChipIcon()}</div>
+            <div style={styles.leftIconWrapper}>{renderChipIcon()}</div>
             <span style={!isSplitAxis ? styles.label : {}}>
                 {dimensionName}
             </span>

--- a/packages/app/src/components/Layout/TooltipContent.js
+++ b/packages/app/src/components/Layout/TooltipContent.js
@@ -2,11 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
-import LockIcon from '@material-ui/icons/Lock'
-import WarningIcon from '@material-ui/icons/Warning'
-
 import i18n from '@dhis2/d2-i18n'
 import { ouIdHelper } from '@dhis2/analytics'
+import { IconWarningFilled16, IconLock16 } from '@dhis2/ui'
 
 import { sGetMetadata } from '../../reducers/metadata'
 import { styles } from './styles/Tooltip.style'
@@ -79,8 +77,8 @@ export const TooltipContent = ({
     const renderWarningLabel = warningLabel => (
         <li style={styles.item}>
             <div style={styles.iconWrapper}>
-                <WarningIcon style={styles.icon} />
-                <span style={styles.warningLabel}>{warningLabel}</span>
+                <IconWarningFilled16 />
+                <span style={styles.label}>{warningLabel}</span>
             </div>
         </li>
     )
@@ -115,8 +113,8 @@ export const TooltipContent = ({
     const renderLockedLabel = () => (
         <li style={styles.item}>
             <div style={styles.iconWrapper}>
-                <LockIcon style={styles.icon} />
-                <span>{lockedLabel}</span>
+                <IconLock16 />
+                <span style={styles.label}>{lockedLabel}</span>
             </div>
         </li>
     )

--- a/packages/app/src/components/Layout/styles/Chip.style.js
+++ b/packages/app/src/components/Layout/styles/Chip.style.js
@@ -33,26 +33,13 @@ export const styles = {
     fixedDimensionIcon: {
         paddingRight: '6px',
     },
-    iconWrapper: {
+    leftIconWrapper: {
         paddingRight: '6px',
         display: 'flex',
         alignItems: 'center',
     },
-    warningIcon: {
-        fontSize: layoutStyle.CHIP_FONT_SIZE,
-    },
-    warningIconWrapper: {
+    rightIconWrapper: {
         paddingLeft: '6px',
-        display: 'flex',
-        alignItems: 'center',
-    },
-    lockIcon: {
-        fontSize: layoutStyle.CHIP_FONT_SIZE,
-    },
-    lockIconWrapper: {
-        paddingLeft: '6px',
-        display: 'flex',
-        alignItems: 'center',
     },
     label: {
         whiteSpace: 'nowrap',

--- a/packages/app/src/components/Layout/styles/Tooltip.style.js
+++ b/packages/app/src/components/Layout/styles/Tooltip.style.js
@@ -25,16 +25,13 @@ export const styles = {
         overflow: 'hidden',
         textOverflow: 'ellipsis',
     },
-    icon: {
-        fontSize: '13px',
-        marginRight: '6px',
-    },
     iconWrapper: {
         display: 'flex',
         alignItems: 'center',
         marginBottom: '5px',
     },
-    warningLabel: {
+    label: {
         whiteSpace: 'normal',
+        marginLeft: '6px',
     },
 }

--- a/packages/app/src/components/VisualizationOptions/VisualizationOptionsManager.js
+++ b/packages/app/src/components/VisualizationOptions/VisualizationOptionsManager.js
@@ -1,5 +1,4 @@
 import React, { Component, Fragment } from 'react'
-import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
 import {
     ButtonStrip,
@@ -42,7 +41,6 @@ class VisualizationOptionsManager extends Component {
         return (
             <Fragment>
                 <MenuButton
-                    className={this.props.className}
                     onClick={this.toggleVisualizationOptionsDialog}
                     dataTest={'app-menubar-options-button'}
                 >
@@ -84,10 +82,6 @@ class VisualizationOptionsManager extends Component {
             </Fragment>
         )
     }
-}
-
-VisualizationOptionsManager.propTypes = {
-    className: PropTypes.string,
 }
 
 export default VisualizationOptionsManager

--- a/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeSelector.js
+++ b/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeSelector.js
@@ -2,10 +2,9 @@ import React, { useState, createRef } from 'react'
 import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown'
 import { visTypeDisplayNames, visTypeDescriptions } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
-import { Card, Divider, Popper } from '@dhis2/ui'
+import { Card, Divider, Popper, IconChevronDown16 } from '@dhis2/ui'
 
 import { prepareCurrentAnalyticalObject } from '../../modules/currentAnalyticalObject'
 import { getAdaptedUiByType } from '../../modules/ui'
@@ -104,7 +103,9 @@ export const VisualizationTypeSelector = (
                 <span data-test="visualization-type-selector-currently-selected-text">
                     {visTypeDisplayNames[visualizationType]}
                 </span>
-                <ArrowDropDownIcon style={{ marginLeft: 'auto' }} />
+                <span style={{ marginLeft: 'auto' }}>
+                    <IconChevronDown16 />
+                </span>
             </div>
             {listIsOpen &&
                 createPortal(

--- a/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeSelector.js
+++ b/packages/app/src/components/VisualizationTypeSelector/VisualizationTypeSelector.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { visTypeDisplayNames, visTypeDescriptions } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
-import { Card, Divider, Popper, IconChevronDown16 } from '@dhis2/ui'
+import { Card, Divider, Popper } from '@dhis2/ui'
 
 import { prepareCurrentAnalyticalObject } from '../../modules/currentAnalyticalObject'
 import { getAdaptedUiByType } from '../../modules/ui'
@@ -16,6 +16,7 @@ import {
     apiSaveAOInUserDataStore,
     CURRENT_AO_KEY,
 } from '../../api/userDataStore'
+import ArrowDown from '../../assets/ArrowDown'
 import VisualizationTypeListItem from './VisualizationTypeListItem'
 import ListItemIcon from './ListItemIcon'
 import styles from './styles/VisualizationTypeSelector.module.css'
@@ -103,8 +104,8 @@ export const VisualizationTypeSelector = (
                 <span data-test="visualization-type-selector-currently-selected-text">
                     {visTypeDisplayNames[visualizationType]}
                 </span>
-                <span style={{ marginLeft: 'auto' }}>
-                    <IconChevronDown16 />
+                <span className={styles.arrowIcon}>
+                    <ArrowDown />
                 </span>
             </div>
             {listIsOpen &&

--- a/packages/app/src/components/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
+++ b/packages/app/src/components/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
@@ -7,6 +7,11 @@
     z-index: 110;
 }
 
+.arrowIcon {
+    display: flex;
+    margin-left: auto;
+}
+
 .button {
     padding: 7px var(--spacers-dp8);
     display: flex;

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^17.0.0",
+        "@dhis2/analytics": "^17.0.3",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.5.5",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^16.0.15",
+        "@dhis2/analytics": "^17.0.0",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,17 +1499,15 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^16.0.15":
-  version "16.0.15"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-16.0.15.tgz#868a4094c7957720b112bf584f13c85f7955a287"
-  integrity sha512-3KgjVigsvPflHBTQSboQ3IpArWzeWI6EYqU/dqvtOPk+h9sw7JVFKUfVVqhEU6gIds/gqMmsPR4VwufNO+Scyg==
+"@dhis2/analytics@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-17.0.0.tgz#ef635ab06a2526f8c61ed7a2996afbbe454bfc3c"
+  integrity sha512-i76hW5iuwNsWw4F+9qFOymOWkgj6YzqBoKVQ/lZC2mSYrqQWrrRRhKHaFBPKDm/chHo0kTF9Au0IaR3aBAKmbg==
   dependencies:
     "@dhis2/d2-ui-favorites-dialog" "^7.1.5"
     "@dhis2/d2-ui-org-unit-dialog" "^7.1.5"
     "@dhis2/d2-ui-sharing-dialog" "^7.1.5"
     "@dhis2/d2-ui-translation-dialog" "^7.1.5"
-    "@material-ui/core" "^3.9.3"
-    "@material-ui/icons" "^3.0.2"
     classnames "^2.2.6"
     d2-utilizr "^0.2.16"
     d3-color "^1.2.3"
@@ -2359,7 +2357,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@material-ui/core@^3.3.1", "@material-ui/core@^3.9.3":
+"@material-ui/core@^3.3.1":
   version "3.9.4"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.9.4.tgz#5297fd4ad9e739a87da4a6d34fc4af5396886e13"
   integrity sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==
@@ -2392,7 +2390,7 @@
     recompose "0.28.0 - 0.30.0"
     warning "^4.0.1"
 
-"@material-ui/icons@^3.0.1", "@material-ui/icons@^3.0.2":
+"@material-ui/icons@^3.0.1":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-3.0.2.tgz#d67a6dd1ec8312d3a88ec97944a63daeef24fe10"
   integrity sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,15 +1499,15 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^17.0.0":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-17.0.0.tgz#ef635ab06a2526f8c61ed7a2996afbbe454bfc3c"
-  integrity sha512-i76hW5iuwNsWw4F+9qFOymOWkgj6YzqBoKVQ/lZC2mSYrqQWrrRRhKHaFBPKDm/chHo0kTF9Au0IaR3aBAKmbg==
+"@dhis2/analytics@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-17.0.3.tgz#b80108c6d61d6f9f8eaa4813ddb7211d9d602abc"
+  integrity sha512-5bzG7OrgTYe8YbpYxPMMiLLhtRCy1Hqi7Myg8uO1p7Rjda6fFBqSAomyEdMkXfcOczIs9g1YF7yjjFNP31MsCw==
   dependencies:
-    "@dhis2/d2-ui-favorites-dialog" "^7.1.5"
-    "@dhis2/d2-ui-org-unit-dialog" "^7.1.5"
-    "@dhis2/d2-ui-sharing-dialog" "^7.1.5"
-    "@dhis2/d2-ui-translation-dialog" "^7.1.5"
+    "@dhis2/d2-ui-favorites-dialog" "^7.2.0"
+    "@dhis2/d2-ui-org-unit-dialog" "^7.2.0"
+    "@dhis2/d2-ui-sharing-dialog" "^7.2.0"
+    "@dhis2/d2-ui-translation-dialog" "^7.2.0"
     classnames "^2.2.6"
     d2-utilizr "^0.2.16"
     d3-color "^1.2.3"
@@ -1692,17 +1692,6 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/d2-ui-core@7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.1.5.tgz#38fd0d74004c23d5cb85e84a003e709c5d400ad6"
-  integrity sha512-L3zCO8JdW0yhBqWghZOrXeQG5oSVXdFBXIEGcedM8QAe0FG42Ch0MNjzP9FNFpCpCNhjOPO2SlX3sCT8BpQKWg==
-  dependencies:
-    babel-runtime "^6.26.0"
-    d2 "~31.7"
-    lodash "^4.17.10"
-    material-ui "^0.20.0"
-    rxjs "^5.5.7"
-
 "@dhis2/d2-ui-core@7.1.6":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.1.6.tgz#2bc65f86f1cbf0e04ca17accfb164968e5fcb7d4"
@@ -1714,15 +1703,27 @@
     material-ui "^0.20.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-favorites-dialog@^7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.1.5.tgz#e4b879dd607ab5b71989fe7b8c2bd7e97eae4309"
-  integrity sha512-ywyVGaGyFm4L4oKWReAWOfRhyn2tAsJXPFWPYloV2I+cMZ4w8/CSLxRjsbrp21YlJy5QYnMu9RyuF/6qBzDR9A==
+"@dhis2/d2-ui-core@7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.2.0.tgz#932c9b2f439dc730ccb28a69129cfeeba15527ad"
+  integrity sha512-ox3//w5/sVwlEpOwp/h3NwMufd0bf653ZZmw4sWpH8t8oosuvt0F4bDGB7Vz0f8tidB09oLGiAsHmtvKTXpLpA==
   dependencies:
-    "@dhis2/d2-ui-sharing-dialog" "7.1.5"
+    babel-runtime "^6.26.0"
+    d2 "~31.7"
+    lodash "^4.17.10"
+    material-ui "^0.20.0"
+    rxjs "^5.5.7"
+
+"@dhis2/d2-ui-favorites-dialog@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.2.0.tgz#b1f853c63d3e352af81b44b275c3881d2dea3c6d"
+  integrity sha512-//sKtdKspCAPEGQbIU6EMpSsPU+RzyvSXaRZplxQc69iRBQwoB2HO3ZajU4u0fwn0uxlB7FGUywQ1olqnIuv1A==
+  dependencies:
+    "@dhis2/d2-ui-sharing-dialog" "7.2.0"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
+    lodash "^4.17.10"
     prop-types "^15.6.0"
     react-redux "^5.0.7"
     redux "^3.7.2"
@@ -1755,22 +1756,22 @@
     lodash "^4.17.10"
     prop-types "^15.6.2"
 
-"@dhis2/d2-ui-org-unit-dialog@^7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.1.5.tgz#aa6b9257a25ff1a238f77a9638323b6cf0ee37d8"
-  integrity sha512-kN+494W2ttNNPHHbY4glXg6QwreJYqmkOKDbl/lrKZ/ReWBG6Ry6t3omB2w8yEX20KPPyf5WiJBv7L9eLgKnlQ==
+"@dhis2/d2-ui-org-unit-dialog@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.2.0.tgz#24182b874148080976a52adc3983e8e40249cd14"
+  integrity sha512-P9SZL8EfJy4pvJlMz671IbYG5KhdVPUs7ID/cKZcDOr8keQ8JNOMkT1vMM1PVFJKt8qFKJ1wg5FJ26uXDkA2TQ==
   dependencies:
-    "@dhis2/d2-ui-org-unit-tree" "7.1.5"
+    "@dhis2/d2-ui-org-unit-tree" "7.2.0"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-org-unit-tree@7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.1.5.tgz#5d5258d5f802cc4cd158f14e61ec37a9e43100b3"
-  integrity sha512-IswS0TZSnOUISQlHjPns8JLo+3CW6P+13ZTOtMyiJAgDumSQtEibqzZU+SNP4GPZOasOjuRBbUXrWoQOjZRIRQ==
+"@dhis2/d2-ui-org-unit-tree@7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.2.0.tgz#039fcff0c056064aea054e9f41305277b8b0c1c4"
+  integrity sha512-0wgLyitzL1qxiarB6vYpMmhhDnVdjAYWQnTSxbVJhKpY4WnkoZY4Qfp4q9IjDFmpYrP2MPF3m1WTo3woshGpCA==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.5"
+    "@dhis2/d2-ui-core" "7.2.0"
     "@material-ui/core" "^3.3.1"
     babel-runtime "^6.26.0"
     prop-types "^15.5.10"
@@ -1784,21 +1785,7 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/d2-ui-sharing-dialog@7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.1.5.tgz#1915832ed070a0278ee9f7830a8814744142336e"
-  integrity sha512-JT6MY1B69maT9znkCk3+cjnzg5zRNr8HvCSibFddZZN0j+HmKfkEHMfMv88tEUpOHskgmniNykWxtwBEVOkRTg==
-  dependencies:
-    "@dhis2/d2-ui-core" "7.1.5"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    babel-runtime "^6.26.0"
-    downshift "^2.2.2"
-    prop-types "^15.5.10"
-    recompose "^0.26.0"
-    rxjs "^5.5.7"
-
-"@dhis2/d2-ui-sharing-dialog@7.1.6", "@dhis2/d2-ui-sharing-dialog@^7.1.5":
+"@dhis2/d2-ui-sharing-dialog@7.1.6":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.1.6.tgz#5e07c936a9231c85b9f485c1f3fd1c306a170965"
   integrity sha512-oERAInDhM6S4ogZ5+CZpKUqGkZ7mxEOAoSSYZYsIi5A5TeMoOYHdf02Yvby0cXPSxLGR6CIHotSdBYN//4fhMA==
@@ -1812,12 +1799,26 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-translation-dialog@^7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.1.5.tgz#f27f496b597e97a839847b1f82cca8ca8a7293eb"
-  integrity sha512-fiFinyYqij+wOFOtpOuGefjG87i0W5r6SvSdghkBOd+ET5s6GWdB6ETLG3sq3uOzN++tIa/FLnY6xlEAge5Khg==
+"@dhis2/d2-ui-sharing-dialog@7.2.0", "@dhis2/d2-ui-sharing-dialog@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.2.0.tgz#18ad372864bc26451ac58f3488b2d68bd235c185"
+  integrity sha512-l12r7yoI9lU5NWxH6yWBlPdXVpIqqRQ96oq5M5taRG/r1UxLNf3KTigOjT8Ghg+LtCnJGFebyXi5ZTFCwN0c/Q==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.5"
+    "@dhis2/d2-ui-core" "7.2.0"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    babel-runtime "^6.26.0"
+    downshift "^2.2.2"
+    prop-types "^15.5.10"
+    recompose "^0.26.0"
+    rxjs "^5.5.7"
+
+"@dhis2/d2-ui-translation-dialog@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.2.0.tgz#4e990e6bf551213f1a514b560a211d3444bd34bd"
+  integrity sha512-hbe1QWGxo8bx+Ha5XNrN4ELVhJJPrwtJ89asybCot8InPjepYbf1U2QQYG6DX4GzEGZ3r+aSq+07QWfK9h9m+Q==
+  dependencies:
+    "@dhis2/d2-ui-core" "7.2.0"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16664,10 +16664,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
### Key features

1. Remove the last of MUI icons and replace them with `ui` icons

---

### Description

DV still used some icons from MUI.
Now the `ui-icons` are available there is no reason to keep MUI icons and the extra dependency.
Discussed with @cooper-joe  some of the replacements and got approval, it would be good anyway if @cooper-joe can have a look to make sure all is good.

---

### Notes

-   the `FatalErrorBoundary` component is using an large icon, the PR replaces it with the equivalent icon from `ui-icons` but the size is not the same.
The component is not in use at the moment, and most probably it's going to be revisited in a separate PR.
**Update**: the component wasn't in use because is now part of the app shell, it has been removed from DV.
- some icons are imported from `@dhis2/analytics` there will be another PR for replacing those

---

### Screenshots

- Layout chip warning and padlock icons
before:
![Screenshot 2021-04-13 at 14 03 33](https://user-images.githubusercontent.com/150978/114549244-126fa700-9c61-11eb-9b83-f2a630643a1b.png)
after:
![Screenshot 2021-04-13 at 14 03 22](https://user-images.githubusercontent.com/150978/114549257-16032e00-9c61-11eb-8484-1525da878424.png)

- Layout chip tooltip warning and padlock icons
before:
![Screenshot 2021-04-13 at 14 06 11](https://user-images.githubusercontent.com/150978/114549557-71cdb700-9c61-11eb-9d51-46d12ec5a3fc.png)
after:
![Screenshot 2021-04-13 at 14 06 04](https://user-images.githubusercontent.com/150978/114549573-75613e00-9c61-11eb-8a7b-a280af67b233.png)

- Visualization type selector drop down arrow
before:
![Screenshot 2021-04-13 at 14 07 05](https://user-images.githubusercontent.com/150978/114549666-93c73980-9c61-11eb-99af-7ebd60330d28.png)
after:
![Screenshot 2021-04-13 at 14 06 57](https://user-images.githubusercontent.com/150978/114549679-97f35700-9c61-11eb-81dd-e4d802d76c97.png)

- Intepretations panel button
before:
![Screenshot 2021-04-13 at 14 08 46](https://user-images.githubusercontent.com/150978/114549883-dbe65c00-9c61-11eb-95e3-a8948fbdb55c.png)
after:
![Screenshot 2021-04-13 at 14 08 57](https://user-images.githubusercontent.com/150978/114549894-e0127980-9c61-11eb-9e6e-8526629754a8.png)
