### PR TITLE
fix: fix paging query parameter passed to dataQuery (DHIS2-11913)

### DIFF
--- a/packages/app/src/components/VisualizationOptions/Options/ApprovalLevel.js
+++ b/packages/app/src/components/VisualizationOptions/Options/ApprovalLevel.js
@@ -23,7 +23,7 @@ const query = {
         params: {
             order: 'level:asc',
             fields: 'id,displayName~rename(name),level',
-            paging: false,
+            paging: 'false',
         },
     },
 }

--- a/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
+++ b/packages/app/src/components/VisualizationOptions/Options/LegendSet.js
@@ -20,7 +20,7 @@ const query = {
                 'displayName~rename(name)',
                 'legends[id,displayName~rename(name),startValue,endValue,color]',
             ],
-            paging: false,
+            paging: 'false',
         },
     },
 }


### PR DESCRIPTION

Implements [DHIS2-11913](https://jira.dhis2.org/browse/DHIS2-11913)

---

### Key features

1. Fix crash when the query for fetching legend sets is run

---

### Description

This was already fixed in 2.35 and it's being solved at later in app-runtime, so now it's ok to pass a boolean to a query parameter.

34.x uses an old version of app-runtime which does not have support for boolean type query parameters.

See also #1083.