### PR TITLE
fix: add border to legend key (DHIS2-75)

### DIFF
--- a/packages/plugin/src/styles/VisualizationPlugin.module.css
+++ b/packages/plugin/src/styles/VisualizationPlugin.module.css
@@ -13,6 +13,7 @@
     top: 0;
     bottom: 0;
     overflow: auto;
+    border: 1px solid var(--colors-grey400);
 }
 .buttonMargin {
     margin-top: 34px;


### PR DESCRIPTION
Implements a fix related tp [DHIS2-75](https://jira.dhis2.org/browse/DHIS2-75)

**Requires https://github.com/dhis2/analytics/pull/1249**

---

### Key features

1. Adds the border around the legend key that was previously provided by Analytics but now has to be provided by the apps

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/171190323-6d100d0b-381d-4fe7-890f-62ee9023b0f1.png)

![image](https://user-images.githubusercontent.com/12590483/171190369-1ba96a1f-2c1e-484a-9083-bb8d2b7f4eff.png)

