### PR TITLE
fix: use normal handling when WEEKS_THIS_YEAR is used in YoY DHIS2-12580

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^23.8.5",
+        "@dhis2/analytics": "^23.9.0",
         "@dhis2/app-runtime": "^3.2.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^23.8.5",
+        "@dhis2/analytics": "^23.9.0",
         "@dhis2/app-runtime": "^3.2.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^7.7.3",

--- a/packages/plugin/src/api/analytics.js
+++ b/packages/plugin/src/api/analytics.js
@@ -5,6 +5,7 @@ import {
     DIMENSION_ID_PERIOD,
     DAILY,
     WEEKLY,
+    WEEKS_THIS_YEAR,
 } from '@dhis2/analytics'
 import { getRelativePeriodTypeUsed } from '../modules/analytics.js'
 
@@ -56,7 +57,10 @@ export const apiFetchAnalyticsForYearOverYear = async (
     const periodItems = layoutGetDimensionItems(visualization, periodId)
 
     // relative week period in use
-    if (getRelativePeriodTypeUsed(periodItems) === WEEKLY) {
+    if (
+        getRelativePeriodTypeUsed(periodItems) === WEEKLY &&
+        !periodItems[0].id === WEEKS_THIS_YEAR
+    ) {
         const relativeWeeksData = await prepareRequestsForRelativeWeeks({
             analyticsEngine,
             visualization,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,15 +2164,15 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^23.8.5":
-  version "23.8.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-23.8.5.tgz#0e815d92fe32bb3ed5d601fda9dce2dc5ec68701"
-  integrity sha512-9mnKB5qyuS5/IZuHVgWUa6Mzct6muRdAnaI6+gG4SO4VgEYM4e+YleqSQuchXWfoFouUkX5M0n5frPgEQX9hFQ==
+"@dhis2/analytics@^23.9.0":
+  version "23.9.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-23.9.0.tgz#6c763e26f1788f8e588c22176069d4c0e425e66c"
+  integrity sha512-+O76Rb2n4AXzAbmwt1mPrnvgscUP9t+pSL/j4V3Pu5GjCvzkXieAQP+BCRKm+5CJoO9p8FkAFRF7gphbcaVMUg==
   dependencies:
     classnames "^2.3.1"
     d2-utilizr "^0.2.16"
     d3-color "^1.2.3"
-    highcharts "^9.1.2"
+    highcharts "^10.1.0"
     lodash "^4.17.21"
     mathjs "^9.4.2"
     react-beautiful-dnd "^10.1.1"
@@ -9454,10 +9454,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highcharts@^9.1.2:
-  version "9.3.3"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.3.3.tgz#ae62178de788fd7934431aa26b8e250b8073c541"
-  integrity sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg==
+highcharts@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-10.1.0.tgz#561872ae8ea819131d78949136d05bcaaa99108b"
+  integrity sha512-gW/pzy/Qy/hiYeCflYHpwgsP2nqQavwuRUswRf+papmbutZ3I7K7AIZJ/yZ9NL5yzpF7X7r2dX7/nzZGN4A1rg==
 
 history@^4.7.2:
   version "4.10.1"


### PR DESCRIPTION
Implements [DHIS2-12580](https://jira.dhis2.org/browse/DHIS2-12580)

**Requires https://github.com/dhis2/analytics/pull/1238**

---

### Key features

1. do now use weekly special handling with WEEKS_THIS_YEAR

---

### Description

The special weekly period handling does not work with this period,
because depending on the current date, it can happen that the same year
is used for fetching the data, instead of the requested years.

---

### TODO

-   [x] bump `@dhis2/analytics` when https://github.com/dhis2/analytics/pull/1238 is merged

---

### Screenshots

Before:
<img width="1114" alt="Screenshot 2022-05-20 at 11 36 03" src="https://user-images.githubusercontent.com/150978/169503515-558f4ea2-1b20-491a-9454-9cec8f91e91a.png">

After:
<img width="1112" alt="Screenshot 2022-05-20 at 11 35 49" src="https://user-images.githubusercontent.com/150978/169503502-57aa7892-3756-4bf4-af8b-12ef384e1455.png">

