### PR TITLE
fix: bump Analytics to latest + update Cypress (DHIS2-12719) 37.x

### DIFF
--- a/cypress/elements/chart.js
+++ b/cypress/elements/chart.js
@@ -15,8 +15,7 @@ const chartContainerEl = '.highcharts-container'
 const highchartsLegendEl = '.highcharts-legend'
 const highchartsTitleEl = '.highcharts-title'
 const highchartsSubtitleEl = '.highcharts-subtitle'
-const highchartsSeriesKeyItemEl = '.data-test-series-key-item' // Note: Highcharts strips out 'data-test' and similar attributes, hence 'class="data-test-..." was used instead
-const highchartsSeriesKeyItemBulletEl = '.data-test-series-key-item-bullet'
+const highchartsSeriesKeyItemEl = '.highcharts-legend-item'
 const highchartsChartItemEl = '.highcharts-series'
 const unsavedVisualizationTitleText = 'Unsaved visualization'
 const AOTitleEl = 'AO-title'
@@ -110,13 +109,6 @@ export const expectAOTitleToNotBeDirty = () =>
 
 export const expectSeriesKeyToHaveSeriesKeyItems = itemAmount =>
     cy.get(highchartsSeriesKeyItemEl).should('have.length', itemAmount)
-
-export const expectSeriesKeyItemToHaveBullets = (itemIndex, bulletAmount) =>
-    cy
-        .get(highchartsSeriesKeyItemEl)
-        .eq(itemIndex)
-        .find(highchartsSeriesKeyItemBulletEl)
-        .should('have.length', bulletAmount)
 
 export const clickChartItem = index =>
     cy.get(highchartsChartItemEl).children().eq(index).click()

--- a/cypress/integration/options/legend.cy.js
+++ b/cypress/integration/options/legend.cy.js
@@ -12,7 +12,6 @@ import {
 } from '@dhis2/analytics'
 import {
     expectChartTitleToBeVisible,
-    expectSeriesKeyItemToHaveBullets,
     expectSeriesKeyToHaveSeriesKeyItems,
     expectVisualizationToBeVisible,
 } from '../../elements/chart'
@@ -57,9 +56,10 @@ import {
     expectLegedKeyItemAmountToBe,
     OPTIONS_TAB_SERIES,
     setItemToType,
-} from '../../elements/optionsModal'
-import { goToStartPage } from '../../elements/startScreen'
-import { changeVisType } from '../../elements/visualizationTypeSelector'
+    clickOptionsModalHideButton,
+} from '../../elements/optionsModal/index.js'
+import { goToStartPage } from '../../elements/startScreen.js'
+import { changeVisType } from '../../elements/visualizationTypeSelector.js'
 import {
     expectEachWindowConfigSeriesItemToHaveLegendSet,
     expectEachWindowConfigSeriesItemToNotHaveLegendSet,
@@ -75,12 +75,10 @@ const TEST_ITEMS = [
     {
         name: 'ANC 1 Coverage',
         legendSet: 'ANC Coverage',
-        legends: 7,
     },
     {
         name: 'Diarrhoea <5 y incidence rate (%)',
         legendSet: 'Diarrhoea',
-        legends: 6,
     },
 ]
 
@@ -565,14 +563,13 @@ describe('Options - Legend', () => {
         it('legend options are not available', () => {
             clickMenuBarOptionsButton()
             expectOptionsTabToBeHidden(OPTIONS_TAB_LEGEND)
+            clickOptionsModalHideButton()
         })
         it('legend key is hidden', () => {
             expectLegendKeyToBeHidden()
         })
-        it(`series key displays the correct amount of bullets (1 each)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, 1)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
     })
     describe('Non-legend set type displays correctly: Line', () => {
@@ -596,10 +593,8 @@ describe('Options - Legend', () => {
         it('legend key is hidden', () => {
             expectLegendKeyToBeHidden()
         })
-        it(`series key displays the correct amount of bullets (1 each)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, 1)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
     })
     describe('The chart series key displaying legend colors', () => {
@@ -610,10 +605,8 @@ describe('Options - Legend', () => {
             clickDimensionModalUpdateButton()
             expectVisualizationToBeVisible(VIS_TYPE_COLUMN)
         })
-        it(`series key items displays the correct amount of bullets (1 each)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, 1)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
         it('enables legend', () => {
             clickMenuBarOptionsButton()
@@ -624,11 +617,6 @@ describe('Options - Legend', () => {
             clickOptionsModalUpdateButton()
             expectChartTitleToBeVisible()
         })
-        it(`series key items displays the correct amount of bullets (first: ${TEST_ITEMS[0].legends}, second: ${TEST_ITEMS[1].legends})`, () => {
-            expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
-            expectSeriesKeyItemToHaveBullets(1, TEST_ITEMS[1].legends)
-        })
         it(`changes legend display strategy to fixed (${TEST_ITEMS[1].legendSet})`, () => {
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_LEGEND)
@@ -638,11 +626,6 @@ describe('Options - Legend', () => {
             changeFixedLegendSet(TEST_ITEMS[1].legendSet)
             clickOptionsModalUpdateButton()
             expectChartTitleToBeVisible()
-        })
-        it(`series key displays the correct amount of bullets (${TEST_ITEMS[1].legends} each)`, () => {
-            expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[1].legends)
-            expectSeriesKeyItemToHaveBullets(1, TEST_ITEMS[1].legends)
         })
     })
     describe('When data is not on series, legend is only applied when strategy fixed is used', () => {
@@ -679,9 +662,8 @@ describe('Options - Legend', () => {
             expectLegendKeyToBeVisible()
             expectLegedKeyItemAmountToBe(1)
         })
-        it(`series key items displays the correct amount of bullets (${TEST_ITEM.legends})`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(1)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
         })
         it('moves period dimension to series axis', () => {
             openContextMenu(DIMENSION_ID_PERIOD)
@@ -695,11 +677,6 @@ describe('Options - Legend', () => {
         })
         it('legend key is hidden', () => {
             expectLegendKeyToBeHidden()
-        })
-        it('series key displays the correct amount of bullets (1 each)', () => {
-            for (let i = 0; i < 3; i++) {
-                expectSeriesKeyItemToHaveBullets(i, 1)
-            }
         })
         it(`changes legend display strategy to fixed (${TEST_ITEMS[1].legendSet})`, () => {
             clickMenuBarOptionsButton()
@@ -720,11 +697,8 @@ describe('Options - Legend', () => {
             expectLegendKeyToBeVisible()
             expectLegedKeyItemAmountToBe(1)
         })
-        it(`series key items displays the correct amount of bullets (${TEST_ITEMS[1].legends})`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(3)
-            for (let i = 0; i < 3; i++) {
-                expectSeriesKeyItemToHaveBullets(i, TEST_ITEMS[1].legends)
-            }
         })
     })
     describe('Legend is not applied to column-as-line items', () => {
@@ -770,10 +744,8 @@ describe('Options - Legend', () => {
         it('legend key is hidden', () => {
             expectLegendKeyToBeHidden()
         })
-        it(`series key displays the correct amount of bullets (1 each)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, 1)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
         it(`changes first item (${TEST_ITEMS[0].name}) to type ${VIS_TYPE_COLUMN}`, () => {
             clickMenuBarOptionsButton()
@@ -794,10 +766,8 @@ describe('Options - Legend', () => {
             expectLegendKeyToBeVisible()
             expectLegedKeyItemAmountToBe(1)
         })
-        it(`series key items displays the correct amount of bullets (first: ${TEST_ITEMS[1].legends}, second: 1)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(2)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
-            expectSeriesKeyItemToHaveBullets(1, 1)
         })
         const TEST_ITEM = {
             name: 'ANC 2 Coverage',
@@ -828,11 +798,8 @@ describe('Options - Legend', () => {
             expectWindowConfigSeriesItemToNotHaveLegendSet(TEST_ITEMS[1].name)
             expectWindowConfigSeriesItemToNotHaveLegendSet(TEST_ITEM.name)
         })
-        it(`series key items displays the correct amount of bullets (first: ${TEST_ITEMS[1].legends}, second: 1, third: 1)`, () => {
+        it(`series key displays the correct amount of items`, () => {
             expectSeriesKeyToHaveSeriesKeyItems(3)
-            expectSeriesKeyItemToHaveBullets(0, TEST_ITEMS[0].legends)
-            expectSeriesKeyItemToHaveBullets(1, 1)
-            expectSeriesKeyItemToHaveBullets(2, 1)
         })
     })
 })

--- a/cypress/utils/config.js
+++ b/cypress/utils/config.js
@@ -44,9 +44,6 @@ export const CONFIG_DEFAULT_LEGEND = {
         color: '#212934',
         fontStyle: 'normal',
     },
-    useHTML: true,
-    symbolWidth: 0.001,
-    symbolHeight: 0.001,
 }
 
 export const CONFIG_DEFAULT_AXIS_LABELS = {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.9.0",
+        "@dhis2/analytics": "^20.9.1",
         "@dhis2/app-runtime": "^2.11.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^20.9.0",
+        "@dhis2/analytics": "^20.9.1",
         "@dhis2/app-runtime": "^2.11.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.23.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,10 +2143,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^20.9.0":
-  version "20.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.9.0.tgz#95e3bf9bd2885b0780cf15e900ce5f70b845bf64"
-  integrity sha512-qU36RU5dOTqFKku3pTenfuj/PDtx9xi0hFElQ2cr0cMw63BugJREC7bxET+eA4bVG3lXnH43x82zQZKUsugIPQ==
+"@dhis2/analytics@^20.9.1":
+  version "20.9.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-20.9.1.tgz#3d6d3bcf29af171e131f8ad7d8ce790fedd92351"
+  integrity sha512-5SH9TYx9jgwTuqO45hLBQQeL5dvBDfW+7eapFLZQ4cIzK2CYTyo2qZTVBCFD6kaoHdjTqMuY0fVRTLtP+4HeMA==
   dependencies:
     "@dhis2/d2-ui-org-unit-dialog" "^7.3.0"
     "@dhis2/d2-ui-translation-dialog" "^7.3.1"
@@ -2354,10 +2354,10 @@
     material-ui "^0.20.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-core@7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.3.4.tgz#88fe3aca89999e4bec11124dcfc2963f54b1e24a"
-  integrity sha512-SYhr9iioZQ475ru92d1l8NXPWlsEcPv0XqADDGSV0vJol9gE45axanmODjGhdqeigMzc4MeFgPKgJ2RFwonqJQ==
+"@dhis2/d2-ui-core@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.4.0.tgz#796afffbca4cf7f76a500d979e53c01abe8ebcb2"
+  integrity sha512-lVk3q2PV3Xb0RoeCcK/UgR2zqymj3SUix4qQXm+5HLZww6UtP8sTj+QcEEuVbPBqHPHaXnSOsKgtoD02QJfm4A==
   dependencies:
     babel-runtime "^6.26.0"
     d2 "~31.7"
@@ -2392,21 +2392,21 @@
     prop-types "^15.6.2"
 
 "@dhis2/d2-ui-org-unit-dialog@^7.3.0":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.3.4.tgz#5c09f5d543e19f66cebf8dab92413af64afa787c"
-  integrity sha512-UW9XltlayWtt5WVYp9uzxfYnyGWyexgYPn18PUOTm4EFs0VfhfK87RI2NOWAwENiCk0FueuHX3zDI9DJwlHZhQ==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.4.0.tgz#5278893bb5dd8f33abfa103aa1faeee377d49a09"
+  integrity sha512-Z22eGEO5iHrruci+KM+1PJ/LAjiIMelIMSqk5Ru24H7tTk6GxV/sLB/GGvJHGReDm+ifQmblwNrO4EiPsWQ4JQ==
   dependencies:
-    "@dhis2/d2-ui-org-unit-tree" "7.3.4"
+    "@dhis2/d2-ui-org-unit-tree" "7.4.0"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-org-unit-tree@7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.3.4.tgz#ddfbfa58a033424e3954f720d314e7e09ea54db5"
-  integrity sha512-V9J8AakOQiCVxg2y3zK+0IPmVUXOmADYoGkk4QUmcg5npZ31tz55mtBBSIr+BBQydeAUy+k1z1qARzkD2C/FRQ==
+"@dhis2/d2-ui-org-unit-tree@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.4.0.tgz#a550278f6f8ed9e984eb7ba3ac209de30e7e0b96"
+  integrity sha512-D44liivosGW8JzOlGhgs31szKGGCxGuML0R1d9ty0YTu/oWyL79OGEdblAg9ET046Gr02ZuPZ0PMGWMhEyM9VA==
   dependencies:
-    "@dhis2/d2-ui-core" "7.3.4"
+    "@dhis2/d2-ui-core" "7.4.0"
     "@material-ui/core" "^3.3.1"
     babel-runtime "^6.26.0"
     prop-types "^15.5.10"
@@ -2435,11 +2435,11 @@
     rxjs "^5.5.7"
 
 "@dhis2/d2-ui-translation-dialog@^7.3.1":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.3.4.tgz#050dbf964e3684cea01550a2f4b07dec94415197"
-  integrity sha512-YnYotRu52UEZHmyd7xYonZAy+yYEKJVPnNpnQxIZNc20Q8C3tRXyuWruPtTHcW8LtUnf6sqb1uLkv2oOhMXP+w==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.4.0.tgz#5d4ef941f416df6c723adc5b5916a83202ed0e60"
+  integrity sha512-bd1ZIkcL8T4LdYPYPpMXptUKW8skWForSS9xCi1H3CdPm5jGpcVaxbxNE7b3+9mJsTahERcDOzRztkcqFXfiVA==
   dependencies:
-    "@dhis2/d2-ui-core" "7.3.4"
+    "@dhis2/d2-ui-core" "7.4.0"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -3080,9 +3080,9 @@
     chalk "^4.0.0"
 
 "@ls-lint/ls-lint@^1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@ls-lint/ls-lint/-/ls-lint-1.9.2.tgz#689f1f4c06072823a726802ba167340efcefe19c"
-  integrity sha512-sugEjWjSSy9OHF6t1ZBLZCAROj52cZthB9dIePmzZzzMwmWwy3qAEMSdJheHeS1FOwDZI7Ipm1H/bWgzJNnSAw==
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@ls-lint/ls-lint/-/ls-lint-1.11.2.tgz#fa7e8c404b7c2f9f7fe3e92b7d69fe37a15c0e1c"
+  integrity sha512-kX+CCjgNz+NHCaOcFyJLSBLRgAoyOxN18QFLpgucz5ILvbr60BGjwKaoPYTv/rBV/77L+Oz82lpP24mzJ2wGsQ==
 
 "@material-ui/core@^3.3.1":
   version "3.9.4"
@@ -12836,7 +12836,7 @@ node-releases@^1.1.61, node-releases@^1.1.75:
 nopt@~1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
+  integrity sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==
   dependencies:
     abbrev "1"
 
@@ -16206,7 +16206,7 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, sourc
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@0.7.3, source-map@^0.7.2, source-map@^0.7.3, source-map@~0.7.2:
+source-map@0.7.3, source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -16215,6 +16215,11 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+source-map@^0.7.2:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 source-map@^0.8.0-beta.0:
   version "0.8.0-beta.0"
@@ -17923,10 +17928,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Backport [DHIS2-12719](https://dhis2.atlassian.net/browse/DHIS2-12719) to 37.x

**Requires https://github.com/dhis2/analytics/pull/1312**

---

Partial cherry-pick from https://github.com/dhis2/data-visualizer-app/pull/2126