### PR TITLE
test: limit query scope to avoid long response time

### DIFF
--- a/cypress/integration/visTypes/scatter.cy.js
+++ b/cypress/integration/visTypes/scatter.cy.js
@@ -17,6 +17,7 @@ import {
     expectDataDimensionModalWarningToContain,
     expectDataItemToBeInactive,
     expectOrgUnitDimensionModalToBeVisible,
+    expectOrgUnitDimensionToNotBeLoading,
     toggleOrgUnitLevel,
     deselectUserOrgUnit,
     selectOrgUnitTreeItem,
@@ -101,7 +102,11 @@ describe('using a Scatter chart', () => {
         openDimension(DIMENSION_ID_ORGUNIT)
         expectOrgUnitDimensionModalToBeVisible()
         deselectUserOrgUnit('User organisation unit')
-        selectOrgUnitTreeItem('Sierra Leone')
+        expectOrgUnitDimensionToNotBeLoading()
+        // FIXME this selection causes a analytics request that takes too long on test instances
+        //selectOrgUnitTreeItem('Sierra Leone')
+        selectOrgUnitTreeItem('Bo')
+        selectOrgUnitTreeItem('Bombali')
         toggleOrgUnitLevel(TEST_ORG_UNIT_LEVEL)
         expectOrgUnitDimensionModalToBeVisible()
         clickDimensionModalUpdateButton()


### PR DESCRIPTION

### Key features

1. tweak the scatter test to avoid timeouts and consequent failures

---

### Description

This is a temporary fix for this test that started to fail on test instances when the facility levels for the whole Sierra Leone are requested.
There isn't a problem with the actual test, but on the current test instances the response consistently takes a very long time to return, causing this test to fail.

Also, wait for the org unit tree to be loaded before trying to select anything else than the root level, this seemed to fail consistently from my local testing.

---

### Screenshot

Select the facility level only on a couple of org units:

![Screenshot 2022-12-05 at 15 31 59](https://user-images.githubusercontent.com/150978/205662580-ea32c5c0-fa34-44d9-9e04-08f08b3746f6.png)

