### PR TITLE
chore: prevent dependabot prs to run the artifacts job

### DIFF
--- a/.github/workflows/dhis2-artifacts.yml
+++ b/.github/workflows/dhis2-artifacts.yml
@@ -8,7 +8,7 @@ env:
 jobs:
     publish:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        if: "!contains(github.event.head_commit.message, '[skip ci]') && !github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1

--- a/.github/workflows/dhis2-artifacts.yml
+++ b/.github/workflows/dhis2-artifacts.yml
@@ -8,7 +8,7 @@ env:
 jobs:
     publish:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]') && !github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
+        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1


### PR DESCRIPTION
Fix failing dependabot PR checks (e.g. https://github.com/dhis2/data-visualizer-app/pull/1816/checks?check_run_id=3286817639) by preventing dependabot PRs from running the artifacts job. Reference: https://github.com/dhis2/workflows/blob/master/ci/dhis2-verify-app.yml#L115