### PR TITLE
fix: drill down bugs (DHIS2-11061)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^18.2.0",
+        "@dhis2/analytics": "^18.2.2",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^18.2.0",
+        "@dhis2/analytics": "^18.2.2",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.5.5",

--- a/packages/plugin/src/ContextualMenu.js
+++ b/packages/plugin/src/ContextualMenu.js
@@ -59,56 +59,54 @@ export const ContextualMenu = ({ config, ouLevels, onClick }) => {
         minWidth: 200,
     }
 
-    return (
+    return ouData ? (
         <FlyoutMenu>
-            {ouData && (
-                <MenuItem dense label={i18n.t('Change org unit')}>
-                    {ouData?.parent && (
-                        <>
-                            <MenuItem
-                                dense
-                                icon={<ArrowUpwardIcon />}
-                                label={
-                                    <span style={menuItemStyle}>
-                                        {ouData.parent.name}
-                                    </span>
-                                }
-                                onClick={() =>
-                                    onClick({
-                                        ou: { id: ouData.parent.id },
-                                    })
-                                }
-                            />
-                            {subLevelData && <Divider />}
-                        </>
-                    )}
-                    {subLevelData && (
+            <MenuItem dense label={i18n.t('Change org unit')}>
+                {ouData?.parent && (
+                    <>
                         <MenuItem
                             dense
-                            icon={<ArrowDownwardIcon />}
+                            icon={<ArrowUpwardIcon />}
                             label={
                                 <span style={menuItemStyle}>
-                                    {i18n.t('{{level}} level in {{orgunit}}', {
-                                        level: subLevelData.name,
-                                        orgunit: ouData.name,
-                                    })}
+                                    {ouData.parent.name}
                                 </span>
                             }
                             onClick={() =>
                                 onClick({
-                                    ou: {
-                                        id: ouData.id,
-                                        path: ouData.path,
-                                        level: subLevelData.id,
-                                    },
+                                    ou: { id: ouData.parent.id },
                                 })
                             }
                         />
-                    )}
-                </MenuItem>
-            )}
+                        {subLevelData && <Divider />}
+                    </>
+                )}
+                {subLevelData && (
+                    <MenuItem
+                        dense
+                        icon={<ArrowDownwardIcon />}
+                        label={
+                            <span style={menuItemStyle}>
+                                {i18n.t('{{level}} level in {{orgunit}}', {
+                                    level: subLevelData.name,
+                                    orgunit: ouData.name,
+                                })}
+                            </span>
+                        }
+                        onClick={() =>
+                            onClick({
+                                ou: {
+                                    id: ouData.id,
+                                    path: ouData.path,
+                                    level: subLevelData.id,
+                                },
+                            })
+                        }
+                    />
+                )}
+            </MenuItem>
         </FlyoutMenu>
-    )
+    ) : null
 }
 
 ContextualMenu.propTypes = {

--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -43,9 +43,10 @@ export const VisualizationPlugin = ({
             setContextualMenuConfig(data)
         } else if (
             data.category &&
-            visualization.rows.some(
-                row => row.dimension === DIMENSION_ID_ORGUNIT
-            )
+            ((visualization.rows.length === 1 &&
+                visualization.rows[0].dimension === DIMENSION_ID_ORGUNIT) ||
+                (visualization.rows.length === 2 &&
+                    visualization.rows[1].dimension === DIMENSION_ID_ORGUNIT))
         ) {
             const ouId = Object.values(
                 fetchResult.responses[0].metaData.items

--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -234,7 +234,7 @@ export const VisualizationPlugin = ({
                     <div onClick={closeContextualMenu} style={styles.backdrop}>
                         <Popper
                             reference={virtualContextualMenuElement}
-                            placement="right"
+                            placement="right-start"
                         >
                             <ContextualMenu
                                 config={contextualMenuConfig}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,10 +1499,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^18.2.0":
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-18.2.0.tgz#c4b2141169b6ebe3ef4d0107b390b7f8f413a7cf"
-  integrity sha512-wmvQmrJlx7xppH+1CgdDfA0nT5SJg/49mW4e4b1ih5MX4sCyPPPh8UxQqjBYkZWIyTUaNTiDKocpHDLfVmW8MQ==
+"@dhis2/analytics@^18.2.2":
+  version "18.2.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-18.2.2.tgz#2a00a4924dfa6c6c631e776220b22d26bb499703"
+  integrity sha512-IHKgFJeFYzLjQZfkYgySW6gzD+odmRyYcVj9NacAXOKQNkMul+/D0Y3cY2EfwDn2ADLnxCj15E0ASkl0GjmmBg==
   dependencies:
     "@dhis2/d2-ui-favorites-dialog" "^7.2.0"
     "@dhis2/d2-ui-org-unit-dialog" "^7.2.0"


### PR DESCRIPTION
Implements a fix for [DHIS2-11061](https://jira.dhis2.org/browse/DHIS2-11061)

**Requires https://github.com/dhis2/analytics/pull/931**

---

### Key features

1. Change the popup placement to `right-start`
2. Hide drill down from dual category when org unit is used as the first category
3. Prevent the popup from opening empty while its still loading.

---

### Description

1. Position `right` didn't work for tall items (columns), as it would put the popup in the vertical center. With `right-start` it goes to the top of the right side.
2. Drill down for dual category when the org unit is the first category doesn't make sense, as the column clicked doesn't represent an org unit. To prevent this, dual category drill down is only available when the column is an org unit (i.e. org unit is the second category)
3. Previously the popup would open directly, while it was still loading, to show just a sliver of the popup (see screenshot below). Now it only opens when it's finished loading.

---

### Screenshots

**BEFORE**
_popup opening in an empty state while loading_
![image](https://user-images.githubusercontent.com/12590483/120644466-a4cd4380-c477-11eb-8e9b-99216536519d.png)

_the content of the popup was only shown after the loading was finished_
![image](https://user-images.githubusercontent.com/12590483/120644539-bdd5f480-c477-11eb-966d-38c196b22f83.png)

**AFTER**

_`right-start` placement for dual category column_
![image](https://user-images.githubusercontent.com/12590483/120643857-f4f7d600-c476-11eb-8463-209f8d84e619.png)

_`right-start` placement for dual category stacked bar_
![image](https://user-images.githubusercontent.com/12590483/120643906-02ad5b80-c477-11eb-8b43-ac1cb6529be7.png)

_`right-start` placement for PT_
![image](https://user-images.githubusercontent.com/12590483/120643932-0b9e2d00-c477-11eb-9643-6e6d726abba3.png)

_no popup available when the org unit is the first category_
![image](https://user-images.githubusercontent.com/12590483/120644035-2a9cbf00-c477-11eb-98f6-30f58295c589.png)
