### PR TITLE
fix: adapt error message to specific dimension (DHIS2-12915) v36

### DIFF
--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -28,6 +28,7 @@ import {
     NoDataOrDataElementGroupSetError,
     CombinationDEGSRRError,
     NoOrgUnitResponseError,
+    NoDataError,
 } from '../../modules/error'
 import LoadingMask from '../../widgets/LoadingMask'
 import { sGetSettingsDisplayNameProperty } from '../../reducers/settings'
@@ -63,7 +64,17 @@ export class Visualization extends Component {
                     error = new CombinationDEGSRRError()
                     break
                 case 'E7124':
-                    error = new NoOrgUnitResponseError()
+                    {
+                        if (response?.message?.includes('`dx`')) {
+                            error = new NoDataError(
+                                this.props.visualization.type
+                            )
+                        } else if (response?.message?.includes('`ou`')) {
+                            error = new NoOrgUnitResponseError()
+                        } else {
+                            error = new GenericServerError()
+                        }
+                    }
                     break
 
                 default:

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -76,7 +76,6 @@ export class Visualization extends Component {
                         }
                     }
                     break
-
                 default:
                     error = response
             }

--- a/packages/app/src/components/Visualization/Visualization.js
+++ b/packages/app/src/components/Visualization/Visualization.js
@@ -1,3 +1,4 @@
+import { DIMENSION_ID_ORGUNIT, DIMENSION_ID_DATA } from '@dhis2/analytics'
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
@@ -65,11 +66,19 @@ export class Visualization extends Component {
                     break
                 case 'E7124':
                     {
-                        if (response?.message?.includes('`dx`')) {
+                        if (
+                            response?.message?.includes(
+                                `\`${DIMENSION_ID_DATA}\``
+                            )
+                        ) {
                             error = new NoDataError(
                                 this.props.visualization.type
                             )
-                        } else if (response?.message?.includes('`ou`')) {
+                        } else if (
+                            response?.message?.includes(
+                                `\`${DIMENSION_ID_ORGUNIT}\``
+                            )
+                        ) {
                             error = new NoOrgUnitResponseError()
                         } else {
                             error = new GenericServerError()


### PR DESCRIPTION
Implements [DHIS2-12915](https://jira.dhis2.org/browse/DHIS2-12915)

---

Partial cherry-pick of https://github.com/dhis2/data-visualizer-app/pull/2009 (only the `Visualization.js` part, as 36.x doesn't have the `ALL_ITEMS` implementation anyway)