### PR TITLE
feat: drill down org units in bar and column charts (DHIS2-11061)

### DIFF
--- a/packages/plugin/src/ChartPlugin.js
+++ b/packages/plugin/src/ChartPlugin.js
@@ -11,6 +11,7 @@ const ChartPlugin = ({
     style,
     onChartGenerated,
     animation: defaultAnimation,
+    onToggleContextualMenu,
 }) => {
     const canvasRef = useRef(undefined)
     const prevStyle = useRef(style)
@@ -26,6 +27,7 @@ const ChartPlugin = ({
                     ...extraOptions,
                     animation,
                     legendSets,
+                    onToggleContextualMenu,
                 },
                 undefined,
                 undefined,
@@ -101,6 +103,7 @@ ChartPlugin.propTypes = {
     id: PropTypes.number,
     style: PropTypes.object,
     onChartGenerated: PropTypes.func,
+    onToggleContextualMenu: PropTypes.func,
 }
 
 export default ChartPlugin

--- a/packages/plugin/src/ContextualMenu.js
+++ b/packages/plugin/src/ContextualMenu.js
@@ -1,14 +1,12 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
-
 import i18n from '@dhis2/d2-i18n'
 import { useDataEngine } from '@dhis2/app-runtime'
 import { Divider, FlyoutMenu, MenuItem } from '@dhis2/ui'
+import { apiFetchOrganisationUnit } from '@dhis2/analytics'
 
 import ArrowUpwardIcon from './assets/ArrowUpwardIcon'
 import ArrowDownwardIcon from './assets/ArrowDownwardIcon'
-
-import { apiFetchOrganisationUnit } from '@dhis2/analytics'
 
 export const ContextualMenu = ({ config, ouLevels, onClick }) => {
     const engine = useDataEngine()

--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -1,13 +1,13 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
-
 import { useDataEngine } from '@dhis2/app-runtime'
 import { Popper } from '@dhis2/ui'
 import {
     VIS_TYPE_PIVOT_TABLE,
     apiFetchOrganisationUnitLevels,
     convertOuLevelsToUids,
+    DIMENSION_ID_ORGUNIT,
 } from '@dhis2/analytics'
 
 import { apiFetchLegendSets } from './api/legendSets'
@@ -15,7 +15,6 @@ import ContextualMenu from './ContextualMenu'
 import ChartPlugin from './ChartPlugin'
 import PivotPlugin from './PivotPlugin'
 import { fetchData } from './modules/fetchData'
-
 import styles from './styles/VisualizationPlugin.style.js'
 
 const LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM = 'BY_DATA_ITEM'
@@ -39,8 +38,44 @@ export const VisualizationPlugin = ({
     const [contextualMenuConfig, setContextualMenuConfig] = useState({})
 
     const onToggleContextualMenu = (ref, data) => {
-        setContextualMenuRef(ref)
-        setContextualMenuConfig(data)
+        if (data.ouId) {
+            setContextualMenuRef(ref)
+            setContextualMenuConfig(data)
+        } else if (
+            data.category &&
+            visualization.rows.some(
+                row => row.dimension === DIMENSION_ID_ORGUNIT
+            )
+        ) {
+            const ouId = Object.values(
+                fetchResult.responses[0].metaData.items
+            ).find(
+                item =>
+                    item.name === data.category &&
+                    fetchResult.responses[0].metaData.dimensions[
+                        DIMENSION_ID_ORGUNIT
+                    ].includes(item.uid)
+            )?.uid
+            setContextualMenuRef(ref)
+            setContextualMenuConfig({ ouId })
+        } else if (
+            data.category &&
+            visualization.columns.some(
+                column => column.dimension === DIMENSION_ID_ORGUNIT
+            )
+        ) {
+            const ouId = Object.values(
+                fetchResult.responses[0].metaData.items
+            ).find(
+                item =>
+                    item.name === data.series &&
+                    fetchResult.responses[0].metaData.dimensions[
+                        DIMENSION_ID_ORGUNIT
+                    ].includes(item.uid)
+            )?.uid
+            setContextualMenuRef(ref)
+            setContextualMenuConfig({ ouId })
+        }
     }
 
     const closeContextualMenu = () => setContextualMenuRef(undefined)
@@ -157,10 +192,7 @@ export const VisualizationPlugin = ({
         return null
     }
 
-    const contextualMenuRect =
-        contextualMenuRef &&
-        contextualMenuRef.current &&
-        contextualMenuRef.current.getBoundingClientRect()
+    const contextualMenuRect = contextualMenuRef?.getBoundingClientRect()
 
     const virtualContextualMenuElement = contextualMenuRect
         ? { getBoundingClientRect: () => contextualMenuRect }
@@ -191,6 +223,9 @@ export const VisualizationPlugin = ({
                     responses={fetchResult.responses}
                     extraOptions={fetchResult.extraOptions}
                     legendSets={fetchResult.legendSets}
+                    onToggleContextualMenu={
+                        onDrill ? onToggleContextualMenu : undefined
+                    }
                     {...props}
                 />
             )}


### PR DESCRIPTION
Implements [DHIS2-11061](https://jira.dhis2.org/browse/DHIS2-11061)

**Requires https://github.com/dhis2/analytics/pull/918**

---

### Key features

1. Add drill down to column and bar vis types

---

### Description

Adds a drill down menu (same as for pivot tables) to column, bar, stacked column and stacked bar. 
Most of the change is in Analytics. DV just changes `onToggleContextualMenu` a bit to fit the new vis types and passes that prop to the `createVisualization` function. 
The menu itself is unchanged and thus works exactly like it does for pivot tables.

Note that org unit has to be in either series or category for the menu to appear on click.

`onToggleContextualMenu` now receives the ref directly, instead of having it wrapped in a `current` prop. The `data` prop has the same structure as before, but Analytics only passes the used props explicitly instead of a whole object with unnecessary parts.

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/117985905-6d1c2180-b339-11eb-84f7-4e904d435444.png)

