### PR TITLE
fix: missing scatter icon (DHIS2-11352) v36

### DIFF
--- a/packages/app/src/components/Visualization/StartScreen.js
+++ b/packages/app/src/components/Visualization/StartScreen.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import { useDataEngine } from '@dhis2/app-runtime'
-import { visTypeIcons } from '@dhis2/analytics'
+import { visTypeIcons, VIS_TYPE_SCATTER } from '@dhis2/analytics'
 
 import styles from './styles/StartScreen.module.css'
 import { sGetLoadError } from '../../reducers/loader'
@@ -21,11 +21,8 @@ const StartScreen = ({ error, username }) => {
 
     useEffect(() => {
         async function populateMostViewedVisualizations(engine) {
-            const mostViewedVisualizationsResult = await apiFetchMostViewedVisualizations(
-                engine,
-                6,
-                username
-            )
+            const mostViewedVisualizationsResult =
+                await apiFetchMostViewedVisualizations(engine, 6, username)
             const visualizations = mostViewedVisualizationsResult.visualization // {position: int, views: int, id: string, created: string}
             if (visualizations && visualizations.length) {
                 const visualizationsResult = await apiFetchVisualizations(
@@ -90,7 +87,7 @@ const StartScreen = ({ error, username }) => {
                                     data-test="start-screen-most-viewed-list-item"
                                 >
                                     <span className={styles.visIcon}>
-                                        {visTypeIcons[visualization.type]}
+                                        {getIcon(visualization.type)}
                                     </span>
                                     <span>{visualization.name}</span>
                                 </p>
@@ -100,6 +97,11 @@ const StartScreen = ({ error, username }) => {
                 )}
             </div>
         )
+
+    const getIcon = visType => {
+        const Icon = visTypeIcons[visType]
+        return visType === VIS_TYPE_SCATTER ? <Icon /> : Icon
+    }
 
     const getErrorContent = () => (
         <div

--- a/packages/app/src/components/Visualization/StartScreen.js
+++ b/packages/app/src/components/Visualization/StartScreen.js
@@ -21,8 +21,11 @@ const StartScreen = ({ error, username }) => {
 
     useEffect(() => {
         async function populateMostViewedVisualizations(engine) {
-            const mostViewedVisualizationsResult =
-                await apiFetchMostViewedVisualizations(engine, 6, username)
+            const mostViewedVisualizationsResult = await apiFetchMostViewedVisualizations(
+                engine,
+                6,
+                username
+            )
             const visualizations = mostViewedVisualizationsResult.visualization // {position: int, views: int, id: string, created: string}
             if (visualizations && visualizations.length) {
                 const visualizationsResult = await apiFetchVisualizations(

--- a/packages/app/src/components/Visualization/StartScreen.js
+++ b/packages/app/src/components/Visualization/StartScreen.js
@@ -87,7 +87,7 @@ const StartScreen = ({ error, username }) => {
                                     data-test="start-screen-most-viewed-list-item"
                                 >
                                     <span className={styles.visIcon}>
-                                        {getIcon(visualization.type)}
+                                        {getVisTypeIcon(visualization.type)}
                                     </span>
                                     <span>{visualization.name}</span>
                                 </p>
@@ -98,7 +98,7 @@ const StartScreen = ({ error, username }) => {
             </div>
         )
 
-    const getIcon = visType => {
+    const getVisTypeIcon = visType => {
         const Icon = visTypeIcons[visType]
         return visType === VIS_TYPE_SCATTER ? <Icon /> : Icon
     }

--- a/packages/app/src/components/Visualization/styles/StartScreen.module.css
+++ b/packages/app/src/components/Visualization/styles/StartScreen.module.css
@@ -84,5 +84,6 @@
 }
 .visIcon svg {
     height: 16px;
+    width: 16px;
     margin-right: var(--spacers-dp8);
 }


### PR DESCRIPTION
Implements [DHIS2-11352](https://jira.dhis2.org/browse/DHIS2-11352) for v36


---

### Key features

1. Wraps the icon for Scatter

---

### Screenshots

_before_
![image](https://user-images.githubusercontent.com/12590483/122212492-31c8c180-cea8-11eb-84a4-29ccc952b66d.png)

_after_
![image](https://user-images.githubusercontent.com/12590483/122212510-38573900-cea8-11eb-90e0-bef53f821476.png)


