### PR TITLE
fix: prevent outline clipping (DHIS2-11239)

### DIFF
--- a/packages/plugin/src/styles/VisualizationPlugin.style.js
+++ b/packages/plugin/src/styles/VisualizationPlugin.style.js
@@ -7,7 +7,7 @@ export default {
         width: '180px',
     },
     legendKeyToggle: {
-        margin: '0 4px',
+        margin: '1px 4px 0',
     },
     wrapper: {
         position: 'absolute',


### PR DESCRIPTION
Implements [DHIS2-11239](https://jira.dhis2.org/browse/DHIS2-11239)

---

### Key features

1. Prevents the outline of the legend key button to be clipped at the top

---

### Screenshots

Note the top part of the yellow outline in the screenshots below:

_before_
![image](https://user-images.githubusercontent.com/12590483/128707079-86847331-d78a-4b0a-aea5-9321ec88d1e1.png)

_after_
![image](https://user-images.githubusercontent.com/12590483/128707099-7b2714fc-f154-4c9c-b139-c1da52d79672.png)

