### PR TITLE
fix: drill down bug fix (DHIS2-11061)

### DIFF
--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -38,8 +38,8 @@ export const VisualizationPlugin = ({
 
     const onToggleContextualMenu = (ref, data) => {
         if (data.ouId) {
-            setContextualMenuRef(ref)
             setContextualMenuConfig(data)
+            setContextualMenuRef(ref)
         } else if (
             data.category &&
             ((visualization.rows.length === 1 &&
@@ -56,8 +56,8 @@ export const VisualizationPlugin = ({
                         DIMENSION_ID_ORGUNIT
                     ].includes(item.uid)
             )?.uid
-            setContextualMenuRef(ref)
             setContextualMenuConfig({ ouId })
+            setContextualMenuRef(ref)
         } else if (
             data.category &&
             visualization.columns.some(
@@ -73,8 +73,8 @@ export const VisualizationPlugin = ({
                         DIMENSION_ID_ORGUNIT
                     ].includes(item.uid)
             )?.uid
-            setContextualMenuRef(ref)
             setContextualMenuConfig({ ouId })
+            setContextualMenuRef(ref)
         }
     }
 


### PR DESCRIPTION
Implements a bug fix for [DHIS2-11061](https://jira.dhis2.org/browse/DHIS2-11061)

Reorder the contextual menu props to make sure the ref (which controls the rendering) is only called once the config (content) is set.
Prevents `ContextualMenu` from rendering twice when used in the chart plugin.