### PR TITLE
fix: return a flat list of dimension items with multiple dimension on axis

### DIFF
--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -686,7 +686,6 @@ describe('reducer: ui', () => {
                 },
             }
 
-            // TODO: what is the expected result?
             const expectedDimensions = ['anc', 'bcg', 'six-months']
 
             expect(ui.sGetDimensionItemsByAxis(state, AXIS_ID_ROWS)).toEqual(

--- a/packages/app/src/reducers/__tests__/ui.spec.js
+++ b/packages/app/src/reducers/__tests__/ui.spec.js
@@ -642,4 +642,56 @@ describe('reducer: ui', () => {
 
         expect(actualState.rightSidebarOpen).toEqual(false)
     })
+
+    describe('selectors', () => {
+        it('sGetDimensionItemsByAxis when 1 dimension on requested axis', () => {
+            const state = {
+                ui: {
+                    layout: {
+                        [AXIS_ID_COLUMNS]: [DIMENSION_ID_DATA],
+                        [AXIS_ID_ROWS]: [DIMENSION_ID_ORGUNIT],
+                        [AXIS_ID_FILTERS]: [DIMENSION_ID_PERIOD],
+                    },
+                    itemsByDimension: {
+                        [DIMENSION_ID_DATA]: ['anc', 'bcg'],
+                        [DIMENSION_ID_ORGUNIT]: ['tanzania'],
+                        [DIMENSION_ID_PERIOD]: ['six-months'],
+                    },
+                },
+            }
+
+            const expectedDimensions = ['anc', 'bcg']
+
+            expect(ui.sGetDimensionItemsByAxis(state, AXIS_ID_COLUMNS)).toEqual(
+                expectedDimensions
+            )
+        })
+
+        it('sGetDimensionItemsByAxis when 2 dimensions on requested axis', () => {
+            const state = {
+                ui: {
+                    layout: {
+                        [AXIS_ID_COLUMNS]: [DIMENSION_ID_ORGUNIT],
+                        [AXIS_ID_ROWS]: [
+                            DIMENSION_ID_DATA,
+                            DIMENSION_ID_PERIOD,
+                        ],
+                        [AXIS_ID_FILTERS]: ['FACILITY_TYPE'],
+                    },
+                    itemsByDimension: {
+                        [DIMENSION_ID_DATA]: ['anc', 'bcg'],
+                        [DIMENSION_ID_ORGUNIT]: ['tanzania'],
+                        [DIMENSION_ID_PERIOD]: ['six-months'],
+                    },
+                },
+            }
+
+            // TODO: what is the expected result?
+            const expectedDimensions = ['anc', 'bcg', 'six-months']
+
+            expect(ui.sGetDimensionItemsByAxis(state, AXIS_ID_ROWS)).toEqual(
+                expectedDimensions
+            )
+        })
+    })
 })

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -108,8 +108,11 @@ export const PRESELECTED_YEAR_OVER_YEAR_SERIES = ['THIS_YEAR', 'LAST_YEAR']
 export const PRESELECTED_YEAR_OVER_YEAR_CATEGORY = ['MONTHS_THIS_YEAR']
 
 const getPreselectedUi = options => {
-    const { rootOrganisationUnit, relativePeriod, digitGroupSeparator } =
-        options
+    const {
+        rootOrganisationUnit,
+        relativePeriod,
+        digitGroupSeparator,
+    } = options
 
     const rootOrganisationUnits = []
     const parentGraphMap = { ...DEFAULT_UI.parentGraphMap }
@@ -724,8 +727,16 @@ export const sGetAxisIdByDimensionId = (state, dimensionId) =>
 export const sGetUiItemsByDimension = (state, dimension) =>
     sGetUiItems(state)[dimension] || DEFAULT_UI.itemsByDimension[dimension]
 
-export const sGetDimensionItemsByAxis = (state, axisId) =>
-    sGetUiItemsByDimension(state, (sGetUiLayout(state) || {})[axisId]) || []
+export const sGetDimensionItemsByAxis = (state, axisId) => {
+    const dimensions = (sGetUiLayout(state) || {})[axisId] || []
+
+    return dimensions
+        .reduce((items, dimension) => {
+            items.push(sGetUiItemsByDimension(state, dimension))
+            return items
+        }, [])
+        .flat()
+}
 
 export const sGetDimensionIdsFromLayout = state =>
     Object.values(sGetUiLayout(state)).reduce(

--- a/packages/app/src/reducers/ui.js
+++ b/packages/app/src/reducers/ui.js
@@ -108,11 +108,8 @@ export const PRESELECTED_YEAR_OVER_YEAR_SERIES = ['THIS_YEAR', 'LAST_YEAR']
 export const PRESELECTED_YEAR_OVER_YEAR_CATEGORY = ['MONTHS_THIS_YEAR']
 
 const getPreselectedUi = options => {
-    const {
-        rootOrganisationUnit,
-        relativePeriod,
-        digitGroupSeparator,
-    } = options
+    const { rootOrganisationUnit, relativePeriod, digitGroupSeparator } =
+        options
 
     const rootOrganisationUnits = []
     const parentGraphMap = { ...DEFAULT_UI.parentGraphMap }


### PR DESCRIPTION
Implements [DHIS2-XXXX](https://jira.dhis2.org/browse/DHIS2-XXXX)

### Key features

1. Bug fix

---

### Description

The `sGetDimensionItemsByAxis` incorrectly returned `undefined` if more than 1 dimension was selected on an axis.
The reason was that an array was passed to `sGetUiItemsByDimension` instead of a dimension id causing that function to return `undefined`.
The fix is looping through the dimensions array and call `sGetUiItemsByDimension` for each dimension before returning a flattened list of dimension items.