### PR TITLE
fix: drill-down menu render side (DHIS2-11061)

### DIFF
--- a/packages/plugin/src/ContextualMenu.js
+++ b/packages/plugin/src/ContextualMenu.js
@@ -1,13 +1,13 @@
 import { apiFetchOrganisationUnit } from '@dhis2/analytics'
 import { useDataEngine } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
-import { Divider, FlyoutMenu, MenuItem } from '@dhis2/ui'
+import { Divider, FlyoutMenu, MenuItem, Popper } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState, useCallback } from 'react'
 import ArrowDownwardIcon from './assets/ArrowDownwardIcon'
 import ArrowUpwardIcon from './assets/ArrowUpwardIcon'
 
-export const ContextualMenu = ({ config, ouLevels, onClick }) => {
+export const ContextualMenu = ({ config, ouLevels, onClick, reference }) => {
     const engine = useDataEngine()
     const [ouData, setOuData] = useState(undefined)
     const [subLevelData, setSubLevelData] = useState(undefined)
@@ -59,58 +59,61 @@ export const ContextualMenu = ({ config, ouLevels, onClick }) => {
     }
 
     return ouData ? (
-        <FlyoutMenu>
-            <MenuItem dense label={i18n.t('Change org unit')}>
-                {ouData?.parent && (
-                    <>
+        <Popper reference={reference} placement="right-start">
+            <FlyoutMenu>
+                <MenuItem dense label={i18n.t('Change org unit')}>
+                    {ouData?.parent && (
+                        <>
+                            <MenuItem
+                                dense
+                                icon={<ArrowUpwardIcon />}
+                                label={
+                                    <span style={menuItemStyle}>
+                                        {ouData.parent.name}
+                                    </span>
+                                }
+                                onClick={() =>
+                                    onClick({
+                                        ou: { id: ouData.parent.id },
+                                    })
+                                }
+                            />
+                            {subLevelData && <Divider />}
+                        </>
+                    )}
+                    {subLevelData && (
                         <MenuItem
                             dense
-                            icon={<ArrowUpwardIcon />}
+                            icon={<ArrowDownwardIcon />}
                             label={
                                 <span style={menuItemStyle}>
-                                    {ouData.parent.name}
+                                    {i18n.t('{{level}} level in {{orgunit}}', {
+                                        level: subLevelData.name,
+                                        orgunit: ouData.name,
+                                    })}
                                 </span>
                             }
                             onClick={() =>
                                 onClick({
-                                    ou: { id: ouData.parent.id },
+                                    ou: {
+                                        id: ouData.id,
+                                        path: ouData.path,
+                                        level: subLevelData.id,
+                                    },
                                 })
                             }
                         />
-                        {subLevelData && <Divider />}
-                    </>
-                )}
-                {subLevelData && (
-                    <MenuItem
-                        dense
-                        icon={<ArrowDownwardIcon />}
-                        label={
-                            <span style={menuItemStyle}>
-                                {i18n.t('{{level}} level in {{orgunit}}', {
-                                    level: subLevelData.name,
-                                    orgunit: ouData.name,
-                                })}
-                            </span>
-                        }
-                        onClick={() =>
-                            onClick({
-                                ou: {
-                                    id: ouData.id,
-                                    path: ouData.path,
-                                    level: subLevelData.id,
-                                },
-                            })
-                        }
-                    />
-                )}
-            </MenuItem>
-        </FlyoutMenu>
+                    )}
+                </MenuItem>
+            </FlyoutMenu>
+        </Popper>
     ) : null
 }
 
 ContextualMenu.propTypes = {
     config: PropTypes.object,
     ouLevels: PropTypes.array,
+    reference: PropTypes.object,
     onClick: PropTypes.func,
 }
 

--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -10,7 +10,7 @@ import {
     VIS_TYPE_LINE,
 } from '@dhis2/analytics'
 import { useDataEngine } from '@dhis2/app-runtime'
-import { Popper, Button, IconLegend24 } from '@dhis2/ui'
+import { Button, IconLegend24 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
@@ -349,16 +349,12 @@ export const VisualizationPlugin = ({
             {contextualMenuRect &&
                 createPortal(
                     <div onClick={closeContextualMenu} style={styles.backdrop}>
-                        <Popper
+                        <ContextualMenu
                             reference={virtualContextualMenuElement}
-                            placement="right-start"
-                        >
-                            <ContextualMenu
-                                config={contextualMenuConfig}
-                                ouLevels={ouLevels}
-                                onClick={onContextualMenuItemClick}
-                            />
-                        </Popper>
+                            config={contextualMenuConfig}
+                            ouLevels={ouLevels}
+                            onClick={onContextualMenuItemClick}
+                        />
                     </div>,
                     document.body
                 )}


### PR DESCRIPTION
Fixes a bug for [DHIS2-11061](https://jira.dhis2.org/browse/DHIS2-11061)

---

### Key features

1. Prevent the drill-down menu from rendering on the wrong side

---

### Description
For the drill-down menu, the content needs to fetch data, so `ContextualMenu` will return null on the first render. The `Popper` would however still render, and since it didn't have any content, it couldn't correctly figure out which side of the element to render on. Once the content was finished loading, this could be placed outside of the viewport, leaving the menu to be cut off.

By bundling the `Popper` with the content, the `Popper` as a whole will only render once the content is ready, meaning the placement can be properly made (i.e. too far to the right edge = render on the left).

---

### Screenshots

_before, Column_
![image](https://user-images.githubusercontent.com/12590483/130042774-4ed3cd22-c329-40ed-b600-4fe5dd2f4436.png)

_after, Column_
![image](https://user-images.githubusercontent.com/12590483/130042944-309c2c0f-22a9-4ea2-b1de-76331175bff7.png)

_before, PT_
![image](https://user-images.githubusercontent.com/12590483/130042675-ed161c3e-b2f5-4eae-8d71-01769e222ae5.png)

_after, PT_
![image](https://user-images.githubusercontent.com/12590483/130042866-48646b09-13ea-455d-b420-ec7b7409cfd0.png)

