### PR TITLE
fix: bump @dhis2/analytics for DHIS2-13911

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.0.9",
+        "@dhis2/analytics": "^24.2.7",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/d2-i18n": "^1.1.0",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.0.9",
+        "@dhis2/analytics": "^24.2.7",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^8.4.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,10 +2142,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24.0.9":
-  version "24.0.9"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.0.9.tgz#6d875547ffa2b4e85c7166d3c6f161cfcfe5ab64"
-  integrity sha512-Q/rFBETgYyGKbSUX1W/jEtzBMyYb44D4hFNXYTCXVpaurimHxHyJWjyiuBiYeTc03JgR8ap6Soz/SWh9b02Olw==
+"@dhis2/analytics@^24.2.7":
+  version "24.2.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.2.7.tgz#c2e7796d909bf8e36552138a5cd6e3d414b8d09d"
+  integrity sha512-orEO14qzdTacQZdUVTOHlbZsdsGm3Q2Wjk3ELPBnsPIKq2c+9J4ve34wwc7wBcvVJP/BlW5LEs97G7DdjqurFA==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     classnames "^2.3.1"


### PR DESCRIPTION
Implements [DHIS2-13911](https://jira.dhis2.org/browse/DHIS2-13911)

**Requires https://github.com/dhis2/analytics/pull/1358**

---

### Key features

1. bump @dhis2/analytics to enable markdown parsing of AO's description

---

### Description

Backport of the same fix in master to have it in later 2.39 patch releases.