### PR TITLE
fix: pass username to the favorites endpoint (DHIS2-11065)

### DIFF
--- a/packages/app/src/api/mostViewedVisualizations.js
+++ b/packages/app/src/api/mostViewedVisualizations.js
@@ -3,12 +3,17 @@
 import { EVENT_TYPE } from './dataStatistics'
 
 // most likely is not needed anywhere else
-export const apiFetchMostViewedVisualizations = (dataEngine, pageSize) => {
+export const apiFetchMostViewedVisualizations = (
+    dataEngine,
+    pageSize,
+    username
+) => {
     const visualizationQuery = {
         resource: 'dataStatistics/favorites',
         params: {
             eventType: EVENT_TYPE,
             pageSize: pageSize || 10,
+            ...(username ? { username } : {}),
         },
     }
 

--- a/packages/app/src/components/Visualization/StartScreen.js
+++ b/packages/app/src/components/Visualization/StartScreen.js
@@ -14,8 +14,9 @@ import { VisualizationError, genericErrorTitle } from '../../modules/error'
 import { GenericError } from '../../assets/ErrorIcons'
 import { apiFetchVisualizations } from '../../api/visualization'
 import { matchVisualizationWithType } from './utils'
+import { sGetUsername } from '../../reducers/user'
 
-const StartScreen = ({ error }) => {
+const StartScreen = ({ error, username }) => {
     const [mostViewedVisualizations, setMostViewedVisualizations] = useState([])
     const engine = useDataEngine()
 
@@ -23,7 +24,8 @@ const StartScreen = ({ error }) => {
         async function populateMostViewedVisualizations(engine) {
             const mostViewedVisualizationsResult = await apiFetchMostViewedVisualizations(
                 engine,
-                6
+                6,
+                username
             )
             const visualizations = mostViewedVisualizationsResult.visualization // {position: int, views: int, id: string, created: string}
             if (visualizations && visualizations.length) {
@@ -141,10 +143,12 @@ const StartScreen = ({ error }) => {
 
 StartScreen.propTypes = {
     error: PropTypes.object,
+    username: PropTypes.string,
 }
 
 const mapStateToProps = state => ({
     error: sGetLoadError(state),
+    username: sGetUsername(state),
 })
 
 export default connect(mapStateToProps)(StartScreen)


### PR DESCRIPTION
Implements [DHIS2-11065](https://jira.dhis2.org/browse/DHIS2-11065)

---

### Key features

1. pass username to the favorites endpoint to get a user specific result

---

### Screenshots

_the start page now shows the most viewed visualizations specific for the user_
![image](https://user-images.githubusercontent.com/12590483/117150583-90365680-adb8-11eb-94e8-e90492f93edf.png)

![image](https://user-images.githubusercontent.com/12590483/117150747-b825ba00-adb8-11eb-8fc7-d6dd90e24854.png)
