### PR TITLE
fix: wait for ouLevels (DHIS2-11931) v36

### DIFF
--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -153,7 +153,7 @@ export const VisualizationPlugin = ({
         /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, [visualization, filters, forDashboard])
 
-    if (!fetchResult) {
+    if (!fetchResult || !ouLevels) {
         return null
     }
 

--- a/packages/plugin/src/__tests__/VisualizationPlugin.spec.js
+++ b/packages/plugin/src/__tests__/VisualizationPlugin.spec.js
@@ -13,7 +13,16 @@ import ChartPlugin from '../ChartPlugin'
 
 jest.mock('../ChartPlugin', () => jest.fn(() => null))
 jest.mock('../PivotPlugin', () => jest.fn(() => null))
-jest.mock('@dhis2/analytics')
+jest.mock('@dhis2/analytics', () => ({
+    ...jest.requireActual('@dhis2/analytics'),
+    apiFetchOrganisationUnitLevels: () =>
+        Promise.resolve([
+            {
+                level: 2,
+                id: '2nd-floor',
+            },
+        ]),
+}))
 
 const dxMock = {
     dimension: 'dx',


### PR DESCRIPTION
Implements [DHIS2-11931](https://jira.dhis2.org/browse/DHIS2-11931) for v36

Waits for ouLevels to finish loading before rendering the plugin

Similar to the fix for v35 https://github.com/dhis2/data-visualizer-app/pull/1921