### PR TITLE
chore: add styled-jsx which is a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.2.0",
         "reselect": "^4.0.0",
+        "styled-jsx": "^4",
         "whatwg-fetch": "^3.6.2"
     },
     "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13684,7 +13684,7 @@ style-loader@^3.3.1:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
   integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
 
-styled-jsx@^4.0.1:
+styled-jsx@^4, styled-jsx@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-4.0.1.tgz#ae3f716eacc0792f7050389de88add6d5245b9e9"
   integrity sha512-Gcb49/dRB1k8B4hdK8vhW27Rlb2zujCk1fISrizCcToIs+55B4vmUM0N9Gi4nnVfFZWe55jRdWpAqH1ldAKWvQ==


### PR DESCRIPTION
@dhis2/ui lists styled-jsx as a peer dependency, and not having it in package.json results in a bunch of warnings during `yarn install`