### PR TITLE
fix: canceled request when no data DHIS2-12130 v35

### DIFF
--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -30,7 +30,7 @@ export const VisualizationPlugin = ({
     ...props
 }) => {
     const engine = useDataEngine()
-    const [ouLevels, setOuLevels] = useState(undefined)
+    const [ouLevels, setOuLevels] = useState()
     const [fetchResult, setFetchResult] = useState(null)
     const [contextualMenuRef, setContextualMenuRef] = useState(undefined)
     const [contextualMenuConfig, setContextualMenuConfig] = useState({})


### PR DESCRIPTION
Fix for a bug related to [DHIS2-12130](https://jira.dhis2.org/browse/DHIS2-12130)

---

### Key features

1. fix canceled request for org unit levels

---

### Description

The fetch was not async, so when the analytics response was coming back first and there is no data available, the request to orgunit levels was canceled when the `VisualizationPlugin` component was replaced by the error screen for no data.
The issue does not happen from v36 and above.

---

### TODO

-   [ ] Fix failing tests

---

### Known issues

-   [ ] tests are failing