### PR TITLE
test: pass GITHUB_TOKEN as env param

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -38,4 +38,4 @@ jobs:
                   group: 'e2e'
               env:
                   CI: true
-                  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -38,3 +38,4 @@ jobs:
                   group: 'e2e'
               env:
                   CI: true
+                  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Pass `GITHUB_TOKEN` to Cypress test GH action, to prevent this bug from occuring: https://dhis2.atlassian.net/browse/CLI-36 (rerunning cypress on CI fails due to identical id)