### PR TITLE
test: selecting level / group with user org unit

### DIFF
--- a/cypress/elements/dimensionModal/orgUnitDimension.js
+++ b/cypress/elements/dimensionModal/orgUnitDimension.js
@@ -108,8 +108,8 @@ export const deselectUserOrgUnit = (name) => {
 
 export const expectOrgUnitTreeToBeDisabled = () => {
     cy.getBySel(orgUnitTreeEl).should('have.css', 'pointer-events', 'none')
-    cy.getBySel(levelSelectEl).should('not.have.css', 'pointer-events', 'none')
-    cy.getBySel(groupSelectEl).should('not.have.css', 'pointer-events', 'none')
+    cy.getBySel(levelSelectEl).should('have.css', 'pointer-events', 'none')
+    cy.getBySel(groupSelectEl).should('have.css', 'pointer-events', 'none')
 }
 
 export const expectOrgUnitTreeToBeEnabled = () => {

--- a/cypress/integration/dimensions/orgUnit.cy.js
+++ b/cypress/integration/dimensions/orgUnit.cy.js
@@ -51,28 +51,6 @@ describe(`Org unit dimension`, () => {
         expectWindowConfigSeriesToHaveLength(1)
         expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
     })
-    const TEST_LEVEL = 'District'
-    it(`selects a level - ${TEST_LEVEL}`, () => {
-        openDimension(DIMENSION_ID_ORGUNIT)
-        expectOrgUnitDimensionModalToBeVisible()
-        expectOrgUnitDimensionToNotBeLoading()
-        expectOrgUnitTreeToBeDisabled()
-        toggleOrgUnitLevel(TEST_LEVEL)
-        clickDimensionModalUpdateButton()
-        expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
-        expectWindowConfigSeriesToHaveLength(13) // number of districts in Sierra Leone
-        expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 2)
-    })
-    it(`deselects ${TEST_LEVEL}`, () => {
-        openDimension(DIMENSION_ID_ORGUNIT)
-        expectOrgUnitDimensionModalToBeVisible()
-        expectOrgUnitDimensionToNotBeLoading()
-        toggleOrgUnitLevel(TEST_LEVEL)
-        clickDimensionModalUpdateButton()
-        expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
-        expectWindowConfigSeriesToHaveLength(1)
-        expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
-    })
     const TEST_DISTRICT_1 = 'Bo'
     it(`selects a district level org unit - ${TEST_DISTRICT_1}`, () => {
         openDimension(DIMENSION_ID_ORGUNIT)
@@ -112,6 +90,28 @@ describe(`Org unit dimension`, () => {
         expectOrgUnitItemToBeSelected(TEST_CHIEFDOM)
         deselectOrgUnitTreeItem(TEST_DISTRICT_1)
         deselectOrgUnitTreeItem(TEST_CHIEFDOM)
+        clickDimensionModalUpdateButton()
+        expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+        expectWindowConfigSeriesToHaveLength(1)
+        expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
+    })
+    const TEST_LEVEL = 'District'
+    it(`selects a level - ${TEST_LEVEL}`, () => {
+        openDimension(DIMENSION_ID_ORGUNIT)
+        expectOrgUnitDimensionModalToBeVisible()
+        expectOrgUnitDimensionToNotBeLoading()
+        expectOrgUnitTreeToBeEnabled()
+        toggleOrgUnitLevel(TEST_LEVEL)
+        clickDimensionModalUpdateButton()
+        expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
+        expectWindowConfigSeriesToHaveLength(13) // number of districts in Sierra Leone
+        expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 2)
+    })
+    it(`deselects ${TEST_LEVEL}`, () => {
+        openDimension(DIMENSION_ID_ORGUNIT)
+        expectOrgUnitDimensionModalToBeVisible()
+        expectOrgUnitDimensionToNotBeLoading()
+        toggleOrgUnitLevel(TEST_LEVEL)
         clickDimensionModalUpdateButton()
         expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
         expectWindowConfigSeriesToHaveLength(1)

--- a/cypress/integration/visTypes/scatter.cy.js
+++ b/cypress/integration/visTypes/scatter.cy.js
@@ -18,6 +18,8 @@ import {
     expectDataItemToBeInactive,
     expectOrgUnitDimensionModalToBeVisible,
     toggleOrgUnitLevel,
+    deselectUserOrgUnit,
+    selectOrgUnitTreeItem,
 } from '../../elements/dimensionModal/index.js'
 import { openDimension } from '../../elements/dimensionsPanel.js'
 import {
@@ -98,6 +100,8 @@ describe('using a Scatter chart', () => {
         const TEST_ORG_UNIT_LEVEL = 'Facility'
         openDimension(DIMENSION_ID_ORGUNIT)
         expectOrgUnitDimensionModalToBeVisible()
+        deselectUserOrgUnit('User organisation unit')
+        selectOrgUnitTreeItem('Sierra Leone')
         toggleOrgUnitLevel(TEST_ORG_UNIT_LEVEL)
         expectOrgUnitDimensionModalToBeVisible()
         clickDimensionModalUpdateButton()

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^21.0.0",
+        "@dhis2/analytics": "^21.1.1",
         "@dhis2/app-runtime": "^3.2.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^21.0.0",
+        "@dhis2/analytics": "^21.1.1",
         "@dhis2/app-runtime": "^3.2.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^7.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2131,10 +2131,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^21.0.0":
-  version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-21.0.0.tgz#9cf151d5b355e2117067764cd97a6e4fd6e335e5"
-  integrity sha512-v3Gj0GsrbtjFOajNa8M/dQKkZrPWA2ps7r4Ok/a2LRXGI8ngKtWJfLFdPzMp2+RRUBUJzblRM3Ut4Fx+o2q6kg==
+"@dhis2/analytics@^21.1.1":
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-21.1.1.tgz#5f4906c3dcbec05e0bed2094f1e104ee055f8f42"
+  integrity sha512-tluiMVv3pCBRznXQNphSGN+XAXTKV2k1ja/HcM/U+GNwVp/8he60zv0UAGe7Z8D5qXu6hYzG1SeMx67YaC93kQ==
   dependencies:
     "@dhis2/d2-ui-translation-dialog" "^7.3.1"
     classnames "^2.3.1"
@@ -3106,7 +3106,7 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@ls-lint/ls-lint@^1.10.0", "@ls-lint/ls-lint@^1.9.2":
+"@ls-lint/ls-lint@^1.9.2":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@ls-lint/ls-lint/-/ls-lint-1.10.0.tgz#cad20085edc010a3e938aa01bb66d05e5e12b3f3"
   integrity sha512-C1vrI8zFp/28CiqCQHtfu/GqUg2iLYZqtlJHCYfqlg6OJopv7lHAPS0rzk06Ev1121yj4Gi/GmXMBlF+j35DcQ==


### PR DESCRIPTION
Adapts the Cypress tests to the changes introduced in the latest Analytics version, specifically that when `User org unit` is selected (which is the new default state when creating a new AO), `Level` and `Group` dropdowns are disabled. ([Analytics PR](https://github.com/dhis2/analytics/pull/1100)).

Before accessing the `Level` or `Group` dropdowns, the `User org unit` needs to be deselected so that they are enabled again (plus making sure that `Sierra Leone` is selected).