### PR TITLE
fix: only store auto and custom title options (DHIS2-11650)

### DIFF
--- a/packages/app/src/components/VisualizationOptions/Options/AxisTitle.js
+++ b/packages/app/src/components/VisualizationOptions/Options/AxisTitle.js
@@ -19,9 +19,9 @@ import {
 } from '../styles/VisualizationOptions.style.js'
 import TextStyle from './TextStyle'
 
-const TITLE_AUTO = 'AUTO'
-const TITLE_NONE = 'NONE'
-const TITLE_CUSTOM = 'CUSTOM'
+export const TITLE_AUTO = 'AUTO'
+export const TITLE_NONE = 'NONE'
+export const TITLE_CUSTOM = 'CUSTOM'
 const colors = ['#4292c6', '#cb181d', '#41ab5d', '#6c66b8']
 
 const AxisTitle = ({

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -19,6 +19,10 @@ import {
 import objectClean from 'd2-utilizr/lib/objectClean'
 import castArray from 'lodash-es/castArray'
 import {
+    TITLE_AUTO,
+    TITLE_CUSTOM,
+} from '../components/VisualizationOptions/Options/AxisTitle'
+import {
     getFilteredLayout,
     getInverseLayout,
     getRetransfer,
@@ -238,7 +242,9 @@ export default (state = DEFAULT_UI, action) => {
                         ...axis,
                         title: {
                             ...axis.title,
-                            textMode: value,
+                            textMode: [TITLE_CUSTOM, TITLE_AUTO].includes(value)
+                                ? value
+                                : null,
                         },
                     })
                     break


### PR DESCRIPTION
Fixes [DHIS2-11650](https://jira.dhis2.org/browse/DHIS2-11650)

---

### Key features

1. Prevent "NONE" from being stored / saved

---

### Description

Backend only supports saving "CUSTOM" and "AUTO", so the "NONE" option needs to be excluded from being stored and saved.
Setting the option to null when "NONE" is being used means that the store will strip out that value and thus strip out the whole axis options object, so setting "NONE" resets the store back to its original state as it should.