### PR TITLE
fix: bump @dhis2/analytics for tokens search support 38.x

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^21.7.0",
+        "@dhis2/analytics": "^21.8.0",
         "@dhis2/app-runtime": "^3.2.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^21.7.0",
+        "@dhis2/analytics": "^21.8.0",
         "@dhis2/app-runtime": "^3.2.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^7.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,10 +2174,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^21.7.0":
-  version "21.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-21.7.0.tgz#e92659f74892274988b8608312bca8c66e65fa2f"
-  integrity sha512-+vzDRgP5BVHnFZeYYq+ZKZ7tlpkendHOz21tpMUCShZ0BpzXH8MQmE8ADUZQ619Fxim+2ANAyNkXGCBx7GcuVg==
+"@dhis2/analytics@^21.8.0":
+  version "21.8.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-21.8.0.tgz#6e9f15be623f17cfd6f42bffb6ef26bdb6d5f09a"
+  integrity sha512-ZYyf/7o1ANtEv6rokqnF3XklhwNS/9vDqxMsAi1UHE6xO+Ri38RYkuHSzeRsc2f9CoO6InjVz94hbjm3SBf+/g==
   dependencies:
     "@dhis2/d2-ui-translation-dialog" "^7.3.1"
     classnames "^2.3.1"
@@ -18489,10 +18489,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Implements [[DHIS2-13475]](https://jira.dhis2.org/browse/DHIS2-13475)

**Requires https://github.com/dhis2/analytics/pull/1293**

---

### Key features

1. bump analytics dependency for new functionality

---

### Description

See https://github.com/dhis2/analytics/pull/1289