### PR TITLE
fix: set height on chart container when not defined

### DIFF
--- a/src/components/VisualizationPlugin/VisualizationPlugin.js
+++ b/src/components/VisualizationPlugin/VisualizationPlugin.js
@@ -267,6 +267,12 @@ export const VisualizationPlugin = ({
               }
             : style
 
+    // force height when no value available otherwise the PivotTable container sets 0 as height hiding the table content
+    // and Highcharts does not render correctly the chart/legend
+    if (!transformedStyle.height) {
+        transformedStyle.height = '100%'
+    }
+
     const getLegendKey = () => {
         if (hasLegendSet && forDashboard) {
             return (
@@ -330,11 +336,7 @@ export const VisualizationPlugin = ({
                             onDrill ? onToggleContextualMenu : undefined
                         }
                         id={id}
-                        // force height when no value available otherwise the PivotTable container sets 0 as height hiding the table content
-                        style={{
-                            ...transformedStyle,
-                            height: transformedStyle.height || '100%',
-                        }}
+                        style={transformedStyle}
                     />
                 ) : (
                     <ChartPlugin


### PR DESCRIPTION

### Key features

1. avoid DV charts cutoff in dashboard

---

### Description

This fixes a cutoff issue in dashboard.
It didn't affect the app before, and with this change everything still seems to work fine in the app.

---

### Screenshots

Before:
<img width="562" alt="Screenshot 2023-03-15 at 16 24 31" src="https://user-images.githubusercontent.com/150978/225357896-065b4762-996c-494e-af43-ff16059b3941.png">

After:
<img width="477" alt="Screenshot 2023-03-15 at 16 22 39" src="https://user-images.githubusercontent.com/150978/225357912-3087d1ab-5657-4003-8f3f-b885583d493c.png">

