### PR TITLE
chore: always use chrome browser for cypress to record videos correctly

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -107,7 +107,10 @@ jobs:
                   wait-on: 'http://localhost:3000'
                   wait-on-timeout: 300
                   record: true
+                  video: true
                   parallel: true
+                  browser: chrome
+                  headless: true
               env:
                   BROWSER: none
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cypress.json
+++ b/cypress.json
@@ -3,7 +3,7 @@
     "projectId": "sojh88",
     "testFiles": "**/*.cy.js",
     "experimentalInteractiveRunEvents": true,
-    "video": false,
+    "video": true,
     "viewportWidth": 1280,
     "viewportHeight": 800,
     "env": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "build": "d2-app-scripts build",
         "start": "d2-app-scripts start",
+        "start:nobrowser": "BROWSER=none yarn start",
         "test": "d2-app-scripts test",
         "coverage": "yarn test --coverage",
         "deploy": "d2-app-scripts deploy",
@@ -14,8 +15,8 @@
         "format": "d2-style apply",
         "validate-commit": "d2-style check --staged",
         "validate-push": "yarn test",
-        "cypress:run": "start-server-and-test 'yarn start' http://localhost:3000 'yarn cypress run --env networkMode=live'",
-        "cypress:live": "start-server-and-test 'yarn start' http://localhost:3000 'yarn cypress open --env networkMode=live'"
+        "cypress:run": "start-server-and-test 'yarn start:nobrowser' http://localhost:3000 'yarn cypress run --browser chrome headless --env networkMode=live'",
+        "cypress:live": "start-server-and-test 'yarn start:nobrowser' http://localhost:3000 'yarn cypress open --browser chrome --env networkMode=live'"
     },
     "devDependencies": {
         "@dhis2/cli-app-scripts": "^10.0.0",


### PR DESCRIPTION
This PR doesn't have a JIRA ticket 😱 

The changes in this PR will ensure that both on CI and locally cypress will use the Chrome browser for runs. For interactive runs (i.e. `cypress open`) the browser will be headed and for regular runs it will be headless.

These changes should fix the issue that videos were not being recorded properly.

TODO:
- [x] Ensure cypress is running in Chrome locally
- [x] Ensure cypress is running in Chrome on CI
- [x] Ensure video is capture on cypress dashboard if a test fails