### PR TITLE
feat: add hover style to chip-menu-button

### DIFF
--- a/packages/app/src/components/IconButton/IconButton.js
+++ b/packages/app/src/components/IconButton/IconButton.js
@@ -10,7 +10,6 @@ const IconButton = ({
     onBlur,
     onClick,
     onFocus,
-    style,
     ariaOwns,
     ariaHaspopup,
 }) => (
@@ -22,7 +21,6 @@ const IconButton = ({
         onBlur={onBlur}
         onClick={onClick}
         onFocus={onFocus}
-        style={style}
         aria-owns={ariaOwns}
         aria-haspopup={ariaHaspopup}
     >

--- a/packages/app/src/components/IconButton/IconButton.js
+++ b/packages/app/src/components/IconButton/IconButton.js
@@ -35,7 +35,6 @@ IconButton.propTypes = {
     dataTest: PropTypes.string,
     disabled: PropTypes.bool,
     name: PropTypes.string,
-    style: PropTypes.object,
     onBlur: PropTypes.func,
     onClick: PropTypes.func,
     onFocus: PropTypes.func,

--- a/packages/app/src/components/IconButton/styles/IconButton.module.css
+++ b/packages/app/src/components/IconButton/styles/IconButton.module.css
@@ -9,8 +9,18 @@
     cursor: pointer;
     padding: 0;
     vertical-align: middle;
+    border-radius: 2px;
+    width: 22px;
+    height: 22px;
+    margin: '0px 0px 0px 2px';
+    color: var(--colors-grey700);
 }
 
 .iconButton:focus {
     outline: none;
+}
+
+.iconButton:hover {
+    background-color: rgba(0, 0, 0, 0.12);
+    color: var(--colors-grey900);
 }

--- a/packages/app/src/components/Layout/ChipMenu.js
+++ b/packages/app/src/components/Layout/ChipMenu.js
@@ -12,7 +12,6 @@ import {
 } from '../../actions/ui.js'
 import * as fromReducers from '../../reducers/index.js'
 import IconButton from '../IconButton/IconButton.js'
-import { styles } from './styles/Menu.style.js'
 
 const ChipMenu = ({
     assignedCategoriesItemHandler,
@@ -39,10 +38,9 @@ const ChipMenu = ({
                     ariaOwns={menuIsOpen ? getMenuId() : null}
                     ariaHaspopup={true}
                     onClick={toggleMenu}
-                    style={styles.icon}
                     dataTest={`layout-chip-menu-button-${dimensionId}`}
                 >
-                    <IconMore16 color="var(--colors-grey700)" />
+                    <IconMore16 />
                 </IconButton>
             </div>
             {/* TODO: Fix bug with the first menu item getting selected when the menu is opened */}

--- a/packages/app/src/components/Layout/ScatterLayout/ScatterAxis.js
+++ b/packages/app/src/components/Layout/ScatterLayout/ScatterAxis.js
@@ -81,10 +81,9 @@ const Axis = ({
                     ariaOwns={dialogIsOpen ? `menu-for-${itemAttribute}` : null}
                     ariaHaspopup={true}
                     onClick={toggleMenu}
-                    style={styles.icon}
                     dataTest={`layout-chip-menu-button-${itemAttribute}`}
                 >
-                    <IconMore16 color="var(--colors-grey700)" />
+                    <IconMore16 />
                 </IconButton>
             </div>
             {dialogIsOpen && (
@@ -134,7 +133,7 @@ const Axis = ({
         ) : (
             <HorizontalIcon />
         )
-
+    console.log('ScatterBrain')
     return (
         <div
             id={label}

--- a/packages/app/src/components/Layout/styles/Menu.style.js
+++ b/packages/app/src/components/Layout/styles/Menu.style.js
@@ -1,7 +1,0 @@
-export const styles = {
-    icon: {
-        width: 22,
-        height: 22,
-        margin: '0px 0px 0px 2px',
-    },
-}


### PR DESCRIPTION
No issue number available

---

### Key features

1. Adds hover style to show-more button in the chip
2. I have removed quite a lot of code that seemed to be redundant
3. Aligns styling of Chip between ER and DV

---

### Description

I basically did exactly the same thing here as I did in https://github.com/dhis2/event-reports-app/pull/903. In ER this component was being used in one place only, but here in DV it was also being used by the `ScatterAxis`. But upon further inspection it turned out that the style object passed to the IconButton from the ChipMenu was actually undefined, and also the chips in the scatter axis didn't look quite right. So in the end I simply did exactly the same changes here as I did in ER and I think it looks correct.

---
### Screenshots
Hover style:
<img width="235" alt="Screenshot 2022-01-19 at 14 10 28" src="https://user-images.githubusercontent.com/353236/150137423-5825c260-4487-407e-b7a0-2670e4b65587.png">

