### PR TITLE
fix: remove old i18n initialisation

### DIFF
--- a/src/AppWrapper.js
+++ b/src/AppWrapper.js
@@ -40,7 +40,6 @@ const AppWrapper = () => {
                             return userSettings?.uiLocale ? (
                                 <D2Shim
                                     d2Config={d2Config}
-                                    i18nRoot="./i18n_old"
                                     locale={userSettings.uiLocale}
                                 >
                                     {({ d2 }) => {


### PR DESCRIPTION
### Key features

1. do not initialise the old i18n with property files

---

### Description

i18n properties files have been removed already, but the `D2Shim` was still using `i18nRoot` which causes the app to try to load the property file for the current locale.

---

### Screenshots

Failed request for old i18n property file:
<img width="1171" alt="Screenshot 2023-03-09 at 15 34 30" src="https://user-images.githubusercontent.com/150978/224057011-78d7aa94-d0c5-4baa-a381-9e4b94295876.png">

