### PR TITLE
fix: PT fixed headers help text

### DIFF
--- a/packages/app/i18n/en.pot
+++ b/packages/app/i18n/en.pot
@@ -414,8 +414,14 @@ msgstr "Number"
 msgid "Fix column headers to top of table"
 msgstr "Fix column headers to top of table"
 
+msgid "There aren’t any column headers because Columns is empty."
+msgstr "There aren’t any column headers because Columns is empty."
+
 msgid "Fix row headers to left of table"
 msgstr "Fix row headers to left of table"
+
+msgid "There aren’t any row headers because Rows is empty."
+msgstr "There aren’t any row headers because Rows is empty."
 
 msgid "Font size"
 msgstr "Font size"

--- a/packages/app/src/components/VisualizationOptions/Options/CheckboxBaseOption.js
+++ b/packages/app/src/components/VisualizationOptions/Options/CheckboxBaseOption.js
@@ -1,4 +1,4 @@
-import { Checkbox } from '@dhis2/ui'
+import { CheckboxField } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
@@ -12,6 +12,7 @@ import TextStyle from './TextStyle.js'
 
 export const UnconnectedCheckboxBaseOption = ({
     option,
+    helpText,
     label,
     value,
     onChange,
@@ -20,8 +21,9 @@ export const UnconnectedCheckboxBaseOption = ({
     dataTest,
 }) => (
     <div className={tabSectionOption.className}>
-        <Checkbox
+        <CheckboxField
             checked={inverted ? !value : value}
+            helpText={helpText}
             label={label}
             name={option.name}
             onChange={({ checked }) => onChange(inverted ? !checked : checked)}
@@ -42,6 +44,7 @@ export const UnconnectedCheckboxBaseOption = ({
 UnconnectedCheckboxBaseOption.propTypes = {
     dataTest: PropTypes.string,
     fontStyleKey: PropTypes.string,
+    helpText: PropTypes.string,
     inverted: PropTypes.bool,
     label: PropTypes.string,
     option: PropTypes.object,

--- a/packages/app/src/components/VisualizationOptions/Options/FixColumnHeaders.js
+++ b/packages/app/src/components/VisualizationOptions/Options/FixColumnHeaders.js
@@ -1,14 +1,26 @@
 import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { CheckboxBaseOption } from './CheckboxBaseOption.js'
 
-const FixColumnHeaders = () => (
+const FixColumnHeaders = ({ columnsHasItems }) => (
     <CheckboxBaseOption
         label={i18n.t('Fix column headers to top of table')}
+        helpText={
+            !columnsHasItems
+                ? i18n.t(
+                      'There aren’t any column headers because Columns is empty.'
+                  )
+                : null
+        }
         option={{
             name: 'fixColumnHeaders',
         }}
     />
 )
+
+FixColumnHeaders.propTypes = {
+    columnsHasItems: PropTypes.bool,
+}
 
 export default FixColumnHeaders

--- a/packages/app/src/components/VisualizationOptions/Options/FixRowHeaders.js
+++ b/packages/app/src/components/VisualizationOptions/Options/FixRowHeaders.js
@@ -1,14 +1,24 @@
 import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
 import React from 'react'
 import { CheckboxBaseOption } from './CheckboxBaseOption.js'
 
-const FixRowHeaders = () => (
+const FixRowHeaders = ({ rowsHasItems }) => (
     <CheckboxBaseOption
         label={i18n.t('Fix row headers to left of table')}
+        helpText={
+            !rowsHasItems
+                ? i18n.t('There aren’t any row headers because Rows is empty.')
+                : null
+        }
         option={{
             name: 'fixRowHeaders',
         }}
     />
 )
+
+FixRowHeaders.propTypes = {
+    rowsHasItems: PropTypes.bool,
+}
 
 export default FixRowHeaders

--- a/packages/app/src/components/VisualizationOptions/VisualizationOptionsManager.js
+++ b/packages/app/src/components/VisualizationOptions/VisualizationOptionsManager.js
@@ -1,5 +1,6 @@
 import {
     AXIS_ID_COLUMNS,
+    AXIS_ID_ROWS,
     hasCustomAxes,
     hasRelativeItems,
     isDualAxisType,
@@ -22,6 +23,7 @@ import UpdateVisualizationContainer from '../UpdateButton/UpdateVisualizationCon
 const VisualizationOptionsManager = ({
     visualizationType,
     columnDimensionItems,
+    rowDimensionItems,
     columns,
     series,
 }) => {
@@ -45,17 +47,21 @@ const VisualizationOptionsManager = ({
             (layoutItem) => layoutItem === seriesItem.dimensionItem
         )
     )
-    const optionsConfig = getOptionsByType(
-        visualizationType,
-        isDualAxisType(visualizationType) &&
+    const optionsConfig = getOptionsByType({
+        type: visualizationType,
+        hasDisabledSections:
+            isDualAxisType(visualizationType) &&
             hasCustomAxes(filteredSeries) &&
             !hasRelativeItems(columns[0], columnDimensionItems),
-        series?.length && isDualAxisType(visualizationType)
-            ? [...new Set(series.map((serie) => serie.axis))].sort(
-                  (a, b) => a - b
-              )
-            : [0]
-    )
+        rangeAxisIds:
+            series?.length && isDualAxisType(visualizationType)
+                ? [...new Set(series.map((serie) => serie.axis))].sort(
+                      (a, b) => a - b
+                  )
+                : [0],
+        hasDimensionItemsInColumns: Boolean(columnDimensionItems.length),
+        hasDimensionItemsInRows: Boolean(rowDimensionItems.length),
+    })
 
     return (
         <>
@@ -84,12 +90,14 @@ VisualizationOptionsManager.propTypes = {
     visualizationType: PropTypes.string.isRequired,
     columnDimensionItems: PropTypes.array,
     columns: PropTypes.array,
+    rowDimensionItems: PropTypes.array,
     series: PropTypes.array,
 }
 
 const mapStateToProps = (state) => ({
     visualizationType: sGetUiType(state),
     columnDimensionItems: sGetDimensionItemsByAxis(state, AXIS_ID_COLUMNS),
+    rowDimensionItems: sGetDimensionItemsByAxis(state, AXIS_ID_ROWS),
     series: sGetUiOptions(state).series,
     columns: sGetUiLayout(state).columns,
 })

--- a/packages/app/src/components/VisualizationOptions/__tests__/CheckboxBaseOption.spec.js
+++ b/packages/app/src/components/VisualizationOptions/__tests__/CheckboxBaseOption.spec.js
@@ -1,4 +1,4 @@
-import { Checkbox } from '@dhis2/ui'
+import { CheckboxField } from '@dhis2/ui'
 import { shallow } from 'enzyme'
 import React from 'react'
 import { UnconnectedCheckboxBaseOption as CheckboxBaseOption } from '../Options/CheckboxBaseOption.js'
@@ -28,19 +28,19 @@ describe('DV > Options > CheckboxBaseOption', () => {
     })
 
     it('renders a label for checkbox', () => {
-        expect(checkboxBaseOption(props).find(Checkbox).props().label).toEqual(
-            props.label
-        )
+        expect(
+            checkboxBaseOption(props).find(CheckboxField).props().label
+        ).toEqual(props.label)
     })
 
     it('renders the checkbox with the correct checked state', () => {
-        expect(checkboxBaseOption(props).find(Checkbox).props().checked).toBe(
-            props.value
-        )
+        expect(
+            checkboxBaseOption(props).find(CheckboxField).props().checked
+        ).toBe(props.value)
     })
 
     it('should trigger the onChange callback on checkbox change', () => {
-        const checkbox = checkboxBaseOption(props).find(Checkbox)
+        const checkbox = checkboxBaseOption(props).find(CheckboxField)
 
         checkbox.simulate('change', { checked: true })
 

--- a/packages/app/src/modules/options/config.js
+++ b/packages/app/src/modules/options/config.js
@@ -18,7 +18,13 @@ import pivotTableConfig from './pivotTableConfig.js'
 import scatterConfig from './scatterConfig.js'
 import singleValueConfig from './singleValueConfig.js'
 
-export const getOptionsByType = (type, hasDisabledSections, rangeAxisIds) => {
+export const getOptionsByType = ({
+    type,
+    hasDimensionItemsInColumns,
+    hasDimensionItemsInRows,
+    hasDisabledSections,
+    rangeAxisIds,
+}) => {
     const isStacked = isStackedType(type)
     const isColumnBased = isColumnBasedType(type)
     const supportsLegends = isLegendSetType(type)
@@ -45,7 +51,10 @@ export const getOptionsByType = (type, hasDisabledSections, rangeAxisIds) => {
         case VIS_TYPE_SINGLE_VALUE:
             return singleValueConfig()
         case VIS_TYPE_PIVOT_TABLE:
-            return pivotTableConfig()
+            return pivotTableConfig({
+                hasDimensionItemsInColumns,
+                hasDimensionItemsInRows,
+            })
         case VIS_TYPE_SCATTER:
             return scatterConfig()
         default:

--- a/packages/app/src/modules/options/pivotTableConfig.js
+++ b/packages/app/src/modules/options/pivotTableConfig.js
@@ -38,7 +38,7 @@ import getLimitValuesTab from './tabs/limitValues.js'
 import getSeriesTab from './tabs/series.js'
 import getStyleTab from './tabs/style.js'
 
-export default () => [
+export default ({ hasDimensionItemsInColumns, hasDimensionItemsInRows }) => [
     getDataTab([
         getDisplayTemplate({
             content: React.Children.toArray([
@@ -79,8 +79,10 @@ export default () => [
                 <DisplayDensity />,
                 <FontSize />,
                 <DigitGroupSeparator />,
-                <FixColumnHeaders />,
-                <FixRowHeaders />,
+                <FixColumnHeaders
+                    columnsHasItems={hasDimensionItemsInColumns}
+                />,
+                <FixRowHeaders rowsHasItems={hasDimensionItemsInRows} />,
             ]),
         },
         {


### PR DESCRIPTION
**Requires https://github.com/dhis2/analytics/pull/1057**

---

### Key features

1. Add help text support to the `CheckboxBaseOption`
2. Add help text to both `FixRowHeaders` and `FixColumnHeaders` options depending on the layout selection

---

### Description

See the PR in analytics for more info about the missing borders issue with fixed headers.
The solution to that issue is in analytics, but in DV we needed a way to explain the user why the option does not appear to do anything even if it is enabled.
For that the `helpText` is used and the `CheckboxBaseOption` is now using ui's `CheckboxField` instead of `Checkbox`.
The 2 options for fix headers have a prop passed which tells if the corresponding axis in the layout has a selection (dimension items) or is empty (no dimension items selected), this is used to enable/disable the help text.
@cooper-joe came up with the texts to use.

---

### Screenshots

DV options:
<img width="327" alt="Screenshot 2021-10-01 at 17 18 04" src="https://user-images.githubusercontent.com/150978/135645304-eeed10fa-89dc-406a-9c94-df85dc2ae152.png">