### PR TITLE
fix: bump analytics to avoid es2022 fn 38.x

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^21.8.1",
+        "@dhis2/analytics": "^21.8.2",
         "@dhis2/app-runtime": "^3.2.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^21.8.1",
+        "@dhis2/analytics": "^21.8.2",
         "@dhis2/app-runtime": "^3.2.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^7.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,10 +2174,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^21.8.1":
-  version "21.8.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-21.8.1.tgz#2e04e80cb2f80336c80a6a1605c295702e1f8d65"
-  integrity sha512-UXkCmZEWhwMaJgx5kJVP7dCr8evbTuyQaPi9jZGvbPeClX+2dg98ewyaVQ3AVdAc+DXdY93uG9nWAygrGXVuBA==
+"@dhis2/analytics@^21.8.2":
+  version "21.8.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-21.8.2.tgz#c8a0e2264fcd7ce2a1615f563e4b03d20f970182"
+  integrity sha512-6RVUxgWULcglECSuGLf0Hl85bJ84o717XnNQAY9bxlP8vZcXNAG1S8TToWc7m0pTtH4jaFIlbJ8ktdgrcd6SZA==
   dependencies:
     "@dhis2/d2-ui-translation-dialog" "^7.3.1"
     classnames "^2.3.1"


### PR DESCRIPTION
Bumps Analytics to https://github.com/dhis2/analytics/pull/1345, which avoids using ES2022 function `.at` that was causing Cypress tests to fail