### PR TITLE
fix: legend options bleed (DHIS2-11239)

### DIFF
--- a/cypress/elements/optionsModal/index.js
+++ b/cypress/elements/optionsModal/index.js
@@ -13,6 +13,9 @@ export const OPTIONS_TAB_LEGEND = 'Legend'
 export const clickOptionsTab = name =>
     cy.getBySel(tabBarEl).contains(name).click()
 
+export const expectOptionsTabToBeHidden = name =>
+    cy.getBySel(tabBarEl).should('not.contain', name)
+
 export const expectOptionsModalToBeVisible = () =>
     cy.getBySel(optionsModalEl).should('be.visible')
 

--- a/cypress/integration/options/legend.cy.js
+++ b/cypress/integration/options/legend.cy.js
@@ -4,6 +4,8 @@ import {
     VIS_TYPE_SINGLE_VALUE,
     VIS_TYPE_GAUGE,
     VIS_TYPE_PIVOT_TABLE,
+    VIS_TYPE_STACKED_COLUMN,
+    VIS_TYPE_LINE,
     visTypeDisplayNames,
 } from '@dhis2/analytics'
 import {
@@ -42,12 +44,14 @@ import {
     expectLegendKeyToBeVisible,
     expectLegendKeyToBeHidden,
     expectLegendKeyOptionToBeDisabled,
+    expectOptionsTabToBeHidden,
 } from '../../elements/optionsModal'
 import { goToStartPage } from '../../elements/startScreen'
 import { changeVisType } from '../../elements/visualizationTypeSelector'
 import {
     expectWindowConfigSeriesDataLabelsToHaveColor,
     expectWindowConfigSeriesItemToHaveLegendSet,
+    expectWindowConfigSeriesItemToNotHaveLegendSet,
     expectWindowConfigYAxisToHaveColor,
 } from '../../utils/window'
 
@@ -499,6 +503,81 @@ describe('Options - Legend', () => {
             expectLegendKeyToBeHidden()
         })
     })
+    describe('Preventing options bleed: Column -> Stacked column', () => {
+        it('navigates to the start page and adds data items', () => {
+            goToStartPage()
+            openDimension(DIMENSION_ID_DATA)
+            selectIndicators(TEST_ITEMS.map(item => item.name))
+            clickDimensionModalUpdateButton()
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+        })
+        it('enables legend', () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_LEGEND)
+            toggleLegend()
+            expectLegendToBeEnabled()
+            expectLegendDisplayStrategyToBeByDataItem()
+            clickOptionsModalUpdateButton()
+            expectChartTitleToBeVisible()
+        })
+        it('legend is applied to Column', () => {
+            TEST_ITEMS.forEach(item =>
+                expectWindowConfigSeriesItemToHaveLegendSet(
+                    item.name,
+                    item.legendSet
+                )
+            )
+        })
+        it('changes vis type to Stacked column', () => {
+            changeVisType(visTypeDisplayNames[VIS_TYPE_STACKED_COLUMN])
+            clickMenuBarUpdateButton()
+            expectVisualizationToBeVisible(VIS_TYPE_STACKED_COLUMN)
+        })
+        it('legend is not applied to Stacked column', () => {
+            TEST_ITEMS.forEach(item =>
+                expectWindowConfigSeriesItemToNotHaveLegendSet(item.name)
+            )
+        })
+        it('legend options are not available', () => {
+            clickMenuBarOptionsButton()
+            expectOptionsTabToBeHidden(OPTIONS_TAB_LEGEND)
+        })
+        it('legend key is hidden', () => {
+            expectLegendKeyToBeHidden()
+        })
+        it(`series key displays the correct amount of bullets (1 each)`, () => {
+            expectSeriesKeyToHaveSeriesKeyItems(2)
+            expectSeriesKeyItemToHaveBullets(0, 1)
+            expectSeriesKeyItemToHaveBullets(1, 1)
+        })
+    })
+    describe('Non-legend set type displays correctly: Line', () => {
+        it('navigates to the start page and adds data items', () => {
+            goToStartPage()
+            changeVisType(visTypeDisplayNames[VIS_TYPE_LINE])
+            openDimension(DIMENSION_ID_DATA)
+            selectIndicators(TEST_ITEMS.map(item => item.name))
+            clickDimensionModalUpdateButton()
+            expectVisualizationToBeVisible(VIS_TYPE_LINE)
+        })
+        it('legend is not applied to Line', () => {
+            TEST_ITEMS.forEach(item =>
+                expectWindowConfigSeriesItemToNotHaveLegendSet(item.name)
+            )
+        })
+        it('legend options are not available', () => {
+            clickMenuBarOptionsButton()
+            expectOptionsTabToBeHidden(OPTIONS_TAB_LEGEND)
+        })
+        it('legend key is hidden', () => {
+            expectLegendKeyToBeHidden()
+        })
+        it(`series key displays the correct amount of bullets (1 each)`, () => {
+            expectSeriesKeyToHaveSeriesKeyItems(2)
+            expectSeriesKeyItemToHaveBullets(0, 1)
+            expectSeriesKeyItemToHaveBullets(1, 1)
+        })
+    })
     describe('The chart series key displaying legend colors', () => {
         it('navigates to the start page and adds data items', () => {
             goToStartPage()
@@ -543,8 +622,3 @@ describe('Options - Legend', () => {
         })
     })
 })
-
-/*  TODO:
-    - Non-legend vis types should show the default colors
-    - Non-legend vis types should not show the legend tab in options
-*/

--- a/cypress/utils/window.js
+++ b/cypress/utils/window.js
@@ -195,6 +195,16 @@ export const expectWindowConfigSeriesItemToHaveLegendSet = (
             )
         })
 
+export const expectWindowConfigSeriesItemToNotHaveLegendSet = seriesItemName =>
+    cy
+        .window()
+        .its(CONFIG_PROP)
+        .its(SERIES_PROP)
+        .then(series => {
+            const seriesItem = series.find(item => item.name === seriesItemName)
+            seriesItem.data.every(item => expect(item).to.be.a('number'))
+        })
+
 export const expectWindowConfigSeriesDataLabelsToHaveColor = (
     seriesItemIndex,
     expectedColor

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.0.0",
+        "@dhis2/analytics": "^20.0.2",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.0.0",
+        "@dhis2/analytics": "^20.0.2",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.9.0",

--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -6,6 +6,7 @@ import {
     LegendKey,
     LEGEND_DISPLAY_STRATEGY_FIXED,
     LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM,
+    isLegendSetType,
 } from '@dhis2/analytics'
 import { useDataEngine } from '@dhis2/app-runtime'
 import { Popper, Button, IconLegend24 } from '@dhis2/ui'
@@ -205,7 +206,9 @@ export const VisualizationPlugin = ({
         ? { getBoundingClientRect: () => contextualMenuRect }
         : null
 
-    const hasLegendSet = fetchResult.legendSets?.length > 0
+    const hasLegendSet =
+        fetchResult.legendSets?.length > 0 &&
+        isLegendSetType(fetchResult.visualization.type)
     const transformedStyle =
         forDashboard && hasLegendSet
             ? {
@@ -217,7 +220,7 @@ export const VisualizationPlugin = ({
             : style
 
     const getLegendKey = () => {
-        if (forDashboard && hasLegendSet) {
+        if (hasLegendSet && forDashboard) {
             return (
                 <>
                     {showLegendKey && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,10 +1558,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^20.0.0":
-  version "20.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.0.0.tgz#fa18386ef73c69ac2892558f6d860a9b8137a3b3"
-  integrity sha512-N3Y3gb3xyRNIA0JvZNF9qoN8B6oNn2Pvahmof+v2/GEXO26siYAEaMysU9LS5wLidEeuEibhusMtC9blwArIBA==
+"@dhis2/analytics@^20.0.2":
+  version "20.0.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.0.2.tgz#0619ffdba59db03df176ae0c2a7d8d5b55fb68b7"
+  integrity sha512-oN7Fo2BE0PIKbaEUFVoED54v71lnmOpdeK00DPlEvG5vB/97pe+tmONz5imW2vkZGwmS/fqcF7C680GV4iRuOQ==
   dependencies:
     "@dhis2/d2-ui-favorites-dialog" "^7.3.0"
     "@dhis2/d2-ui-org-unit-dialog" "^7.3.0"


### PR DESCRIPTION
Implements [DHIS2-11239](https://jira.dhis2.org/browse/DHIS2-11239)

**Requires https://github.com/dhis2/analytics/pull/982**

---

### Key features

1. check vis type before displaying the legend key
2. add Cypress tests for options bleed

---

### Description

Legend set options were bleeding in to non-supported vis types, as only the existence of a legend set in itself was the criteria to apply legend specific options. Since the user can apply the legend for a supported type and switch to a non-supported type, the current vistype needs to be verified before applying the options.
