### PR TITLE
fix: make sure the legend set name is fetched DHIS2-12264

### DIFF
--- a/packages/app/src/modules/fields/nestedFields.js
+++ b/packages/app/src/modules/fields/nestedFields.js
@@ -11,6 +11,7 @@ const ITEMS = `${DIMENSION_ITEM},${NAME},dimensionItemType`
 
 const AXIS = `dimension,filter,legendSet[${LEGEND_SET}],items[${ITEMS}]`
 const INTERPRETATIONS = 'id,created'
+const LEGEND = `showKey,style,strategy,set[${LEGEND_SET}]`
 
 // nested fields map
 export const nestedFields = {
@@ -19,6 +20,7 @@ export const nestedFields = {
     filters: AXIS,
     user: USER,
     interpretations: INTERPRETATIONS,
+    legend: LEGEND,
 }
 
 export const extendFields = (field) =>


### PR DESCRIPTION
Fixes [DHIS2-12264](https://jira.dhis2.org/browse/DHIS2-12264)

---

### Key features

1. fix empty label for preselected legend set option

---

### Description

After the structure for the legend option changed to an object with keys and a nested object for legend set, the legend set label was not fetched from the api, causing an empty option in the dropdown (see screenshot).
The fix is about fetching only the fields needed for `legend` in the AO.


### Screenshots

Before:
<img width="445" alt="Screenshot 2021-12-22 at 08 39 56" src="https://user-images.githubusercontent.com/150978/147070924-e69276a8-a538-4938-9116-6734ac2bf0b4.png">

After:
<img width="400" alt="Screenshot 2021-12-22 at 10 36 40" src="https://user-images.githubusercontent.com/150978/147070993-bee94c89-6b44-4f52-8205-54b1b295f677.png">

