### PR TITLE
fix: correct typo with display name property (DHIS2-10174)

### DIFF
--- a/packages/app/src/components/UserSettingsProvider.js
+++ b/packages/app/src/components/UserSettingsProvider.js
@@ -24,7 +24,7 @@ const UserSettingsProvider = ({ children }) => {
             setSettings({
                 ...userSettings,
                 displayProperty: userSettings.keyAnalysisDisplayProperty,
-                displayPropertyName:
+                displayNameProperty:
                     userSettings.keyAnalysisDisplayProperty === 'name'
                         ? 'displayName'
                         : 'displayShortName',


### PR DESCRIPTION
Implements [DHIS2-10174](https://jira.dhis2.org/browse/DHIS2-10174)

---

### Key features

1. Solves the issue with `shortName` not being displayed even when that system/user setting is in use

---

### Description

The typo was first introduced by changing 
https://github.com/dhis2/data-visualizer-app/pull/1691/files#diff-88e65845537b664e65118a925f68f58981ff188e8b91d5e1d312cb040787f5c2L12
to
https://github.com/dhis2/data-visualizer-app/pull/1691/files#diff-8c7632f9344bbb0929aa941f9e9088c8a73bf0ef619c7757b707281520348399R27

---

### Known issues

-   [ ] Org unit tree still doesn't display the `shortName` properly. Libs ticket: https://dhis2.atlassian.net/browse/LIBS-314

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/164644419-79148bdd-827d-4441-a636-0195f6a1014e.png)

![image](https://user-images.githubusercontent.com/12590483/164644446-9d82bd46-ee58-4fbb-8bbc-15d80a23f3a2.png)

![image](https://user-images.githubusercontent.com/12590483/164644498-08cd0db6-942e-49cf-b1b0-8ea945ca96a6.png)

![image](https://user-images.githubusercontent.com/12590483/164644554-4ef2bdc0-d407-4117-88da-b4ad8331327b.png)

