### PR TITLE
fix: do not override height if present in style object DHIS2-13812

### DIFF
--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -328,8 +328,11 @@ export const VisualizationPlugin = ({
                             onDrill ? onToggleContextualMenu : undefined
                         }
                         id={id}
-                        // force height otherwise the PivotTable container sets 0 as height hiding the table content
-                        style={{ ...transformedStyle, height: '100%' }}
+                        // force height when no value available otherwise the PivotTable container sets 0 as height hiding the table content
+                        style={{
+                            ...transformedStyle,
+                            height: transformedStyle.height || '100%',
+                        }}
                     />
                 ) : (
                     <ChartPlugin


### PR DESCRIPTION
Fixes [DHIS2-13812](https://jira.dhis2.org/browse/DHIS2-13812)

---

### Key features

1. fix hidden PT plugin in dashboard

---

### Description

Dashboard app passed `height` and `width` in a `style` prop to the DV plugin.
A previous change to fix the same issue in the interpretation modal in DV app was overriding the `height` but caused the problem in dashboard app.

The fix is to use the passed value for `height` if available, and fallback to `100%`.
The former works for dashboard app while the latter works for the interpretation modal in DV.

---

### Screenshots

Before:
<img width="748" alt="Screenshot 2022-09-27 at 11 52 45" src="https://user-images.githubusercontent.com/150978/192495133-a86982c2-a3f0-4ca6-bdf7-1242fb025e7b.png">

After:
<img width="522" alt="Screenshot 2022-09-27 at 11 51 48" src="https://user-images.githubusercontent.com/150978/192495157-4414ff61-f91e-499c-986c-12ab36037a8d.png">


