### PR TITLE
fix: type selector: Wrong hover style for active selection (DHIS2-9262)

### DIFF
--- a/src/components/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
+++ b/src/components/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
@@ -59,7 +59,8 @@
     border-color: var(--colors-grey400);
 }
 
-.listItemActive {
+.listItemActive,
+.listItemActive:hover {
     background: var(--colors-teal050);
     border: 2px solid var(--colors-teal300);
 }


### PR DESCRIPTION
Implements [DHIS2-9262](https://jira.dhis2.org/browse/DHIS2-9262)

---

### Key features

1. Removes the hover style from the active list item

---

### Description

When hovering the active (green) item, the item will remain unchanged. 
Previously, the "hover" style (gray) would overwrite the "active" style (green).

Note: Can't be shown in a screenshot properly, but can be seen on the Netlify build.

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/204487297-f30980a8-bd47-483d-9754-7a19a81e1dee.png)
