### PR TITLE
fix: use normal handling when WEEKS_THIS_YEAR is used in YoY DHIS2-12580 (37.x)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.7.1",
+        "@dhis2/analytics": "^20.9.0",
         "@dhis2/app-runtime": "^2.11.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.7.1",
+        "@dhis2/analytics": "^20.9.0",
         "@dhis2/app-runtime": "^2.11.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.23.5",

--- a/packages/plugin/src/api/analytics.js
+++ b/packages/plugin/src/api/analytics.js
@@ -5,6 +5,7 @@ import {
     DIMENSION_ID_PERIOD,
     DAILY,
     WEEKLY,
+    WEEKS_THIS_YEAR,
 } from '@dhis2/analytics'
 import { getRelativePeriodTypeUsed } from '../modules/analytics'
 
@@ -56,7 +57,10 @@ export const apiFetchAnalyticsForYearOverYear = async (
     const periodItems = layoutGetDimensionItems(visualization, periodId)
 
     // relative week period in use
-    if (getRelativePeriodTypeUsed(periodItems) === WEEKLY) {
+    if (
+        getRelativePeriodTypeUsed(periodItems) === WEEKLY &&
+        !periodItems[0].id === WEEKS_THIS_YEAR
+    ) {
         const relativeWeeksData = await prepareRequestsForRelativeWeeks({
             analyticsEngine,
             visualization,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,10 +2143,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^20.7.1":
-  version "20.7.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.7.1.tgz#6190979758c57b01d47a5382b29fc8b6b419ceae"
-  integrity sha512-JrhuEsU91esWtDkHrS73bO97fQVjrh+1SkslalCBcKikMgZvtn9LorJz3gqUiYmQbKkYx5Z+JoNMsGwUXcElhA==
+"@dhis2/analytics@^20.9.0":
+  version "20.9.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.9.0.tgz#95e3bf9bd2885b0780cf15e900ce5f70b845bf64"
+  integrity sha512-qU36RU5dOTqFKku3pTenfuj/PDtx9xi0hFElQ2cr0cMw63BugJREC7bxET+eA4bVG3lXnH43x82zQZKUsugIPQ==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.3.0"
     "@dhis2/d2-ui-translation-dialog" "^7.3.1"


### PR DESCRIPTION
Implements [DHIS2-12580](https://jira.dhis2.org/browse/DHIS2-12580)

**Requires https://github.com/dhis2/analytics/pull/1246**

---

### Key features

1. backport of #2065 
---

### TODO

-   [x] update `analytics` to latest 20.x version
