### PR TITLE
test: fix failing test, use a different Gauge AO

### DIFF
--- a/cypress/utils/data.js
+++ b/cypress/utils/data.js
@@ -67,7 +67,7 @@ export const TEST_AOS = [
         type: VIS_TYPE_PIE,
     },
     {
-        name: 'Immunization: OPV 3 coverage last month',
+        name: 'Immunization: OPV Coverage meter chart last quarter',
         type: VIS_TYPE_GAUGE,
     },
     {


### PR DESCRIPTION
### Key features

1. fix a failing Cypress test

---

### Description

The Gauge test is failing. Use a different AO.