### PR TITLE
fix: fetch PT fix headers options

### DIFF
--- a/packages/app/src/modules/fields/baseFields.js
+++ b/packages/app/src/modules/fields/baseFields.js
@@ -18,6 +18,8 @@ export const fieldsByType = {
         getFieldObject('regression', { option: true }),
         getFieldObject('reportingParams', { option: true }),
         getFieldObject('skipRounding', { option: true }),
+        getFieldObject('fixColumnHeaders', { option: true }),
+        getFieldObject('fixRowHeaders', { option: true }),
     ],
     chart: [
         getFieldObject('category', { excluded: true }),

--- a/packages/plugin/src/modules/options.js
+++ b/packages/plugin/src/modules/options.js
@@ -89,12 +89,12 @@ export const options = {
         requestable: true,
         savable: false,
     },
-    fixedColumnHeaders: {
+    fixColumnHeaders: {
         defaultValue: false,
         requestable: false,
         savable: true,
     },
-    fixedRowHeaders: {
+    fixRowHeaders: {
         defaultValue: false,
         requestable: false,
         savable: true,


### PR DESCRIPTION
Part of the implementation for [DHIS2-11057](https://jira.dhis2.org/browse/DHIS2-11057)

---

### Key features

1. Fetch the PT fix headers options on visualization load

---

### Description

The options can be saved, but need to be in the list of fields when fetching the visualization.