### PR TITLE
fix: bump Analytics to latest + update Cypress + update history impl (DHIS2-12719)

### DIFF
--- a/cypress/elements/chart.js
+++ b/cypress/elements/chart.js
@@ -15,7 +15,7 @@ const chartContainerEl = '.highcharts-container'
 const highchartsLegendEl = '.highcharts-legend'
 const highchartsTitleEl = '.highcharts-title'
 const highchartsSubtitleEl = '.highcharts-subtitle'
-const highchartsSeriesKeyItemEl = '.highcharts-legend-item' // Note: Highcharts strips out 'data-test' and similar attributes, hence 'class="data-test-..." was used instead
+const highchartsSeriesKeyItemEl = '.highcharts-legend-item'
 const highchartsChartItemEl = '.highcharts-series'
 const unsavedVisualizationTitleText = 'Unsaved visualization'
 const AOTitleEl = 'AO-title'

--- a/cypress/elements/chart.js
+++ b/cypress/elements/chart.js
@@ -15,8 +15,7 @@ const chartContainerEl = '.highcharts-container'
 const highchartsLegendEl = '.highcharts-legend'
 const highchartsTitleEl = '.highcharts-title'
 const highchartsSubtitleEl = '.highcharts-subtitle'
-const highchartsSeriesKeyItemEl = '.data-test-series-key-item' // Note: Highcharts strips out 'data-test' and similar attributes, hence 'class="data-test-..." was used instead
-const highchartsSeriesKeyItemBulletEl = '.data-test-series-key-item-bullet'
+const highchartsSeriesKeyItemEl = '.highcharts-legend-item' // Note: Highcharts strips out 'data-test' and similar attributes, hence 'class="data-test-..." was used instead
 const highchartsChartItemEl = '.highcharts-series'
 const unsavedVisualizationTitleText = 'Unsaved visualization'
 const AOTitleEl = 'AO-title'
@@ -110,13 +109,6 @@ export const expectAOTitleToNotBeDirty = () =>
 
 export const expectSeriesKeyToHaveSeriesKeyItems = (itemAmount) =>
     cy.get(highchartsSeriesKeyItemEl).should('have.length', itemAmount)
-
-export const expectSeriesKeyItemToHaveBullets = (itemIndex, bulletAmount) =>
-    cy
-        .get(highchartsSeriesKeyItemEl)
-        .eq(itemIndex)
-        .find(highchartsSeriesKeyItemBulletEl)
-        .should('have.length', bulletAmount)
 
 export const clickChartItem = (index) =>
     cy.get(highchartsChartItemEl).children().eq(index).click()

--- a/cypress/integration/options/legend.cy.js
+++ b/cypress/integration/options/legend.cy.js
@@ -12,7 +12,6 @@ import {
 } from '@dhis2/analytics'
 import {
     expectChartTitleToBeVisible,
-    expectSeriesKeyItemToHaveBullets,
     expectSeriesKeyToHaveSeriesKeyItems,
     expectVisualizationToBeVisible,
 } from '../../elements/chart.js'
@@ -57,6 +56,7 @@ import {
     expectLegedKeyItemAmountToBe,
     OPTIONS_TAB_SERIES,
     setItemToType,
+    clickOptionsModalHideButton,
 } from '../../elements/optionsModal/index.js'
 import { goToStartPage } from '../../elements/startScreen.js'
 import { changeVisType } from '../../elements/visualizationTypeSelector.js'
@@ -75,12 +75,10 @@ const TEST_ITEMS = [
     {
         name: 'ANC 1 Coverage',
         legendSet: 'ANC Coverage',
-        legends: 7,
     },
     {
         name: 'Diarrhoea <5 y incidence rate (%)',
         legendSet: 'Diarrhoea',
-        legends: 6,
     },
 ]
 
@@ -565,14 +563,13 @@ describe('Options - Legend', () => {
         it('legend options are not available', () => {
             clickMenuBarOptionsButton()
             expectOptionsTabToBeHidden(OPTIONS_TAB_LEGEND)
+            clickOptionsModalHideButton()
         })
         it('legend key is hidden', () => {
             expectLegendKeyToBeHidden()
         })
-        it(`series key displays the correct amount of bullets (1 each)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, 1)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
     })
     describe('Non-legend set type displays correctly: Line', () => {
@@ -596,10 +593,8 @@ describe('Options - Legend', () => {
         it('legend key is hidden', () => {
             expectLegendKeyToBeHidden()
         })
-        it(`series key displays the correct amount of bullets (1 each)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, 1)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
     })
     describe('The chart series key displaying legend colors', () => {
@@ -610,10 +605,8 @@ describe('Options - Legend', () => {
             clickDimensionModalUpdateButton()
             expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
         })
-        it(`series key items displays the correct amount of bullets (1 each)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, 1)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
         it('enables legend', () => {
             clickMenuBarOptionsButton()
@@ -624,11 +617,6 @@ describe('Options - Legend', () => {
             clickOptionsModalUpdateButton()
             expectChartTitleToBeVisible()
         })
-        it(`series key items displays the correct amount of bullets (first: ${TEST_ITEMS[0].legends}, second: ${TEST_ITEMS[1].legends})`, () => {
-            expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
-            expectSeriesKeyItemToHaveBullets(1, TEST_ITEMS[1].legends)
-        })
         it(`changes legend display strategy to fixed (${TEST_ITEMS[1].legendSet})`, () => {
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_LEGEND)
@@ -638,11 +626,6 @@ describe('Options - Legend', () => {
             changeFixedLegendSet(TEST_ITEMS[1].legendSet)
             clickOptionsModalUpdateButton()
             expectChartTitleToBeVisible()
-        })
-        it(`series key displays the correct amount of bullets (${TEST_ITEMS[1].legends} each)`, () => {
-            expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[1].legends)
-            expectSeriesKeyItemToHaveBullets(1, TEST_ITEMS[1].legends)
         })
     })
     describe('When data is not on series, legend is only applied when strategy fixed is used', () => {
@@ -679,9 +662,8 @@ describe('Options - Legend', () => {
             expectLegendKeyToBeVisible()
             expectLegedKeyItemAmountToBe(1)
         })
-        it(`series key items displays the correct amount of bullets (${TEST_ITEM.legends})`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(1)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
         })
         it('moves period dimension to series axis', () => {
             openContextMenu(DIMENSION_ID_PERIOD)
@@ -695,11 +677,6 @@ describe('Options - Legend', () => {
         })
         it('legend key is hidden', () => {
             expectLegendKeyToBeHidden()
-        })
-        it('series key displays the correct amount of bullets (1 each)', () => {
-            for (let i = 0; i < 3; i++) {
-                expectSeriesKeyItemToHaveBullets(i, 1)
-            }
         })
         it(`changes legend display strategy to fixed (${TEST_ITEMS[1].legendSet})`, () => {
             clickMenuBarOptionsButton()
@@ -720,11 +697,8 @@ describe('Options - Legend', () => {
             expectLegendKeyToBeVisible()
             expectLegedKeyItemAmountToBe(1)
         })
-        it(`series key items displays the correct amount of bullets (${TEST_ITEMS[1].legends})`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(3)
-            for (let i = 0; i < 3; i++) {
-                expectSeriesKeyItemToHaveBullets(i, TEST_ITEMS[1].legends)
-            }
         })
     })
     describe('Legend is not applied to column-as-line items', () => {
@@ -770,10 +744,8 @@ describe('Options - Legend', () => {
         it('legend key is hidden', () => {
             expectLegendKeyToBeHidden()
         })
-        it(`series key displays the correct amount of bullets (1 each)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, 1)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
         it(`changes first item (${TEST_ITEMS[0].name}) to type ${VIS_TYPE_COLUMN}`, () => {
             clickMenuBarOptionsButton()
@@ -794,10 +766,8 @@ describe('Options - Legend', () => {
             expectLegendKeyToBeVisible()
             expectLegedKeyItemAmountToBe(1)
         })
-        it(`series key items displays the correct amount of bullets (first: ${TEST_ITEMS[1].legends}, second: 1)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
         const TEST_ITEM = {
             name: 'ANC 2 Coverage',
@@ -828,11 +798,8 @@ describe('Options - Legend', () => {
             expectWindowConfigSeriesItemToNotHaveLegendSet(TEST_ITEMS[1].name)
             expectWindowConfigSeriesItemToNotHaveLegendSet(TEST_ITEM.name)
         })
-        it(`series key items displays the correct amount of bullets (first: ${TEST_ITEMS[1].legends}, second: 1, third: 1)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(3)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
-            expectSeriesKeyItemToHaveBullets(1, 1)
-            expectSeriesKeyItemToHaveBullets(2, 1)
         })
     })
 })

--- a/cypress/utils/config.js
+++ b/cypress/utils/config.js
@@ -44,9 +44,6 @@ export const CONFIG_DEFAULT_LEGEND = {
         color: '#212934',
         fontStyle: 'normal',
     },
-    useHTML: true,
-    symbolWidth: 0.001,
-    symbolHeight: 0.001,
 }
 
 export const CONFIG_DEFAULT_AXIS_LABELS = {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^23.12.5",
+        "@dhis2/analytics": "^23.13.2",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^23.13.2",
+        "@dhis2/analytics": "^23.13.3",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/app/src/actions/__tests__/index.spec.js
+++ b/packages/app/src/actions/__tests__/index.spec.js
@@ -363,10 +363,10 @@ describe('index', () => {
                         expectedVis
                     )
                     expect(history.default.replace).toHaveBeenCalled()
-                    expect(history.default.replace).toHaveBeenCalledWith({
-                        pathname: `/${uid}`,
-                        state: { isSaving: true },
-                    })
+                    expect(history.default.replace).toHaveBeenCalledWith(
+                        { pathname: `/${uid}` },
+                        { isSaving: true }
+                    )
                 })
         })
 
@@ -388,10 +388,10 @@ describe('index', () => {
                         expectedVis
                     )
                     expect(history.default.push).toHaveBeenCalled()
-                    expect(history.default.push).toHaveBeenCalledWith({
-                        pathname: `/${uid}`,
-                        state: { isSaving: true },
-                    })
+                    expect(history.default.push).toHaveBeenCalledWith(
+                        { pathname: `/${uid}` },
+                        { isSaving: true }
+                    )
                 })
         })
     })

--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -191,12 +191,12 @@ export const tDoSaveVisualization =
                 if (copy) {
                     history.push(
                         { pathname: `/${res.response.uid}` },
-                        { isSaving: true },
+                        { isSaving: true }
                     ) // Save as
                 } else {
                     history.replace(
                         { pathname: `/${res.response.uid}` },
-                        { isSaving: true },
+                        { isSaving: true }
                     ) // Save
                 }
             }

--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -189,15 +189,15 @@ export const tDoSaveVisualization =
         const onSuccess = (res) => {
             if (res.status === 'OK' && res.response.uid) {
                 if (copy) {
-                    history.push({
-                        pathname: `/${res.response.uid}`,
-                        state: { isSaving: true },
-                    }) // Save as
+                    history.push(
+                        { pathname: `/${res.response.uid}` },
+                        { isSaving: true },
+                    ) // Save as
                 } else {
-                    history.replace({
-                        pathname: `/${res.response.uid}`,
-                        state: { isSaving: true },
-                    }) // Save
+                    history.replace(
+                        { pathname: `/${res.response.uid}` },
+                        { isSaving: true },
+                    ) // Save
                 }
             }
         }

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^23.12.5",
+        "@dhis2/analytics": "^23.13.2",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^7.7.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^23.13.2",
+        "@dhis2/analytics": "^23.13.3",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^7.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,10 +2164,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^23.12.5":
-  version "23.12.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-23.12.5.tgz#c3445836cbec05f7b4967c70255f2907a7bcd6b4"
-  integrity sha512-c/n+bW/fQzo00aoOYIJMYGLjxsjoGJZLltQHDFdQybmzdw7kX3AHKsLK+qI3jRLk0oo9e8R3H9KNhsFeeu65gw==
+"@dhis2/analytics@^23.13.2":
+  version "23.13.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-23.13.2.tgz#71dd38270535ecb130b4ff8878610d6429f51b2c"
+  integrity sha512-5sM0y4BSNHueFA9T23YsDR3lFWht/MPzcJR1rILNpWtiu881KcIUzTe4/tz1uCegFs0UG+Ka2ep8tTHyDS3/mw==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     classnames "^2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,10 +2164,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^23.13.2":
-  version "23.13.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-23.13.2.tgz#71dd38270535ecb130b4ff8878610d6429f51b2c"
-  integrity sha512-5sM0y4BSNHueFA9T23YsDR3lFWht/MPzcJR1rILNpWtiu881KcIUzTe4/tz1uCegFs0UG+Ka2ep8tTHyDS3/mw==
+"@dhis2/analytics@^23.13.3":
+  version "23.13.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-23.13.3.tgz#f3a3f337badc9b5d4205d4141c5d1990818e4d42"
+  integrity sha512-m3txIpMaMws47DJd7ez/ar+TN+SpkZ5DDDot0sIb4y5Y+Pimqa5Ag7sarFpNDZ5MTh6fnzabTyCbXSRXNxOuhw==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     classnames "^2.3.1"


### PR DESCRIPTION
Implements [DHIS2-12719](https://jira.dhis2.org/browse/DHIS2-12719)

**Requires https://github.com/dhis2/analytics/pull/1279**

---

1. _See Analytics PR for more info_
2. Updates Cypress tests to reflect the latest changes
3. Updates the History implementation to support the v5 syntax (@edoardo)
