### PR TITLE
fix: avoid encoding of visualization name in snackbar

### DIFF
--- a/packages/app/src/actions/index.js
+++ b/packages/app/src/actions/index.js
@@ -254,7 +254,7 @@ export const tDoDeleteVisualization = () => (dispatch, getState) => {
     dispatch(
         fromSnackbar.acReceivedSnackbarMessage({
             variant: VARIANT_SUCCESS,
-            message: i18n.t('"{{deletedObject}}" successfully deleted.', {
+            message: i18n.t('"{{- deletedObject}}" successfully deleted.', {
                 deletedObject: current.name,
             }),
             duration: 2000,


### PR DESCRIPTION

### Key features

1. avoid encoding of visualization name in snackbar

---

### Description

Some characters like `/` are encoded by default by `i18n.t`.
We already instruct `i18n.t` to not encode the text when interpolating the variable in several places.
The visualization name should be safe.

---

### Screenshots

Before:
![image (12)](https://user-images.githubusercontent.com/150978/183369970-20a8ac68-2603-4dda-a22e-ce6cc1a87136.png)

After:
<img width="406" alt="Screenshot 2022-08-08 at 09 55 03" src="https://user-images.githubusercontent.com/150978/183370136-af86b984-cb46-4d37-8790-73edead67343.png">

