### PR TITLE
test: extend timeout for loading visualizations

### DIFF
--- a/cypress/elements/chart.js
+++ b/cypress/elements/chart.js
@@ -21,7 +21,7 @@ const unsavedVisualizationTitleText = 'Unsaved visualization'
 const AOTitleEl = 'AO-title'
 const AOTitleDirtyEl = 'AO-title-dirty'
 const timeout = {
-    timeout: 20000,
+    timeout: 40000,
 }
 const nonHighchartsTypes = [VIS_TYPE_PIVOT_TABLE, VIS_TYPE_SINGLE_VALUE]
 


### PR DESCRIPTION
extends the timeout for when visualizations are loading since that seems to be slow sometimes (which could be because of the server), e.g. this test failed when trying to open a PR because the result didn't return fast enough https://cloud.cypress.io/projects/sojh88/runs/2000/test-results/834f2e45-c119-4b4f-9c08-d7f95653be2b