### PR TITLE
test: add Cypress tests for SV icon (DHIS2-10496)

### DIFF
--- a/cypress/elements/chart.js
+++ b/cypress/elements/chart.js
@@ -21,7 +21,7 @@ const unsavedVisualizationTitleText = 'Unsaved visualization'
 const AOTitleEl = 'AO-title'
 const AOTitleDirtyEl = 'AO-title-dirty'
 const timeout = {
-    timeout: 20000,
+    timeout: 40000,
 }
 const nonHighchartsTypes = [VIS_TYPE_PIVOT_TABLE, VIS_TYPE_SINGLE_VALUE]
 

--- a/cypress/elements/chart.js
+++ b/cypress/elements/chart.js
@@ -18,8 +18,8 @@ const highchartsSubtitleEl = '.highcharts-subtitle'
 const highchartsSeriesKeyItemEl = '.highcharts-legend-item'
 const highchartsChartItemEl = '.highcharts-series'
 const unsavedVisualizationTitleText = 'Unsaved visualization'
-const AOTitleEl = 'visualization-title'
-const AOTitleDirtyEl = 'visualization-title-dirty'
+const AOTitleEl = 'AO-title'
+const AOTitleDirtyEl = 'AO-title-dirty'
 const timeout = {
     timeout: 40000,
 }

--- a/cypress/elements/chart.js
+++ b/cypress/elements/chart.js
@@ -18,8 +18,8 @@ const highchartsSubtitleEl = '.highcharts-subtitle'
 const highchartsSeriesKeyItemEl = '.highcharts-legend-item'
 const highchartsChartItemEl = '.highcharts-series'
 const unsavedVisualizationTitleText = 'Unsaved visualization'
-const AOTitleEl = 'AO-title'
-const AOTitleDirtyEl = 'AO-title-dirty'
+const AOTitleEl = 'visualization-title'
+const AOTitleDirtyEl = 'visualization-title-dirty'
 const timeout = {
     timeout: 40000,
 }

--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -89,6 +89,8 @@ export const expectGroupSelectToBe = (group) =>
 
 export const switchGroupTo = (group) => {
     cy.getBySel(groupSelectButtonEl).click()
+    cy.getBySelLike(groupSelectOptionEl).should('have.length.least', 2)
+    cy.getBySelLike('singleselect-loading').should('not.exist')
     cy.getBySelLike(groupSelectOptionEl).contains(group).click()
 }
 

--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -26,6 +26,15 @@ const rightHeaderEl = 'data-dimension-transfer-rightheader'
 const searchFieldEl = 'data-dimension-left-header-filter-input-field-content'
 const emptySourceEl = 'data-dimension-empty-source'
 
+const expectItemsToBeInSource = (items) => {
+    cy.getBySelLike('transfer-sourceoptions').should(($elems) => {
+        const $container = $elems.first()
+        expect($container).to.have.class('container')
+        const $options = $container.find('[data-test*="transfer-option"]')
+        items.forEach((item) => expect($options).to.contain(item))
+    })
+}
+
 export const expectDataDimensionModalToBeVisible = () =>
     expectDimensionModalToBeVisible(DIMENSION_ID_DATA)
 
@@ -46,8 +55,9 @@ export const scrollSourceToBottom = () => {
 }
 
 export const selectDataElements = (dataElements) => {
-    switchDataTypeTo('Data elements')
     expectSourceToNotBeLoading()
+    switchDataTypeTo('Data elements')
+    expectItemsToBeInSource(dataElements)
     dataElements.forEach((item) => selectItemByDoubleClick(item))
 }
 
@@ -55,8 +65,9 @@ export const selectFirstDataItem = () =>
     cy.getBySel(selectableItemsEl).findBySel(optionContentEl).eq(0).dblclick()
 
 export const selectIndicators = (indicators) => {
-    switchDataTypeTo('Indicators')
     expectSourceToNotBeLoading()
+    switchDataTypeTo('Indicators')
+    expectItemsToBeInSource(indicators)
     indicators.forEach((item) => selectItemByDoubleClick(item))
 }
 
@@ -126,6 +137,22 @@ export const clickEDIEditButton = (item) =>
         .parent()
         .findBySel('data-dimension-transfer-option-edit-button')
         .click()
+
+export const expectSelectableDataItemsAmountToBe = (amount) =>
+    cy.getBySelLike('transfer-sourceoptions').should(($elems) => {
+        const $container = $elems.first()
+        expect(
+            $container.find('[data-test="data-dimension-transfer-option"]')
+        ).to.have.lengthOf(amount)
+    })
+
+export const expectSelectableDataItemsAmountToBeLeast = (amount) =>
+    cy.getBySelLike('transfer-sourceoptions').should(($elems) => {
+        const $container = $elems.first()
+        expect(
+            $container.find('[data-test="data-dimension-transfer-option"]')
+        ).to.have.length.of.at.least(amount)
+    })
 
 /* TODO: Find a way to use random items
     export const replaceDataItemsWithRandomDataElements = amount => {

--- a/cypress/elements/dimensionModal/index.js
+++ b/cypress/elements/dimensionModal/index.js
@@ -97,20 +97,6 @@ export const expectSelectedItemsAmountToBeLeast = (amount) =>
         .filter('.wrapper')
         .should('have.length.least', amount)
 
-export const expectSelectableItemsAmountToBeLeast = (amount) =>
-    cy
-        .getBySelLike(transferSelectableItemsEl)
-        .findBySelLike(transferOptionEl)
-        .filter('.wrapper')
-        .should('have.length.least', amount)
-
-export const expectSelectableItemsAmountToBe = (amount) =>
-    cy
-        .getBySelLike(transferSelectableItemsEl)
-        .findBySelLike(transferOptionEl)
-        .filter('.wrapper')
-        .should('have.length', amount)
-
 export const expectSelectedItemsAmountToBe = (amount) =>
     cy
         .getBySelLike(transferSelectedItemsEl)
@@ -143,6 +129,8 @@ export {
     expectSubGroupSelectToBe,
     switchSubGroupTo,
     clickEDIEditButton,
+    expectSelectableDataItemsAmountToBeLeast,
+    expectSelectableDataItemsAmountToBe,
 } from './dataDimension.js'
 
 export {
@@ -161,6 +149,8 @@ export {
     expectRelativePeriodTypeSelectToNotContain,
     expectFixedPeriodTypeSelectToNotContain,
     expectFixedPeriodTypeToBe,
+    expectSelectablePeriodItemsAmountToBeLeast,
+    expectSelectablePeriodItemsAmountToBe,
 } from './periodDimension.js'
 
 export {

--- a/cypress/elements/dimensionModal/periodDimension.js
+++ b/cypress/elements/dimensionModal/periodDimension.js
@@ -101,3 +101,19 @@ export const openRelativePeriodsTypeSelect = () =>
 
 export const openFixedPeriodsTypeSelect = () =>
     cy.getBySel(fixedPeriodsPeriodTypeButtonEl).click()
+
+export const expectSelectablePeriodItemsAmountToBe = (amount) =>
+    cy.getBySelLike('transfer-sourceoptions').should(($elems) => {
+        const $container = $elems.first()
+        expect(
+            $container.find('[data-test="period-dimension-transfer-option"]')
+        ).to.have.lengthOf(amount)
+    })
+
+export const expectSelectablePeriodItemsAmountToBeLeast = (amount) =>
+    cy.getBySelLike('transfer-sourceoptions').should(($elems) => {
+        const $container = $elems.first()
+        expect(
+            $container.find('[data-test="period-dimension-transfer-option"]')
+        ).to.have.length.of.at.least(amount)
+    })

--- a/cypress/elements/optionsModal/legend.js
+++ b/cypress/elements/optionsModal/legend.js
@@ -4,6 +4,7 @@ const legendKeyEl = 'visualization-legend-key'
 const legendKeyContainerEl = 'legend-key-container'
 const legendKeyItemEl = 'legend-key-item'
 const singleValueTextEl = 'visualization-primary-value'
+const singleValueIconEl = 'visualization-icon'
 const singleValueOutputEl = 'visualization-container'
 const legendDisplayStrategyByDataItemEl = 'legend-display-strategy-BY_DATA_ITEM'
 const legendDisplayStrategyFixedEl = 'legend-display-strategy-FIXED'
@@ -88,6 +89,12 @@ export const expectSingleValueToHaveBackgroundColor = (color) =>
         .getBySel(singleValueOutputEl)
         .invoke('attr', 'style')
         .should('contain', `background-color: ${color}`)
+
+export const expectSingleValueToHaveIconColor = (color) =>
+    cy
+        .getBySel(singleValueIconEl)
+        .invoke('attr', 'style')
+        .should('contain', `color: ${color}`)
 
 export const toggleLegendKeyOption = () =>
     cy.getBySel(optionsModalContentEl).contains('Show legend key').click()

--- a/cypress/integration/dimensions/data.cy.js
+++ b/cypress/integration/dimensions/data.cy.js
@@ -13,11 +13,11 @@ import {
     expectSelectedItemsAmountToBeLeast,
     expectSelectedItemsAmountToBe,
     expectItemToBeSelectable,
-    expectSelectableItemsAmountToBe,
+    expectSelectableDataItemsAmountToBe,
     inputSearchTerm,
     switchDataTypeTo,
     clearSearchTerm,
-    expectSelectableItemsAmountToBeLeast,
+    expectSelectableDataItemsAmountToBeLeast,
     expectGroupSelectToBeVisible,
     switchGroupTo,
     selectFirstDataItem,
@@ -106,7 +106,7 @@ describe('Data dimension', () => {
             expectSourceToNotBeLoading()
         })
         it('more items are fetched', () => {
-            expectSelectableItemsAmountToBeLeast(PAGE_SIZE)
+            expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
             expectItemToBeSelectable(secondPageItemName)
         })
         it('all items can be unselected', () => {
@@ -122,7 +122,7 @@ describe('Data dimension', () => {
                 expect(response.body.dataItems.length).to.eq(PAGE_SIZE)
             })
             expectSourceToNotBeLoading()
-            expectSelectableItemsAmountToBeLeast(PAGE_SIZE * 3)
+            expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE * 3)
         })
     })
     describe('global search', () => {
@@ -140,7 +140,7 @@ describe('Data dimension', () => {
         })
         // TODO: Test that the search is only called once, i.e. debounce works
         it('search result is displayed', () => {
-            expectSelectableItemsAmountToBe(1)
+            expectSelectableDataItemsAmountToBe(1)
             expectItemToBeSelectable(testSearchTerm)
         })
         it('search result is maintained when switching data type', () => {
@@ -152,7 +152,7 @@ describe('Data dimension', () => {
                 expect(response.body.dataElements.length).to.be.eq(1)
             })
             expectSourceToNotBeLoading()
-            expectSelectableItemsAmountToBe(1)
+            expectSelectableDataItemsAmountToBe(1)
             expectItemToBeSelectable(testSearchTerm)
             clearSearchTerm()
             cy.wait('@dataElements').then(({ request, response }) => {
@@ -169,7 +169,7 @@ describe('Data dimension', () => {
                 expect(response.body.dataItems.length).to.eq(PAGE_SIZE)
             })
             expectSourceToNotBeLoading()
-            expectSelectableItemsAmountToBeLeast(PAGE_SIZE)
+            expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
         })
         it('search displays a correct error message', () => {
             const testSearchTermWithNoMatch = 'nomatch'
@@ -195,7 +195,7 @@ describe('Data dimension', () => {
                 expect(response.body.dataItems.length).to.be.eq(PAGE_SIZE)
             })
             expectSourceToNotBeLoading()
-            expectSelectableItemsAmountToBeLeast(PAGE_SIZE)
+            expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
         })
         it('modal is closed', () => {
             clickDimensionModalHideButton()
@@ -289,7 +289,7 @@ describe('Data dimension', () => {
                     ).to.be.least(1)
                 })
                 expectSourceToNotBeLoading()
-                expectSelectableItemsAmountToBeLeast(PAGE_SIZE)
+                expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
             })
             it('group select is visible', () => {
                 expectGroupSelectToBeVisible()
@@ -310,7 +310,7 @@ describe('Data dimension', () => {
                         ).to.be.least(1)
                     })
                     expectSourceToNotBeLoading()
-                    expectSelectableItemsAmountToBeLeast(PAGE_SIZE + 1)
+                    expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE + 1)
                 })
             }
             it('an item can be selected', () => {
@@ -328,7 +328,7 @@ describe('Data dimension', () => {
                 })
                 expectSourceToNotBeLoading()
                 expectGroupSelectToBe(testDataType.testGroup.name)
-                expectSelectableItemsAmountToBe(
+                expectSelectableDataItemsAmountToBe(
                     testDataType.testGroup.itemAmount
                 )
                 expectItemToBeSelected(testDataType.testItem.name)
@@ -336,7 +336,7 @@ describe('Data dimension', () => {
             it('the first item can be selected', () => {
                 selectFirstDataItem()
                 expectSelectedItemsAmountToBe(2)
-                expectSelectableItemsAmountToBe(
+                expectSelectableDataItemsAmountToBe(
                     testDataType.testGroup.itemAmount - 1
                 )
             })
@@ -366,7 +366,7 @@ describe('Data dimension', () => {
                     })
                     expectSourceToNotBeLoading()
                     expectSubGroupSelectToBe(testDataType.testSubGroup.name)
-                    expectSelectableItemsAmountToBe(
+                    expectSelectableDataItemsAmountToBe(
                         testDataType.testSubGroup.itemAmount
                     )
                     expectItemToBeSelected(testDataType.testItem.name)
@@ -382,7 +382,7 @@ describe('Data dimension', () => {
                     })
                     expectSourceToNotBeLoading()
                     expectSubGroupSelectToBe(testDataType.defaultSubGroup.name)
-                    expectSelectableItemsAmountToBe(
+                    expectSelectableDataItemsAmountToBe(
                         testDataType.testGroup.itemAmount - 1
                     )
                     expectItemToBeSelected(testDataType.testItem.name)
@@ -421,7 +421,7 @@ describe('Data dimension', () => {
                     }
                 )
                 expectSourceToNotBeLoading()
-                expectSelectableItemsAmountToBe(
+                expectSelectableDataItemsAmountToBe(
                     testDataType.testGroup.itemAmount
                 )
                 switchGroupToAll()
@@ -432,7 +432,7 @@ describe('Data dimension', () => {
                     }
                 )
                 expectSourceToNotBeLoading()
-                expectSelectableItemsAmountToBeLeast(PAGE_SIZE)
+                expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
                 if (testDataType.endpoint.requestUrl !== DATA_ITEMS_URL) {
                     cy.intercept('GET', DATA_ITEMS_URL).as('**/dataItems*')
                 }
@@ -444,7 +444,7 @@ describe('Data dimension', () => {
                     expect(response.body.dataItems.length).to.eq(PAGE_SIZE)
                 })
                 expectSourceToNotBeLoading()
-                expectSelectableItemsAmountToBeLeast(PAGE_SIZE)
+                expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
             })
             it('modal is closed', () => {
                 clickDimensionModalHideButton()

--- a/cypress/integration/dimensions/period.cy.js
+++ b/cypress/integration/dimensions/period.cy.js
@@ -26,8 +26,8 @@ import {
     clickMoveUpButton,
     clickMoveDownButton,
     singleClickSelectedItem,
-    expectSelectableItemsAmountToBeLeast,
-    expectSelectableItemsAmountToBe,
+    expectSelectablePeriodItemsAmountToBeLeast,
+    expectSelectablePeriodItemsAmountToBe,
 } from '../../elements/dimensionModal/index.js'
 import { openDimension } from '../../elements/dimensionsPanel.js'
 import { goToStartPage } from '../../elements/startScreen.js'
@@ -129,7 +129,7 @@ describe('Period dimension', () => {
             it(`relative period type '${type.name}' has ${type.amountOfChildren} items`, () => {
                 openRelativePeriodsTypeSelect()
                 selectPeriodType(type.name)
-                expectSelectableItemsAmountToBe(type.amountOfChildren)
+                expectSelectablePeriodItemsAmountToBe(type.amountOfChildren)
             })
         )
         it('can switch to fixed periods', () => {
@@ -162,10 +162,12 @@ describe('Period dimension', () => {
                 openFixedPeriodsTypeSelect()
                 selectPeriodType(type.name)
                 type.amountOfChildren > 50
-                    ? expectSelectableItemsAmountToBeLeast(
+                    ? expectSelectablePeriodItemsAmountToBeLeast(
                           type.amountOfChildren
                       )
-                    : expectSelectableItemsAmountToBe(type.amountOfChildren)
+                    : expectSelectablePeriodItemsAmountToBe(
+                          type.amountOfChildren
+                      )
             })
         )
     })

--- a/cypress/integration/options/icon.cy.js
+++ b/cypress/integration/options/icon.cy.js
@@ -161,8 +161,8 @@ describe('Icon', () => {
         // switch to use a data item that will trigger the contrast color
         openDimension(DIMENSION_ID_DATA)
         expectDataDimensionModalToBeVisible()
-        expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
         unselectAllItemsByButton()
+        expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
         inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])
         selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])
         expectItemToBeSelected(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])

--- a/cypress/integration/options/icon.cy.js
+++ b/cypress/integration/options/icon.cy.js
@@ -173,7 +173,7 @@ describe('Icon', () => {
         expectIconToBeVisible()
         expectSingleValueToHaveIconColor('#2166ac')
 
-        // switch to apply legend to text color
+        // switch to apply legend color to text
         clickMenuBarOptionsButton()
         clickOptionsTab(OPTIONS_TAB_LEGEND)
         changeDisplayStyleToText()

--- a/cypress/integration/options/icon.cy.js
+++ b/cypress/integration/options/icon.cy.js
@@ -112,7 +112,7 @@ describe('Icon', () => {
                 switchSubGroupTo('Reporting rate')
             } else if (type === DIMENSION_TYPE_EVENT_DATA_ITEM) {
                 switchDataTypeTo('Event data items')
-                switchGroupTo('Child programme')
+                switchGroupTo('Child Programme')
             }
 
             // select the data item

--- a/cypress/integration/options/icon.cy.js
+++ b/cypress/integration/options/icon.cy.js
@@ -12,6 +12,7 @@ import {
 import { expectVisualizationToBeVisible } from '../../elements/chart.js'
 import { clickCheckbox } from '../../elements/common.js'
 import {
+    expectSelectableDataItemsAmountToBeLeast,
     switchDataTypeTo,
     switchGroupTo,
     switchSubGroupTo,
@@ -70,6 +71,8 @@ const TEST_ITEMS = {
     [DIMENSION_TYPE_PROGRAM_INDICATOR]: 'Average weight (g)',
 }
 
+const PAGE_SIZE = 50
+
 describe('Icon', () => {
     beforeEach(() => {
         goToStartPage()
@@ -79,6 +82,7 @@ describe('Icon', () => {
         // select a data item
         openDimension(DIMENSION_ID_DATA)
         expectDataDimensionModalToBeVisible()
+        expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
         inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
         selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
         clickDimensionModalUpdateButton()
@@ -98,6 +102,7 @@ describe('Icon', () => {
             // find the data item
             openDimension(DIMENSION_ID_DATA)
             expectDataDimensionModalToBeVisible()
+            expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
             inputSearchTerm(TEST_ITEMS[type])
 
             if (type === DIMENSION_TYPE_DATA_SET) {
@@ -139,6 +144,7 @@ describe('Icon', () => {
         // select a data item
         openDimension(DIMENSION_ID_DATA)
         expectDataDimensionModalToBeVisible()
+        expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
         inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
         selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
         clickDimensionModalUpdateButton()
@@ -151,6 +157,7 @@ describe('Icon', () => {
         // switch to use a data item that will trigger the contrast color
         openDimension(DIMENSION_ID_DATA)
         expectDataDimensionModalToBeVisible()
+        expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
         unselectAllItemsByButton()
         inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])
         selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])

--- a/cypress/integration/options/icon.cy.js
+++ b/cypress/integration/options/icon.cy.js
@@ -1,5 +1,6 @@
 import {
     DIMENSION_ID_DATA,
+    DIMENSION_ID_PERIOD,
     DIMENSION_TYPE_DATA_ELEMENT,
     DIMENSION_TYPE_DATA_SET,
     DIMENSION_TYPE_EVENT_DATA_ITEM,
@@ -15,18 +16,30 @@ import {
     switchSubGroupTo,
 } from '../../elements/dimensionModal/dataDimension.js'
 import {
+    clickDimensionModalHideButton,
     clickDimensionModalUpdateButton,
     expectDataDimensionModalToBeVisible,
     inputSearchTerm,
     selectItemByDoubleClick,
+    selectRelativePeriods,
+    unselectAllItemsByButton,
 } from '../../elements/dimensionModal/index.js'
 import { openDimension } from '../../elements/dimensionsPanel.js'
 import { clickMenuBarOptionsButton } from '../../elements/menuBar.js'
 import {
+    OPTIONS_TAB_LEGEND,
     OPTIONS_TAB_STYLE,
     clickOptionsModalHideButton,
+    clickOptionsModalUpdateButton,
     clickOptionsTab,
 } from '../../elements/optionsModal/index.js'
+import {
+    changeDisplayStrategyToFixed,
+    changeDisplayStyleToText,
+    changeFixedLegendSet,
+    expectSingleValueToHaveIconColor,
+    toggleLegend,
+} from '../../elements/optionsModal/legend.js'
 import { goToStartPage } from '../../elements/startScreen.js'
 import { changeVisType } from '../../elements/visualizationTypeSelector.js'
 
@@ -74,7 +87,7 @@ describe('Icon', () => {
         expectIconToBeHidden()
     })
     TEST_TYPES.forEach((type) => {
-        it('icon shows when option is enabled', () => {
+        it(`icon shows when option is enabled for ${type}`, () => {
             // enable the icon
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_STYLE)
@@ -103,24 +116,59 @@ describe('Icon', () => {
             expectIconToBeVisible()
         })
     })
+    it('icon gets correct color when a legend is in use', () => {
+        // enable the icon
+        clickMenuBarOptionsButton()
+        clickOptionsTab(OPTIONS_TAB_STYLE)
+        clickCheckbox('option-show-data-item-icon')
+
+        // enable the legend
+        clickOptionsTab(OPTIONS_TAB_LEGEND)
+        toggleLegend()
+        changeDisplayStrategyToFixed()
+        changeFixedLegendSet('E2E legend')
+        clickOptionsModalHideButton()
+
+        // select a period
+        openDimension(DIMENSION_ID_PERIOD)
+        unselectAllItemsByButton()
+        selectRelativePeriods(['This year'], 'Years')
+        clickDimensionModalHideButton()
+
+        // select a data item
+        openDimension(DIMENSION_ID_DATA)
+        expectDataDimensionModalToBeVisible()
+        inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
+        selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
+        clickDimensionModalUpdateButton()
+
+        // default text color is applied to icon
+        expectVisualizationToBeVisible(VIS_TYPE_SINGLE_VALUE)
+        expectIconToBeVisible()
+        expectSingleValueToHaveIconColor('#212934')
+
+        // switch to use a data item that will trigger the contrast color
+        openDimension(DIMENSION_ID_DATA)
+        expectDataDimensionModalToBeVisible()
+        unselectAllItemsByButton()
+        inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])
+        selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])
+        clickDimensionModalUpdateButton()
+
+        // contrast color is applied to icon
+        expectVisualizationToBeVisible(VIS_TYPE_SINGLE_VALUE)
+        expectIconToBeVisible()
+        expectSingleValueToHaveIconColor('#2166ac')
+
+        // switch to apply legend to text color
+        clickMenuBarOptionsButton()
+        clickOptionsTab(OPTIONS_TAB_LEGEND)
+        changeDisplayStyleToText()
+        clickOptionsModalUpdateButton()
+
+        // legend color is applied to icon
+        expectVisualizationToBeVisible(VIS_TYPE_SINGLE_VALUE)
+        expectIconToBeVisible()
+        expectSingleValueToHaveIconColor('#ffffff')
+    })
 })
-
-// TODO:
-
-// icon color matches value color when a legend is set, i.e.
-//    1. gets the legend color when legend is set to changes text color
-//    2. gets the contrast color when legend is set to changes background color and contrast is applicable
-//    3. doesn’t get the legend color when legend is set to changes background color and no contrast is applicable
-//    4. all of 3. but for a “filled” icon, (like  :black_square_button: vs :white_square_button:)
-
-/*
-
-ICONS:
-
-Indicator: ANC 2 Coverage - Preg woman, black background
-Data element: ANC 2nd visit - Preg woman, outline
-Data set: Child Health - Preg woman, filled
-Event data items: Child Programme MCH Weight (g) - Scale, filled
-Program indicator: Child Programme Average weight - Scale, outline
-
-*/

--- a/cypress/integration/options/icon.cy.js
+++ b/cypress/integration/options/icon.cy.js
@@ -1,0 +1,126 @@
+import {
+    DIMENSION_ID_DATA,
+    DIMENSION_TYPE_DATA_ELEMENT,
+    DIMENSION_TYPE_DATA_SET,
+    DIMENSION_TYPE_EVENT_DATA_ITEM,
+    DIMENSION_TYPE_INDICATOR,
+    DIMENSION_TYPE_PROGRAM_INDICATOR,
+    VIS_TYPE_SINGLE_VALUE,
+} from '@dhis2/analytics'
+import { expectVisualizationToBeVisible } from '../../elements/chart.js'
+import { clickCheckbox } from '../../elements/common.js'
+import {
+    switchDataTypeTo,
+    switchGroupTo,
+    switchSubGroupTo,
+} from '../../elements/dimensionModal/dataDimension.js'
+import {
+    clickDimensionModalUpdateButton,
+    expectDataDimensionModalToBeVisible,
+    inputSearchTerm,
+    selectItemByDoubleClick,
+} from '../../elements/dimensionModal/index.js'
+import { openDimension } from '../../elements/dimensionsPanel.js'
+import { clickMenuBarOptionsButton } from '../../elements/menuBar.js'
+import {
+    OPTIONS_TAB_STYLE,
+    clickOptionsModalHideButton,
+    clickOptionsTab,
+} from '../../elements/optionsModal/index.js'
+import { goToStartPage } from '../../elements/startScreen.js'
+import { changeVisType } from '../../elements/visualizationTypeSelector.js'
+
+const expectIconToBeVisible = () => {
+    cy.getBySelLike('visualization-icon')
+        .should('have.length', 1)
+        .and('be.visible')
+}
+
+const expectIconToBeHidden = () => {
+    cy.getBySelLike('visualization-icon').should('not.exist')
+}
+
+const TEST_TYPES = [
+    DIMENSION_TYPE_INDICATOR,
+    DIMENSION_TYPE_DATA_ELEMENT,
+    DIMENSION_TYPE_DATA_SET,
+    DIMENSION_TYPE_EVENT_DATA_ITEM,
+    DIMENSION_TYPE_PROGRAM_INDICATOR,
+]
+
+const TEST_ITEMS = {
+    [DIMENSION_TYPE_INDICATOR]: 'ANC 2 Coverage',
+    [DIMENSION_TYPE_DATA_ELEMENT]: 'ANC 2nd visit',
+    [DIMENSION_TYPE_DATA_SET]: 'Child Health',
+    [DIMENSION_TYPE_EVENT_DATA_ITEM]: 'MCH Weight (g)',
+    [DIMENSION_TYPE_PROGRAM_INDICATOR]: 'Average weight (g)',
+}
+
+describe('Icon', () => {
+    beforeEach(() => {
+        goToStartPage()
+        changeVisType(VIS_TYPE_SINGLE_VALUE)
+    })
+    it('no icon shows when option is disabled', () => {
+        // select a data item
+        openDimension(DIMENSION_ID_DATA)
+        expectDataDimensionModalToBeVisible()
+        inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
+        selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
+        clickDimensionModalUpdateButton()
+
+        // icon is hidden
+        expectVisualizationToBeVisible(VIS_TYPE_SINGLE_VALUE)
+        expectIconToBeHidden()
+    })
+    TEST_TYPES.forEach((type) => {
+        it('icon shows when option is enabled', () => {
+            // enable the icon
+            clickMenuBarOptionsButton()
+            clickOptionsTab(OPTIONS_TAB_STYLE)
+            clickCheckbox('option-show-data-item-icon')
+            clickOptionsModalHideButton()
+
+            // find the data item
+            openDimension(DIMENSION_ID_DATA)
+            expectDataDimensionModalToBeVisible()
+            inputSearchTerm(TEST_ITEMS[type])
+
+            if (type === DIMENSION_TYPE_DATA_SET) {
+                switchDataTypeTo('Data sets')
+                switchSubGroupTo('Reporting rate')
+            } else if (type === DIMENSION_TYPE_EVENT_DATA_ITEM) {
+                switchDataTypeTo('Event data items')
+                switchGroupTo('Child programme')
+            }
+
+            // select the data item
+            selectItemByDoubleClick(TEST_ITEMS[type])
+            clickDimensionModalUpdateButton()
+
+            // icon is shown
+            expectVisualizationToBeVisible(VIS_TYPE_SINGLE_VALUE)
+            expectIconToBeVisible()
+        })
+    })
+})
+
+// TODO:
+
+// icon color matches value color when a legend is set, i.e.
+//    1. gets the legend color when legend is set to changes text color
+//    2. gets the contrast color when legend is set to changes background color and contrast is applicable
+//    3. doesn’t get the legend color when legend is set to changes background color and no contrast is applicable
+//    4. all of 3. but for a “filled” icon, (like  :black_square_button: vs :white_square_button:)
+
+/*
+
+ICONS:
+
+Indicator: ANC 2 Coverage - Preg woman, black background
+Data element: ANC 2nd visit - Preg woman, outline
+Data set: Child Health - Preg woman, filled
+Event data items: Child Programme MCH Weight (g) - Scale, filled
+Program indicator: Child Programme Average weight - Scale, outline
+
+*/

--- a/cypress/integration/options/icon.cy.js
+++ b/cypress/integration/options/icon.cy.js
@@ -171,7 +171,7 @@ describe('Icon', () => {
         // contrast color is applied to icon
         expectVisualizationToBeVisible(VIS_TYPE_SINGLE_VALUE)
         expectIconToBeVisible()
-        expectSingleValueToHaveIconColor('#2166ac')
+        expectSingleValueToHaveIconColor('#ffffff')
 
         // switch to apply legend color to text
         clickMenuBarOptionsButton()
@@ -182,6 +182,6 @@ describe('Icon', () => {
         // legend color is applied to icon
         expectVisualizationToBeVisible(VIS_TYPE_SINGLE_VALUE)
         expectIconToBeVisible()
-        expectSingleValueToHaveIconColor('#ffffff')
+        expectSingleValueToHaveIconColor('#2166ac')
     })
 })

--- a/cypress/integration/options/icon.cy.js
+++ b/cypress/integration/options/icon.cy.js
@@ -7,6 +7,7 @@ import {
     DIMENSION_TYPE_INDICATOR,
     DIMENSION_TYPE_PROGRAM_INDICATOR,
     VIS_TYPE_SINGLE_VALUE,
+    visTypeDisplayNames,
 } from '@dhis2/analytics'
 import { expectVisualizationToBeVisible } from '../../elements/chart.js'
 import { clickCheckbox } from '../../elements/common.js'
@@ -72,7 +73,7 @@ const TEST_ITEMS = {
 describe('Icon', () => {
     beforeEach(() => {
         goToStartPage()
-        changeVisType(VIS_TYPE_SINGLE_VALUE)
+        changeVisType(visTypeDisplayNames[VIS_TYPE_SINGLE_VALUE])
     })
     it('no icon shows when option is disabled', () => {
         // select a data item

--- a/cypress/integration/options/icon.cy.js
+++ b/cypress/integration/options/icon.cy.js
@@ -21,6 +21,7 @@ import {
     clickDimensionModalHideButton,
     clickDimensionModalUpdateButton,
     expectDataDimensionModalToBeVisible,
+    expectItemToBeSelected,
     inputSearchTerm,
     selectItemByDoubleClick,
     selectRelativePeriods,
@@ -85,6 +86,7 @@ describe('Icon', () => {
         expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
         inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
         selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
+        expectItemToBeSelected(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
         clickDimensionModalUpdateButton()
 
         // icon is hidden
@@ -115,6 +117,7 @@ describe('Icon', () => {
 
             // select the data item
             selectItemByDoubleClick(TEST_ITEMS[type])
+            expectItemToBeSelected(TEST_ITEMS[type])
             clickDimensionModalUpdateButton()
 
             // icon is shown
@@ -147,6 +150,7 @@ describe('Icon', () => {
         expectSelectableDataItemsAmountToBeLeast(PAGE_SIZE)
         inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
         selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
+        expectItemToBeSelected(TEST_ITEMS[DIMENSION_TYPE_INDICATOR])
         clickDimensionModalUpdateButton()
 
         // default text color is applied to icon
@@ -161,6 +165,7 @@ describe('Icon', () => {
         unselectAllItemsByButton()
         inputSearchTerm(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])
         selectItemByDoubleClick(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])
+        expectItemToBeSelected(TEST_ITEMS[DIMENSION_TYPE_DATA_ELEMENT])
         clickDimensionModalUpdateButton()
 
         // contrast color is applied to icon

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "start-server-and-test": "^1.14.0"
     },
     "dependencies": {
-        "@dhis2/analytics": "^25.1.10",
+        "@dhis2/analytics": "^25.1.11",
         "@dhis2/app-runtime": "^3.7.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/src/components/TitleBar/TitleBar.js
+++ b/src/components/TitleBar/TitleBar.js
@@ -50,7 +50,7 @@ const getSuffix = (titleState) => {
                         ...styles.suffix,
                         ...styles.titleDirty,
                     }}
-                    data-test="visualization-title-dirty"
+                    data-test="AO-title-dirty"
                 >{`- ${getTitleDirty()}`}</div>
             )
         default:
@@ -65,7 +65,7 @@ export const UnconnectedTitleBar = ({ titleState, titleText }) => {
     }
 
     return titleText ? (
-        <div data-test="visualization-title" style={styles.titleBar}>
+        <div data-test="AO-title" style={styles.titleBar}>
             <div style={titleStyle}>
                 {titleText}
                 {getSuffix(titleState)}

--- a/src/components/TitleBar/TitleBar.js
+++ b/src/components/TitleBar/TitleBar.js
@@ -50,7 +50,7 @@ const getSuffix = (titleState) => {
                         ...styles.suffix,
                         ...styles.titleDirty,
                     }}
-                    data-test="AO-title-dirty"
+                    data-test="visualization-title-dirty"
                 >{`- ${getTitleDirty()}`}</div>
             )
         default:
@@ -65,7 +65,7 @@ export const UnconnectedTitleBar = ({ titleState, titleText }) => {
     }
 
     return titleText ? (
-        <div data-test="AO-title" style={styles.titleBar}>
+        <div data-test="visualization-title" style={styles.titleBar}>
             <div style={titleStyle}>
                 {titleText}
                 {getSuffix(titleState)}

--- a/src/components/VisualizationOptions/Options/DataIcon.js
+++ b/src/components/VisualizationOptions/Options/DataIcon.js
@@ -11,6 +11,7 @@ const DataIcon = () => (
         option={{
             name: 'icons',
         }}
+        dataTest={'option-show-data-item-icon'}
     />
 )
 

--- a/src/components/VisualizationOptions/Options/DataIcon.js
+++ b/src/components/VisualizationOptions/Options/DataIcon.js
@@ -11,7 +11,7 @@ const DataIcon = () => (
         option={{
             name: 'icons',
         }}
-        dataTest={'option-show-data-item-icon'}
+        dataTest="option-show-data-item-icon"
     />
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2028,10 +2028,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^25.1.10":
-  version "25.1.10"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-25.1.10.tgz#b8bfb442335e6de2dbacfccadbeb907cc01173f4"
-  integrity sha512-5+jQIcLi0m9V27aIsxUMwf18Lpd3X8HyOxAnXYV5QMthbs2sodAQZNfM3TsPxPlcKCqNBLAIgyVrRm5RDn2zSw==
+"@dhis2/analytics@^25.1.11":
+  version "25.1.11"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-25.1.11.tgz#04c1990798f1c33bebd16849dff4a81523d9e1ce"
+  integrity sha512-+aLYTbcVsxt5ZVLROJgvljFoLWK31jsS6xWzhwzWTQi+7WGVt5ONRUS45rZBYJas4FQj+SqPhCF6nXCssx7huA==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
Implements [DHIS2-10496](https://jira.dhis2.org/browse/DHIS2-10496)

**Requires https://github.com/dhis2/analytics/pull/1479**

---

Adds Cypress tests for SV icon

Also, copies changes from #2321 and #2368 as these were incorrectly targeting `master` instead of `dev`

[DHIS2-10496]: https://dhis2.atlassian.net/browse/DHIS2-10496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ