### PR TITLE
fix: update analytics with SV no data fix

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.4.7",
+        "@dhis2/analytics": "^20.4.8",
         "@dhis2/app-runtime": "^2.11.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.4.7",
+        "@dhis2/analytics": "^20.4.8",
         "@dhis2/app-runtime": "^2.11.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.23.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,10 +2105,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^20.4.7":
-  version "20.4.7"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.4.7.tgz#97ae0a5470585b50928b253fa08e8e511993d397"
-  integrity sha512-zWzkecWElWd3M/3Irf4SJ19ekIuyWKb0f9+UVpRpdsCn1/qvlRAJ4zz0NtWAhwBChye3ZW8CExSSJYdrCSrzIw==
+"@dhis2/analytics@^20.4.8":
+  version "20.4.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.4.8.tgz#caf64b342d7b5ff262d5a813dcf7edc83a0c1f01"
+  integrity sha512-/wqvEcJMKiQv2ZzFrlHFyEmbuDj7QG+LT1+HvFdfl307sOQdEIsck368IWRIZ0fF8T19eXIf6uPrHrKJBzfiHg==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.3.0"
     "@dhis2/d2-ui-translation-dialog" "^7.3.1"
@@ -17785,10 +17785,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
**Requires https://github.com/dhis2/analytics/pull/1048**

---

### Key features

1. Update analytics with the fix for SV no data issue

---

### Description

The version bump here is needed for the plugin also used in dashboard app where the problem showed.
DV has a different handling for the no data situation, so no apparent changes in DV.