### PR TITLE
test: wait for loading to finish when data type has changed

### DIFF
--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -2,7 +2,7 @@ import { DIMENSION_ID_DATA } from '@dhis2/analytics'
 import { clearInput, typeInput } from '../common'
 import {
     expectDimensionModalToBeVisible,
-    expectSourceToBeLoading,
+    expectSourceToNotBeLoading,
     selectItemByDoubleClick,
 } from '.'
 
@@ -98,13 +98,13 @@ export const switchSubGroupTo = group => {
 export const switchDataTypeTo = dataType => {
     cy.getBySel(dataTypesSelectButtonEl).click()
     cy.getBySelLike(dataTypeSelectOptionEl).contains(dataType).click()
-    expectSourceToBeLoading()
+    expectSourceToNotBeLoading()
 }
 
 export const switchDataTypeToAll = () => {
     cy.getBySel(dataTypesSelectButtonEl).click()
     cy.getBySelLike(dataTypeSelectOptionEl).eq(0).click()
-    expectSourceToBeLoading()
+    expectSourceToNotBeLoading()
 }
 
 export const inputSearchTerm = searchTerm => {

--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -1,6 +1,10 @@
 import { DIMENSION_ID_DATA } from '@dhis2/analytics'
 import { clearInput, typeInput } from '../common'
-import { expectDimensionModalToBeVisible, selectItemByDoubleClick } from '.'
+import {
+    expectDimensionModalToBeVisible,
+    expectSourceToBeLoading,
+    selectItemByDoubleClick,
+} from '.'
 
 const optionContentEl = 'data-dimension-transfer-option-content'
 const selectableItemsEl = 'data-dimension-transfer-sourceoptions'
@@ -94,11 +98,13 @@ export const switchSubGroupTo = group => {
 export const switchDataTypeTo = dataType => {
     cy.getBySel(dataTypesSelectButtonEl).click()
     cy.getBySelLike(dataTypeSelectOptionEl).contains(dataType).click()
+    expectSourceToBeLoading()
 }
 
 export const switchDataTypeToAll = () => {
     cy.getBySel(dataTypesSelectButtonEl).click()
     cy.getBySelLike(dataTypeSelectOptionEl).eq(0).click()
+    expectSourceToBeLoading()
 }
 
 export const inputSearchTerm = searchTerm => {

--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -47,6 +47,7 @@ export const scrollSourceToBottom = () => {
 
 export const selectDataElements = dataElements => {
     switchDataTypeTo('Data elements')
+    expectSourceToNotBeLoading()
     dataElements.forEach(item => selectItemByDoubleClick(item))
 }
 
@@ -55,6 +56,7 @@ export const selectFirstDataItem = () =>
 
 export const selectIndicators = indicators => {
     switchDataTypeTo('Indicators')
+    expectSourceToNotBeLoading()
     indicators.forEach(item => selectItemByDoubleClick(item))
 }
 
@@ -98,13 +100,11 @@ export const switchSubGroupTo = group => {
 export const switchDataTypeTo = dataType => {
     cy.getBySel(dataTypesSelectButtonEl).click()
     cy.getBySelLike(dataTypeSelectOptionEl).contains(dataType).click()
-    expectSourceToNotBeLoading()
 }
 
 export const switchDataTypeToAll = () => {
     cy.getBySel(dataTypesSelectButtonEl).click()
     cy.getBySelLike(dataTypeSelectOptionEl).eq(0).click()
-    expectSourceToNotBeLoading()
 }
 
 export const inputSearchTerm = searchTerm => {


### PR DESCRIPTION
Seems there's an issue with Cypress using the outdated list of transfer items when the data type has changed in the data dimension modal, e.g. going from "all" to "indicators" would still try to select an item from the "all" list.

![image](https://user-images.githubusercontent.com/12590483/142388900-b4a0e206-dca3-4abe-aff9-3e5cb040b0f0.png)
![image](https://user-images.githubusercontent.com/12590483/142388925-a048bacf-4a23-418f-a213-ecbf4a40a84f.png)

The `expectSourceToNotBeLoading` was added after the type has been switched to hopefully counter this.