### PR TITLE
fix: ac with a non-data element throws backend error instead of custom error

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -44,6 +44,7 @@ export class UnconnectedVisualization extends Component {
         let error
         if (response) {
             switch (response.details?.errorCode) {
+                case 'E7113':
                 case 'E7114':
                     error = new AssignedCategoriesDataElementsError()
                     break


### PR DESCRIPTION
Implements [DHIS2-15243](https://jira.dhis2.org/browse/DHIS2-15243)

---

### Key features

1. Throw same error for case `E7113` as for case `E7114`

---

### Description

Throws the same custom error message for case `E7113` (DE and non-DE used with AC) as for case `E7114` (non-DE used with AC), as they essentially have the same solution (make sure that only DE's are used with AC).

---

### Screenshots

_the custom error being thrown_
![image](https://user-images.githubusercontent.com/12590483/235677456-7be17101-2ab4-4c71-bb1f-262300e826f7.png)



[DHIS2-15243]: https://dhis2.atlassian.net/browse/DHIS2-15243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ