### PR TITLE
fix: legend key bugs (DHIS2-11239)

### DIFF
--- a/cypress/elements/optionsModal/index.js
+++ b/cypress/elements/optionsModal/index.js
@@ -83,4 +83,5 @@ export {
     expectLegendKeyOptionToBeDisabled,
     expectLegendKeyToBeHidden,
     expectLegendKeyToBeVisible,
+    expectLegedKeyItemAmountToBe,
 } from './legend'

--- a/cypress/elements/optionsModal/index.js
+++ b/cypress/elements/optionsModal/index.js
@@ -63,7 +63,7 @@ export { setCustomSubtitle } from './subtitle'
 
 export { clickOutliersCheckbox } from './outliers'
 
-export { setItemToAxis } from './series'
+export { setItemToAxis, setItemToType } from './series'
 
 export {
     toggleLegend,

--- a/cypress/elements/optionsModal/legend.js
+++ b/cypress/elements/optionsModal/legend.js
@@ -1,6 +1,8 @@
 const optionsModalContentEl = 'options-modal-content'
 const legendKeyOptionEl = 'option-legend-key'
 const legendKeyEl = 'visualization-legend-key'
+const legendKeyContainerEl = 'legend-key-container'
+const legendKeyItemEl = 'legend-key-item'
 const singleValueOutputEl = 'visualization-primary-value'
 const legendDisplayStrategyByDataItemEl = 'legend-display-strategy-BY_DATA_ITEM'
 const legendDisplayStrategyFixedEl = 'legend-display-strategy-FIXED'
@@ -91,3 +93,9 @@ export const expectLegendKeyToBeHidden = () =>
 
 export const expectLegendKeyToBeVisible = () =>
     cy.getBySel(legendKeyEl).should('be.visible')
+
+export const expectLegedKeyItemAmountToBe = amount =>
+    cy
+        .getBySel(legendKeyContainerEl)
+        .findBySelLike(legendKeyItemEl)
+        .should('have.length', amount)

--- a/cypress/elements/optionsModal/series.js
+++ b/cypress/elements/optionsModal/series.js
@@ -4,3 +4,10 @@ export const setItemToAxis = (itemIndex, axis) =>
         .eq(itemIndex)
         .findBySel(`item-axis-${axis}`)
         .click()
+
+export const setItemToType = (itemIndex, type) =>
+    cy
+        .getBySel('series-table-item')
+        .eq(itemIndex)
+        .findBySel(`item-type-${type}`)
+        .click()

--- a/cypress/integration/options/legend.cy.js
+++ b/cypress/integration/options/legend.cy.js
@@ -55,6 +55,8 @@ import {
     expectLegendKeyOptionToBeDisabled,
     expectOptionsTabToBeHidden,
     expectLegedKeyItemAmountToBe,
+    OPTIONS_TAB_SERIES,
+    setItemToType,
 } from '../../elements/optionsModal'
 import { goToStartPage } from '../../elements/startScreen'
 import { changeVisType } from '../../elements/visualizationTypeSelector'
@@ -62,8 +64,10 @@ import {
     expectEachWindowConfigSeriesItemToHaveLegendSet,
     expectEachWindowConfigSeriesItemToNotHaveLegendSet,
     expectWindowConfigSeriesDataLabelsToHaveColor,
+    expectWindowConfigSeriesItemToBeType,
     expectWindowConfigSeriesItemToHaveLegendSet,
     expectWindowConfigSeriesItemToNotHaveLegendSet,
+    expectWindowConfigSeriesItemToNotHaveType,
     expectWindowConfigYAxisToHaveColor,
 } from '../../utils/window'
 
@@ -723,5 +727,112 @@ describe('Options - Legend', () => {
             }
         })
     })
-    describe('Legend is not applied to column-as-line items', () => {})
+    describe('Legend is not applied to column-as-line items', () => {
+        it('navigates to the start page and adds data items, legend and legend key', () => {
+            goToStartPage()
+            openDimension(DIMENSION_ID_DATA)
+            selectIndicators(TEST_ITEMS.map(item => item.name))
+            clickDimensionModalUpdateButton()
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_LEGEND)
+            toggleLegend()
+            expectLegendToBeEnabled()
+            expectLegendDisplayStrategyToBeByDataItem()
+            toggleLegendKeyOption()
+            expectLegendKeyOptionToBeEnabled()
+            clickOptionsModalUpdateButton()
+            expectVisualizationToBeVisible()
+        })
+        it('legend by data item is applied', () => {
+            TEST_ITEMS.forEach(item =>
+                expectWindowConfigSeriesItemToHaveLegendSet(
+                    item.name,
+                    item.legendSet
+                )
+            )
+        })
+        it(`changes all items to type ${VIS_TYPE_LINE}`, () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_SERIES)
+            TEST_ITEMS.forEach((item, index) =>
+                setItemToType(index, VIS_TYPE_LINE)
+            )
+            clickOptionsModalUpdateButton()
+            expectVisualizationToBeVisible()
+            TEST_ITEMS.forEach((item, index) =>
+                expectWindowConfigSeriesItemToBeType(index, 'line')
+            )
+        })
+        it('no legend is applied', () => {
+            expectEachWindowConfigSeriesItemToNotHaveLegendSet()
+        })
+        it('legend key is hidden', () => {
+            expectLegendKeyToBeHidden()
+        })
+        it(`series key displays the correct amount of bullets (1 each)`, () => {
+            expectSeriesKeyToHaveSeriesKeyItems(2)
+            expectSeriesKeyItemToHaveBullets(0, 1)
+            expectSeriesKeyItemToHaveBullets(1, 1)
+        })
+        it(`changes first item (${TEST_ITEMS[0].name}) to type ${VIS_TYPE_COLUMN}`, () => {
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_SERIES)
+            setItemToType(0, VIS_TYPE_COLUMN)
+            clickOptionsModalUpdateButton()
+            expectVisualizationToBeVisible()
+            expectWindowConfigSeriesItemToNotHaveType(0)
+        })
+        it('legend by data item is applied to the first item', () => {
+            expectWindowConfigSeriesItemToHaveLegendSet(
+                TEST_ITEMS[0].name,
+                TEST_ITEMS[0].legendSet
+            )
+            expectWindowConfigSeriesItemToNotHaveLegendSet(TEST_ITEMS[1].name)
+        })
+        it('legend key is shown with 1 item', () => {
+            expectLegendKeyToBeVisible()
+            expectLegedKeyItemAmountToBe(1)
+        })
+        it(`series key items displays the correct amount of bullets (first: ${TEST_ITEMS[1].legends}, second: 1)`, () => {
+            expectSeriesKeyToHaveSeriesKeyItems(2)
+            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
+            expectSeriesKeyItemToHaveBullets(1, 1)
+        })
+        const TEST_ITEM = {
+            name: 'ANC 2 Coverage',
+            legendSet: 'ANC Coverage',
+            legends: 7,
+        }
+        it(`adds a third item (${TEST_ITEM.name} - same legendset as the first item) with type ${VIS_TYPE_LINE}`, () => {
+            openDimension(DIMENSION_ID_DATA)
+            selectIndicators([TEST_ITEM.name])
+            clickDimensionModalUpdateButton()
+            expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_SERIES)
+            setItemToType(2, VIS_TYPE_LINE)
+            clickOptionsModalUpdateButton()
+            expectVisualizationToBeVisible()
+            expectWindowConfigSeriesItemToNotHaveType(0)
+        })
+        it('legend key is shown with 1 item', () => {
+            expectLegendKeyToBeVisible()
+            expectLegedKeyItemAmountToBe(1)
+        })
+        it('legend by data item is applied to the first item', () => {
+            expectWindowConfigSeriesItemToHaveLegendSet(
+                TEST_ITEMS[0].name,
+                TEST_ITEMS[0].legendSet
+            )
+            expectWindowConfigSeriesItemToNotHaveLegendSet(TEST_ITEMS[1].name)
+            expectWindowConfigSeriesItemToNotHaveLegendSet(TEST_ITEM.name)
+        })
+        it(`series key items displays the correct amount of bullets (first: ${TEST_ITEMS[1].legends}, second: 1, third: 1)`, () => {
+            expectSeriesKeyToHaveSeriesKeyItems(3)
+            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
+            expectSeriesKeyItemToHaveBullets(1, 1)
+            expectSeriesKeyItemToHaveBullets(2, 1)
+        })
+    })
 })

--- a/cypress/utils/data.js
+++ b/cypress/utils/data.js
@@ -10,7 +10,6 @@ import {
     VIS_TYPE_SCATTER,
     VIS_TYPE_RADAR,
     VIS_TYPE_SINGLE_VALUE,
-    VIS_TYPE_AREA,
     VIS_TYPE_STACKED_BAR,
     VIS_TYPE_STACKED_AREA,
     VIS_TYPE_YEAR_OVER_YEAR_COLUMN,
@@ -72,10 +71,10 @@ export const TEST_AOS = [
         name: 'BCG coverage last 12 months - Bo',
         type: VIS_TYPE_SINGLE_VALUE,
     },
-    {
-        name: 'Expenditures: Expenses by districts area',
-        type: VIS_TYPE_AREA,
-    },
+    // {
+    //     name: 'Expenditures: Expenses by districts area',
+    //     type: VIS_TYPE_AREA,
+    // }, // FIXME: replace with an AO that has data for "Last 2 six-month"
     {
         name: 'Nutrition: Malnutrition indicators stacked bar',
         type: VIS_TYPE_STACKED_BAR,

--- a/cypress/utils/data.js
+++ b/cypress/utils/data.js
@@ -8,6 +8,12 @@ import {
     VIS_TYPE_STACKED_COLUMN,
     VIS_TYPE_YEAR_OVER_YEAR_LINE,
     VIS_TYPE_SCATTER,
+    VIS_TYPE_RADAR,
+    VIS_TYPE_SINGLE_VALUE,
+    VIS_TYPE_AREA,
+    VIS_TYPE_STACKED_BAR,
+    VIS_TYPE_STACKED_AREA,
+    VIS_TYPE_YEAR_OVER_YEAR_COLUMN,
 } from '@dhis2/analytics'
 
 /*
@@ -47,6 +53,10 @@ export const TEST_AOS = [
         type: VIS_TYPE_GAUGE,
     },
     {
+        name: 'Immunization: Indicators last 12 months radar',
+        type: VIS_TYPE_RADAR,
+    },
+    {
         name: 'Immunization: FIC year over year',
         type: VIS_TYPE_YEAR_OVER_YEAR_LINE,
     },
@@ -57,6 +67,26 @@ export const TEST_AOS = [
     {
         name: 'Measles: Dropout rate v Coverage <1y per district',
         type: VIS_TYPE_SCATTER,
+    },
+    {
+        name: 'BCG coverage last 12 months - Bo',
+        type: VIS_TYPE_SINGLE_VALUE,
+    },
+    {
+        name: 'Expenditures: Expenses by districts area',
+        type: VIS_TYPE_AREA,
+    },
+    {
+        name: 'Nutrition: Malnutrition indicators stacked bar',
+        type: VIS_TYPE_STACKED_BAR,
+    },
+    {
+        name: 'Nutrition: Malnutrition indicators stacked area',
+        type: VIS_TYPE_STACKED_AREA,
+    },
+    {
+        name: 'Nutrition: Malnutrition this year vs last year',
+        type: VIS_TYPE_YEAR_OVER_YEAR_COLUMN,
     },
 ]
 

--- a/cypress/utils/window.js
+++ b/cypress/utils/window.js
@@ -195,6 +195,19 @@ export const expectWindowConfigSeriesItemToHaveLegendSet = (
             )
         })
 
+export const expectEachWindowConfigSeriesItemToHaveLegendSet = expectedLS =>
+    cy
+        .window()
+        .its(CONFIG_PROP)
+        .its(SERIES_PROP)
+        .then(series =>
+            series.forEach(seriesItem =>
+                seriesItem.data.every(item =>
+                    expect(item.legendSet).to.eq(expectedLS)
+                )
+            )
+        )
+
 export const expectWindowConfigSeriesItemToNotHaveLegendSet = seriesItemName =>
     cy
         .window()
@@ -204,6 +217,17 @@ export const expectWindowConfigSeriesItemToNotHaveLegendSet = seriesItemName =>
             const seriesItem = series.find(item => item.name === seriesItemName)
             seriesItem.data.every(item => expect(item).to.be.a('number'))
         })
+
+export const expectEachWindowConfigSeriesItemToNotHaveLegendSet = () =>
+    cy
+        .window()
+        .its(CONFIG_PROP)
+        .its(SERIES_PROP)
+        .then(series =>
+            series.forEach(seriesItem =>
+                seriesItem.data.every(item => expect(item).to.be.a('number'))
+            )
+        )
 
 export const expectWindowConfigSeriesDataLabelsToHaveColor = (
     seriesItemIndex,

--- a/cypress/utils/window.js
+++ b/cypress/utils/window.js
@@ -100,6 +100,24 @@ export const expectWindowConfigSeriesToHaveTrendline = expectedTL =>
             expect(actualTL.zIndex).to.eq(expectedTL.zIndex)
         })
 
+export const expectWindowConfigSeriesItemToBeType = (itemIndex, type) =>
+    cy
+        .window()
+        .its(CONFIG_PROP)
+        .its(SERIES_PROP)
+        .then(series => {
+            expect(series[itemIndex].type).to.eq(type)
+        })
+
+export const expectWindowConfigSeriesItemToNotHaveType = itemIndex =>
+    cy
+        .window()
+        .its(CONFIG_PROP)
+        .its(SERIES_PROP)
+        .then(series => {
+            expect(series[itemIndex].type).to.be.undefined
+        })
+
 export const expectWindowConfigYAxisToHaveTitleText = text =>
     cy
         .window()

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.0.2",
+        "@dhis2/analytics": "^20.0.3",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.0.3",
+        "@dhis2/analytics": "^20.0.4",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/app/src/components/VisualizationOptions/Options/ColorSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/ColorSet.js
@@ -84,20 +84,33 @@ const ColorSetPreview = ({ colorSet, disabled }) => (
     >
         {colorSet?.patterns &&
             colorSet.patterns.map((pattern, index) => (
-                <div key={`pattern-${index}`}>
-                    <svg
-                        width={14}
-                        height={14}
-                        xmlns="http://www.w3.org/2000/svg"
-                    >
-                        <path
-                            d={pattern.path}
-                            stroke={pattern.color}
-                            strokeWidth={2}
-                            fill="none"
-                        />
-                    </svg>
-                </div>
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width={14}
+                    height={14}
+                    key={`pattern-${index}`}
+                >
+                    <defs>
+                        <pattern
+                            id={`bg${index}`}
+                            patternUnits="userSpaceOnUse"
+                            width={pattern.width}
+                            height={pattern.height}
+                        >
+                            <path
+                                d={pattern.path}
+                                stroke={pattern.color}
+                                strokeWidth={2}
+                                fill="none"
+                            />
+                        </pattern>
+                    </defs>
+                    <rect
+                        height="14"
+                        width="14"
+                        fill={`url(#bg${index})`}
+                    ></rect>
+                </svg>
             ))}
         {colorSet?.colors &&
             colorSet.colors.map(color => (

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.0.3",
+        "@dhis2/analytics": "^20.0.4",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.10.5",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.0.2",
+        "@dhis2/analytics": "^20.0.3",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.10.5",

--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -7,6 +7,7 @@ import {
     LEGEND_DISPLAY_STRATEGY_FIXED,
     LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM,
     isLegendSetType,
+    VIS_TYPE_LINE,
 } from '@dhis2/analytics'
 import { useDataEngine } from '@dhis2/app-runtime'
 import { Popper, Button, IconLegend24 } from '@dhis2/ui'
@@ -206,8 +207,21 @@ export const VisualizationPlugin = ({
         ? { getBoundingClientRect: () => contextualMenuRect }
         : null
 
+    const legendSets = fetchResult.legendSets.filter(legendSet =>
+        Object.values(fetchResult.responses[0].metaData.items)
+            .filter(item =>
+                visualization.series
+                    .filter(serie => serie.type !== VIS_TYPE_LINE)
+                    .map(serie => serie.dimensionItem)
+                    .includes(item.uid)
+            )
+            .map(item => item.legendSet)
+            .includes(legendSet.id)
+    )
+    // TODO: remove all legendSets that only belong to data items when data isn't on Series and "by element" strategy is used
+
     const hasLegendSet =
-        fetchResult.legendSets?.length > 0 &&
+        legendSets?.length > 0 &&
         isLegendSetType(fetchResult.visualization.type)
     const transformedStyle =
         forDashboard && hasLegendSet
@@ -234,9 +248,7 @@ export const VisualizationPlugin = ({
                                     ...styles.buttonMargin,
                                 }}
                             >
-                                <LegendKey
-                                    legendSets={fetchResult.legendSets}
-                                />
+                                <LegendKey legendSets={legendSets} />
                             </div>
                         </div>
                     )}
@@ -261,7 +273,7 @@ export const VisualizationPlugin = ({
                     data-test="visualization-legend-key"
                 >
                     <div style={styles.wrapper}>
-                        <LegendKey legendSets={fetchResult.legendSets} />
+                        <LegendKey legendSets={legendSets} />
                     </div>
                 </div>
             )
@@ -279,7 +291,7 @@ export const VisualizationPlugin = ({
                             fetchResult.visualization
                         )}
                         responses={fetchResult.responses}
-                        legendSets={fetchResult.legendSets}
+                        legendSets={legendSets}
                         onToggleContextualMenu={
                             onDrill ? onToggleContextualMenu : undefined
                         }
@@ -294,7 +306,7 @@ export const VisualizationPlugin = ({
                         )}
                         responses={fetchResult.responses}
                         extraOptions={fetchResult.extraOptions}
-                        legendSets={fetchResult.legendSets}
+                        legendSets={legendSets}
                         onToggleContextualMenu={
                             onDrill ? onToggleContextualMenu : undefined
                         }

--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -352,7 +352,7 @@ VisualizationPlugin.propTypes = {
     visualization: PropTypes.object.isRequired,
     filters: PropTypes.object,
     forDashboard: PropTypes.bool,
-    id: PropTypes.string,
+    id: PropTypes.number,
     style: PropTypes.object,
     userSettings: PropTypes.object,
     onChartGenerated: PropTypes.func,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2682,10 +2682,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^20.0.3":
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.0.3.tgz#62ea67eae1451a7257e216878f54fc4837bd35a1"
-  integrity sha512-7GrB4cEKY4HJHDRLhnGq3aRYr/8bTwDZEQ+32X6nvWR4EfcctAg4VmwPwP8u550/SRg75cew/xDpwS7FThoF4Q==
+"@dhis2/analytics@^20.0.4":
+  version "20.0.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.0.4.tgz#d68fa1c068a5ca58731dcd90526f3291e6189358"
+  integrity sha512-0ogkqlmXrOdDaZ60RDSIIIMJEp/e1OqISzekEYMc9WwKNpVOXU681o+oXlBgAl1KEm0w5AB0KDZT6H+sr1Y2uQ==
   dependencies:
     "@dhis2/d2-ui-favorites-dialog" "^7.3.0"
     "@dhis2/d2-ui-org-unit-dialog" "^7.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2682,10 +2682,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^20.0.2":
-  version "20.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.0.2.tgz#0619ffdba59db03df176ae0c2a7d8d5b55fb68b7"
-  integrity sha512-oN7Fo2BE0PIKbaEUFVoED54v71lnmOpdeK00DPlEvG5vB/97pe+tmONz5imW2vkZGwmS/fqcF7C680GV4iRuOQ==
+"@dhis2/analytics@^20.0.3":
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.0.3.tgz#62ea67eae1451a7257e216878f54fc4837bd35a1"
+  integrity sha512-7GrB4cEKY4HJHDRLhnGq3aRYr/8bTwDZEQ+32X6nvWR4EfcctAg4VmwPwP8u550/SRg75cew/xDpwS7FThoF4Q==
   dependencies:
     "@dhis2/d2-ui-favorites-dialog" "^7.3.0"
     "@dhis2/d2-ui-org-unit-dialog" "^7.3.0"


### PR DESCRIPTION
Implements [DHIS2-11239](https://jira.dhis2.org/browse/DHIS2-11239)

**Requires https://github.com/dhis2/analytics/pull/983**

---

### Key features

1. Correctly removes legend from column-as-line items 
2. Fixes a visual regression for the pattern preview due to a highcharts version bump
3. Implements the latest version of Analytics that also fixes:
- 3a. Prevent gauge from applying legend to fill when text is selected
- 3b. Add missing series key icon for trendline
- 3c. Add missing series key icon for pattern

---

### Screenshots

_column-as-line won't display a legend_
![image](https://user-images.githubusercontent.com/12590483/125294626-b7635400-e324-11eb-8324-dc7d75036672.png)

_pattern and trendline icons in the series key display correctly_
![image](https://user-images.githubusercontent.com/12590483/125294825-e974b600-e324-11eb-804a-e0b73c9abfcd.png)


_color set patterns_
![image](https://user-images.githubusercontent.com/12590483/125055861-f33db580-e0a7-11eb-9b8f-5fc532d208dc.png)

