### PR TITLE
fix: use translated name in title DHIS2-13015

### DIFF
--- a/packages/app/src/components/TitleBar/TitleBar.js
+++ b/packages/app/src/components/TitleBar/TitleBar.js
@@ -35,7 +35,7 @@ const getTitleText = (titleState, visualization) => {
             return getTitleUnsaved()
         case STATE_SAVED:
         case STATE_DIRTY:
-            return visualization.name
+            return visualization.displayName || visualization.name
         default:
             return ''
     }


### PR DESCRIPTION
Implements [DHIS2-13015](https://jira.dhis2.org/browse/DHIS2-13015)

**Requires https://github.com/dhis2/analytics/pull/XXX**

---

### Key features

1. use translated name in visualization title
2. perform the search on `displayName` instead of `name`

---

### Description

The title was using `visualization.name` which is the original name chosen when the visualization was saved.
Instead, `visualization.displayName` should be used, which contains the translated version in the current user language (when available).

The search in the `OpenFileDialog` was also performed on `name` instead of `displayName`.

---

### TODO

-   [ ] updated `analytics` dependency with the fix for the search in `OpenFileDialog`

---

### Known issues

-   [ ] blocked by https://dhis2.slack.com/archives/G3TL0J145/p1648477842131529

---

### Screenshots

Before:
<img width="1115" alt="Screenshot 2022-04-04 at 13 36 34" src="https://user-images.githubusercontent.com/150978/161535790-7939d31c-7777-4eea-938d-e6fc08d3bef2.png">

After:
<img width="1112" alt="Screenshot 2022-04-04 at 13 35 56" src="https://user-images.githubusercontent.com/150978/161535812-0df79fed-cac0-4ee7-ba0e-f806f2cd21be.png">

