### PR TITLE
test: add extended timeout for file open modal

### DIFF
--- a/cypress/elements/dimensionModal/orgUnitDimension.js
+++ b/cypress/elements/dimensionModal/orgUnitDimension.js
@@ -1,9 +1,7 @@
 import { DIMENSION_ID_ORGUNIT } from '@dhis2/analytics'
+import { EXTENDED_TIMEOUT } from '../../support/utils.js'
 import { expectDimensionModalToBeVisible } from './index.js'
 
-const timeout = {
-    timeout: 20000,
-}
 const orgUnitModalEl = 'dialog-manager-ou'
 const levelSelectEl = 'org-unit-level-select'
 const levelSelectOptionEl = 'org-unit-level-select-option'
@@ -21,7 +19,7 @@ export const expectOrgUnitDimensionModalToBeVisible = () =>
 export const expectOrgUnitDimensionToNotBeLoading = () =>
     cy
         .getBySel(orgUnitTreeEl)
-        .find('[role="progressbar"]', timeout)
+        .find('[role="progressbar"]', EXTENDED_TIMEOUT)
         .should('not.exist')
 
 export const expectOrgUnitItemToBeSelected = (itemName) =>

--- a/cypress/elements/fileMenu/open.js
+++ b/cypress/elements/fileMenu/open.js
@@ -1,3 +1,4 @@
+import { EXTENDED_TIMEOUT } from '../../support/utils.js'
 import { generateRandomChar, generateRandomNumber } from '../../utils/random.js'
 import { clickMenuBarFileButton } from '../menuBar.js'
 import { FILE_MENU_BUTTON_OPEN, clickFileMenuButton } from './index.js'
@@ -67,5 +68,7 @@ export const openAOByName = (name) => {
     clickMenuBarFileButton()
     clickFileMenuButton(FILE_MENU_BUTTON_OPEN)
     searchAOByName(name)
-    cy.getBySel(openModalEl).contains(name).click()
+    cy.getBySel(openModalEl, EXTENDED_TIMEOUT)
+        .contains(name, EXTENDED_TIMEOUT)
+        .click()
 }

--- a/cypress/elements/startScreen.js
+++ b/cypress/elements/startScreen.js
@@ -1,3 +1,5 @@
+import { EXTENDED_TIMEOUT } from '../support/utils.js'
+
 //const startScreen = '*[class^="StartScreen_outer"]'
 const primaryTitleText = 'Getting started'
 const primaryTitleEl = 'start-screen-primary-section-title'
@@ -14,9 +16,7 @@ export const goToStartPage = () => {
 
 export const expectStartScreenToBeVisible = () =>
     cy
-        .getBySel(primaryTitleEl, {
-            timeout: 15000,
-        })
+        .getBySel(primaryTitleEl, EXTENDED_TIMEOUT)
         .should('contain', primaryTitleText)
 
 export const expectMostViewedToBeVisible = () => {

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -1,0 +1,1 @@
+export const EXTENDED_TIMEOUT = { timeout: 15000 }


### PR DESCRIPTION
Adds `EXTENDED_TIMEOUT` to the File Open modal to prevent timing out when the list of AOs is slow to load while testing.