### PR TITLE
fix: await ou levels

### DIFF
--- a/packages/app/src/components/App.js
+++ b/packages/app/src/components/App.js
@@ -140,7 +140,7 @@ export class UnconnectedApp extends Component {
         this.props.loadUserAuthority(APPROVAL_LEVEL_OPTION_AUTH)
         this.props.setDimensions()
 
-        this.fetchOuLevels()
+        await this.fetchOuLevels()
 
         const rootOrgUnits = this.props.settings.rootOrganisationUnits
 


### PR DESCRIPTION
The issue is about visualizations that have org unit levels in their org unit selection.

https://play.dhis2.org/dev/dhis-web-data-visualizer/#/w992mEjBzCB
https://play.dhis2.org/dev/dhis-web-data-visualizer/#/wp86U5zU4X3
https://play.dhis2.org/dev/dhis-web-data-visualizer/#/VffWmdKFHSq
https://play.dhis2.org/dev/dhis-web-data-visualizer/#/CNkMibmx1Zr
https://play.dhis2.org/dev/dhis-web-data-visualizer/#/zKl0LcQyxPl

When loading these via the url or before any other visualizations, they crash because we don't await the ou levels request.