### PR TITLE
fix: await ou levels

### DIFF
--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -153,7 +153,7 @@ export const VisualizationPlugin = ({
         /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, [visualization, filters, forDashboard])
 
-    if (!fetchResult) {
+    if (!fetchResult || !ouLevels) {
         return null
     }
 

--- a/packages/plugin/src/__tests__/VisualizationPlugin.spec.js
+++ b/packages/plugin/src/__tests__/VisualizationPlugin.spec.js
@@ -13,7 +13,16 @@ import ChartPlugin from '../ChartPlugin'
 
 jest.mock('../ChartPlugin', () => jest.fn(() => null))
 jest.mock('../PivotPlugin', () => jest.fn(() => null))
-jest.mock('@dhis2/analytics')
+jest.mock('@dhis2/analytics', () => ({
+    ...jest.requireActual('@dhis2/analytics'),
+    apiFetchOrganisationUnitLevels: () =>
+        Promise.resolve([
+            {
+                level: 2,
+                id: '2nd-floor',
+            },
+        ]),
+}))
 
 const dxMock = {
     dimension: 'dx',


### PR DESCRIPTION
### Key features

1. properly await `ouLevels` to prevent race condition

---

### Description

There's an issue on dashboards where dashboard items fail to load.
It's caused by [ouLevelUtils in Analytics](https://github.com/dhis2/analytics/blob/37b3c6650924ee92c948dd5eeaee12a03b1be159/src/modules/ouLevelUtils/index.js#L19) receiving undefined `ouLevels`, which are provided by https://github.com/dhis2/data-visualizer-app/blob/06f0426626d47c0f181cbf261ed6fc73c400a96a/packages/plugin/src/VisualizationPlugin.js#L92

As the `ouLevels` are fetched in a `useEffect`, there's a race condition where the fetching sometimes doesn't finish before the component returns. This is prevented by only returning if `ouLevels` are finished fetching.

---

### Screenshots

_error in dashboards_
![image](https://user-images.githubusercontent.com/12590483/117431712-d3fc9d80-af29-11eb-88b1-48ddd0bba8f6.png)