### PR TITLE
fix: start screen vis type crash

### DIFF
--- a/packages/app/src/components/Visualization/StartScreen.js
+++ b/packages/app/src/components/Visualization/StartScreen.js
@@ -13,6 +13,7 @@ import history from '../../modules/history'
 import { VisualizationError, genericErrorTitle } from '../../modules/error'
 import { GenericError } from '../../assets/ErrorIcons'
 import { apiFetchVisualizations } from '../../api/visualization'
+import { matchVisualizationWithType } from './utils'
 
 const StartScreen = ({ error }) => {
     const [mostViewedVisualizations, setMostViewedVisualizations] = useState([])
@@ -32,19 +33,10 @@ const StartScreen = ({ error }) => {
                 )
                 const visualizationsWithType =
                     visualizationsResult.visualization.visualizations // {id: string, type: string}
-                const result = []
-
-                visualizations.forEach(visualization => {
-                    const type = visualizationsWithType.find(
-                        visWithType => visWithType.id === visualization.id
-                    )?.type
-                    if (type) {
-                        result.push({
-                            ...visualization,
-                            type,
-                        })
-                    }
-                })
+                const result = matchVisualizationWithType(
+                    visualizations,
+                    visualizationsWithType
+                )
 
                 setMostViewedVisualizations(result)
             }

--- a/packages/app/src/components/Visualization/StartScreen.js
+++ b/packages/app/src/components/Visualization/StartScreen.js
@@ -24,20 +24,27 @@ const StartScreen = ({ error }) => {
                 engine,
                 6
             )
-            const visualizations = mostViewedVisualizationsResult.visualization
+            const visualizations = mostViewedVisualizationsResult.visualization // {position: int, views: int, id: string, created: string}
             if (visualizations && visualizations.length) {
                 const visualizationsResult = await apiFetchVisualizations(
                     engine,
-                    visualizations.map(vis => vis.id)
+                    visualizations.map(visualization => visualization.id)
                 )
                 const visualizationsWithType =
-                    visualizationsResult.visualization.visualizations
-                const result = visualizations.map(vis => ({
-                    ...visualizationsWithType.find(
-                        visWithType => visWithType.id === vis.id && visWithType
-                    ),
-                    ...vis,
-                }))
+                    visualizationsResult.visualization.visualizations // {id: string, type: string}
+                const result = []
+
+                visualizations.forEach(visualization => {
+                    const type = visualizationsWithType.find(
+                        visWithType => visWithType.id === visualization.id
+                    )?.type
+                    if (type) {
+                        result.push({
+                            ...visualization,
+                            type,
+                        })
+                    }
+                })
 
                 setMostViewedVisualizations(result)
             }

--- a/packages/app/src/components/Visualization/__tests__/utils.spec.js
+++ b/packages/app/src/components/Visualization/__tests__/utils.spec.js
@@ -1,0 +1,103 @@
+import { matchVisualizationWithType } from '../utils'
+
+let visualizations
+
+describe('utils', () => {
+    describe('matchVisualizationWithType', () => {
+        beforeEach(() => {
+            visualizations = [
+                {
+                    position: 1,
+                    views: 10,
+                    id: 'aaa111',
+                    created: '2020-01-01',
+                },
+                {
+                    position: 2,
+                    views: 9,
+                    id: 'bbb222',
+                    created: '2020-01-02',
+                },
+                {
+                    position: 3,
+                    views: 8,
+                    id: 'ccc333',
+                    created: '2020-01-03',
+                },
+            ]
+        })
+        it('all visualizations are matched with a type', () => {
+            const types = [
+                {
+                    id: 'aaa111',
+                    type: 'typeX',
+                },
+                {
+                    id: 'bbb222',
+                    type: 'typeY',
+                },
+                {
+                    id: 'ccc333',
+                    type: 'typeZ',
+                },
+            ]
+            const expectedResult = [
+                {
+                    position: 1,
+                    views: 10,
+                    id: 'aaa111',
+                    created: '2020-01-01',
+                    type: 'typeX',
+                },
+                {
+                    position: 2,
+                    views: 9,
+                    id: 'bbb222',
+                    created: '2020-01-02',
+                    type: 'typeY',
+                },
+                {
+                    position: 3,
+                    views: 8,
+                    id: 'ccc333',
+                    created: '2020-01-03',
+                    type: 'typeZ',
+                },
+            ]
+            expect(matchVisualizationWithType(visualizations, types)).toEqual(
+                expectedResult
+            )
+        })
+        it('only visualizations with a type are returned', () => {
+            const types = [
+                {
+                    id: 'aaa111',
+                    type: 'typeX',
+                },
+                {
+                    id: 'bbb222',
+                    type: 'typeY',
+                },
+            ]
+            const expectedResult = [
+                {
+                    position: 1,
+                    views: 10,
+                    id: 'aaa111',
+                    created: '2020-01-01',
+                    type: 'typeX',
+                },
+                {
+                    position: 2,
+                    views: 9,
+                    id: 'bbb222',
+                    created: '2020-01-02',
+                    type: 'typeY',
+                },
+            ]
+            expect(matchVisualizationWithType(visualizations, types)).toEqual(
+                expectedResult
+            )
+        })
+    })
+})

--- a/packages/app/src/components/Visualization/utils.js
+++ b/packages/app/src/components/Visualization/utils.js
@@ -1,0 +1,18 @@
+export const matchVisualizationWithType = (
+    visualizations,
+    visualizationsWithType
+) => {
+    const result = []
+    visualizations.forEach(visualization => {
+        const type = visualizationsWithType.find(
+            visWithType => visWithType.id === visualization.id
+        )?.type
+        if (type) {
+            result.push({
+                ...visualization,
+                type,
+            })
+        }
+    })
+    return result
+}


### PR DESCRIPTION
### Description

The "most viewed" section works by first fetching the "favourites" and then fetching the types of each item.
If, for whatever reason, there's a mismatch between these two results (i.e. not all favourites have a corresponding item in the type response) the app crashes.
This change prevents this from happening by excluding the mismatched items.
Will lead to favourites being missing from the list (maybe not ideal) but at least the app won't crash.

---

### Screenshots

_no visual changes_
![image](https://user-images.githubusercontent.com/12590483/116854194-9a5d2700-abf7-11eb-9c6b-057d76a53e04.png)