### PR TITLE
chore: upgrade react-redux to 7.2.4

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -28,7 +28,7 @@
         "react": "^16.14",
         "react-beautiful-dnd": "^13.1.0",
         "react-dom": "^16.14",
-        "react-redux": "^5.1.0",
+        "react-redux": "^7.2.4",
         "redux": "^4.0.5",
         "redux-actions": "^2.2.1",
         "redux-logger": "^3.0.6",

--- a/packages/app/src/actions/__tests__/index.spec.js
+++ b/packages/app/src/actions/__tests__/index.spec.js
@@ -201,7 +201,7 @@ describe('index', () => {
         })
     })
 
-    describe('clearVisualization', () => {
+    describe('clearAll', () => {
         it('dispatches the correct actions when clearing the visualization', () => {
             const expectedActions = [
                 { type: CLEAR_LOAD_ERROR },
@@ -219,7 +219,7 @@ describe('index', () => {
 
             const store = mockStore({})
 
-            fromActions.clearVisualization(store.dispatch, store.getState)
+            fromActions.clearAll()(store.dispatch, store.getState)
 
             expect(store.getActions()).toEqual(expectedActions)
         })

--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -95,34 +95,36 @@ export const tDoLoadVisualization =
             } else {
                 error = new GenericServerError()
             }
-            clearVisualization(dispatch, getState, error)
+            dispatch(clearAll(error))
 
             logError('tDoLoadVisualization', error)
         }
     }
 
-export const clearVisualization = (dispatch, getState, error = null) => {
-    if (error) {
-        dispatch(fromLoader.acSetLoadError(error))
-    } else {
-        dispatch(fromLoader.acClearLoadError())
+export const clearAll =
+    (error = null) =>
+    (dispatch, getState) => {
+        if (error) {
+            dispatch(fromLoader.acSetLoadError(error))
+        } else {
+            dispatch(fromLoader.acClearLoadError())
+        }
+
+        dispatch(fromVisualization.acClear())
+        dispatch(fromCurrent.acClear())
+
+        const rootOrganisationUnit = sGetRootOrgUnit(getState())
+        const relativePeriod = sGetRelativePeriod(getState())
+        const digitGroupSeparator = sGetSettingsDigitGroupSeparator(getState())
+
+        dispatch(
+            fromUi.acClear({
+                rootOrganisationUnit,
+                relativePeriod,
+                digitGroupSeparator,
+            })
+        )
     }
-
-    dispatch(fromVisualization.acClear())
-    dispatch(fromCurrent.acClear())
-
-    const rootOrganisationUnit = sGetRootOrgUnit(getState())
-    const relativePeriod = sGetRelativePeriod(getState())
-    const digitGroupSeparator = sGetSettingsDigitGroupSeparator(getState())
-
-    dispatch(
-        fromUi.acClear({
-            rootOrganisationUnit,
-            relativePeriod,
-            digitGroupSeparator,
-        })
-    )
-}
 
 export const tDoRenameVisualization =
     ({ name, description }) =>

--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -78,8 +78,6 @@ export class App extends Component {
     }
 
     loadVisualization = async location => {
-        const { store } = this.context
-
         if (location.pathname.length > 1) {
             // /currentAnalyticalObject
             // /${id}/
@@ -106,51 +104,42 @@ export class App extends Component {
             }
 
             if (!urlContainsCurrentAOKey && this.refetch(location)) {
-                await store.dispatch(
-                    fromActions.tDoLoadVisualization({
-                        id,
-                        interpretationId,
-                        ouLevels: this.props.ouLevels,
-                    })
-                )
+                await this.props.setVisualization({
+                    id,
+                    interpretationId,
+                    ouLevels: this.props.ouLevels,
+                })
             }
 
             if (!interpretationId) {
-                store.dispatch(fromActions.fromUi.acClearUiInterpretation())
+                this.props.clearInterpretation()
             }
         } else {
-            fromActions.clearVisualization(store.dispatch, store.getState)
-            fromActions.fromUi.acClearUiInterpretation(store.dispatch)
+            this.props.clearAll()
+            this.props.clearInterpretation()
         }
         this.setState({ initialLoadIsComplete: true })
         this.setState({ previousLocation: location.pathname })
     }
 
     componentDidMount = async () => {
-        const { store } = this.context
         const { d2, userSettings } = this.props
 
-        await store.dispatch(
-            fromActions.fromSettings.tAddSettings(userSettings)
-        )
-        store.dispatch(fromActions.fromUser.acReceivedUser(d2.currentUser))
-        store.dispatch(
-            fromActions.fromUser.tLoadUserAuthority(APPROVAL_LEVEL_OPTION_AUTH)
-        )
-        store.dispatch(fromActions.fromDimensions.tSetDimensions())
+        await this.props.addSettings(userSettings)
+        this.props.setUser(d2.currentUser)
+        this.props.loadUserAuthority(APPROVAL_LEVEL_OPTION_AUTH)
+        this.props.setDimensions()
 
         const rootOrgUnit = this.props.settings.rootOrganisationUnit
 
         if (rootOrgUnit && rootOrgUnit.id) {
-            store.dispatch(
-                fromActions.fromMetadata.acAddMetadata({
-                    ...defaultMetadata(),
-                    [rootOrgUnit.id]: {
-                        ...rootOrgUnit,
-                        path: `/${rootOrgUnit.id}`,
-                    },
-                })
-            )
+            this.props.addMetadata({
+                ...defaultMetadata(),
+                [rootOrgUnit.id]: {
+                    ...rootOrgUnit,
+                    path: `/${rootOrgUnit.id}`,
+                },
+            })
         }
 
         this.loadVisualization(this.props.location)
@@ -334,17 +323,22 @@ const mapStateToProps = state => ({
     snackbar: fromReducers.fromSnackbar.sGetSnackbar(state),
 })
 
-const mapDispatchToProps = dispatch => ({
-    setCurrentFromUi: ui =>
-        dispatch(fromActions.fromCurrent.acSetCurrentFromUi(ui)),
-    clearVisualization: () => dispatch(fromActions.fromVisualization.acClear()),
-    clearCurrent: () => dispatch(fromActions.fromCurrent.acClear()),
-    setUiFromVisualization: visualization =>
-        dispatch(fromActions.fromUi.acSetUiFromVisualization(visualization)),
-    addParentGraphMap: parentGraphMap =>
-        dispatch(fromActions.fromUi.acAddParentGraphMap(parentGraphMap)),
-    clearSnackbar: () => dispatch(fromActions.fromSnackbar.acClearSnackbar()),
-})
+const mapDispatchToProps = {
+    setCurrentFromUi: fromActions.fromCurrent.acSetCurrentFromUi,
+    clearVisualization: fromActions.fromVisualization.acClear,
+    clearCurrent: fromActions.fromCurrent.acClear,
+    setUiFromVisualization: fromActions.fromUi.acSetUiFromVisualization,
+    addParentGraphMap: fromActions.fromUi.acAddParentGraphMap,
+    clearSnackbar: fromActions.fromSnackbar.acClearSnackbar,
+    addSettings: fromActions.fromSettings.tAddSettings,
+    setUser: fromActions.fromUser.acReceivedUser,
+    loadUserAuthority: fromActions.fromUser.tLoadUserAuthority,
+    setDimensions: fromActions.fromDimensions.tSetDimensions,
+    addMetadata: fromActions.fromMetadata.acAddMetadata,
+    setVisualization: fromActions.tDoLoadVisualization,
+    clearInterpretation: fromActions.fromUi.acClearUiInterpretation,
+    clearAll: fromActions.clearAll,
+}
 
 App.contextTypes = {
     store: PropTypes.object,
@@ -358,18 +352,26 @@ App.childContextTypes = {
 }
 
 App.propTypes = {
+    addMetadata: PropTypes.func,
     addParentGraphMap: PropTypes.func,
+    addSettings: PropTypes.func,
     baseUrl: PropTypes.string,
+    clearAll: PropTypes.func,
     clearCurrent: PropTypes.func,
+    clearInterpretation: PropTypes.func,
     clearVisualization: PropTypes.func,
     current: PropTypes.object,
     d2: PropTypes.object,
     dataEngine: PropTypes.object,
     interpretation: PropTypes.object,
+    loadUserAuthority: PropTypes.func,
     location: PropTypes.object,
     ouLevels: PropTypes.array,
     setCurrentFromUi: PropTypes.func,
+    setDimensions: PropTypes.func,
     setUiFromVisualization: PropTypes.func,
+    setUser: PropTypes.func,
+    setVisualization: PropTypes.func,
     settings: PropTypes.object,
     ui: PropTypes.object,
     userSettings: PropTypes.object,

--- a/packages/app/src/components/__tests__/App.spec.js
+++ b/packages/app/src/components/__tests__/App.spec.js
@@ -60,11 +60,19 @@ describe('App', () => {
             setCurrentFromUi: jest.fn(),
             clearVisualization: jest.fn(),
             clearCurrent: jest.fn(),
+            clearAll: jest.fn(),
+            addSettings: jest.fn(),
+            setUser: jest.fn(),
+            loadUserAuthority: jest.fn(),
+            setDimensions: jest.fn(),
+            addMetadata: jest.fn(),
+            setVisualization: jest.fn(),
+            clearInterpretation: jest.fn(),
         }
         shallowApp = undefined
 
         /* eslint-disable no-import-assign, import/namespace */
-        actions.tDoLoadVisualization = jest.fn()
+        props.setVisualization = jest.fn()
         actions.clearVisualization = jest.fn()
         userDataStore.apiFetchAOFromUserDataStore = jest.fn()
         ui.getParentGraphMapFromVisualization = jest.fn()
@@ -84,24 +92,24 @@ describe('App', () => {
     })
 
     describe('location pathname', () => {
-        it('calls clear visualization action when location pathname is root', done => {
+        it('calls clearAll when location pathname is root', done => {
             props.location.pathname = '/'
             app()
 
             setTimeout(() => {
-                expect(actions.tDoLoadVisualization).not.toHaveBeenCalled()
-                expect(actions.clearVisualization).toBeCalledTimes(1)
+                expect(props.setVisualization).not.toHaveBeenCalled()
+                expect(props.clearAll).toBeCalledTimes(1)
                 done()
             })
         })
 
-        it('calls load visualization action when location pathname has length', done => {
+        it('calls setVisualization when location pathname has length', done => {
             props.location.pathname = '/twilightsparkle'
             app()
 
             setTimeout(() => {
-                expect(actions.tDoLoadVisualization).toBeCalledTimes(1)
-                expect(actions.clearVisualization).not.toHaveBeenCalled()
+                expect(props.setVisualization).toBeCalledTimes(1)
+                expect(props.clearAll).not.toHaveBeenCalled()
                 done()
             })
         })
@@ -113,7 +121,7 @@ describe('App', () => {
 
             setTimeout(() => {
                 history.push('/rainbowdash')
-                expect(actions.tDoLoadVisualization).toBeCalledTimes(2)
+                expect(props.setVisualization).toBeCalledTimes(2)
 
                 done()
             })
@@ -129,7 +137,7 @@ describe('App', () => {
                     pathname: '/fluttershy',
                     state: { isOpening: true },
                 })
-                expect(actions.tDoLoadVisualization).toBeCalledTimes(2)
+                expect(props.setVisualization).toBeCalledTimes(2)
 
                 done()
             })
@@ -145,7 +153,7 @@ describe('App', () => {
                     pathname: '/fluttershy',
                     state: { isSaving: true },
                 })
-                expect(actions.tDoLoadVisualization).toBeCalledTimes(2)
+                expect(props.setVisualization).toBeCalledTimes(2)
 
                 done()
             })
@@ -181,7 +189,7 @@ describe('App', () => {
 
                 setTimeout(() => {
                     history.push('/applejack')
-                    expect(actions.tDoLoadVisualization).toBeCalledTimes(1)
+                    expect(props.setVisualization).toBeCalledTimes(1)
 
                     done()
                 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -15047,7 +15047,7 @@ react-portal@^4.1.5:
   dependencies:
     prop-types "^15.5.8"
 
-react-redux@^5.0.7, react-redux@^5.1.0:
+react-redux@^5.0.7:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.2.tgz#b19cf9e21d694422727bf798e934a916c4080f57"
   integrity sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==
@@ -15060,7 +15060,7 @@ react-redux@^5.0.7, react-redux@^5.1.0:
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
 
-react-redux@^7.2.0:
+react-redux@^7.2.0, react-redux@^7.2.4:
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.4.tgz#1ebb474032b72d806de2e0519cd07761e222e225"
   integrity sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==


### PR DESCRIPTION
Had to replace the old school `store.dispatch` in components, which is no longer available in the latest version of `react-redux`. 

The mock store in the tests still provide this so the tests are still using that, but we may want to review the jest tests and discard what we think isn't useful anymore, now that we have cypress.