### PR TITLE
chore: run workflow release job on tags as well

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -89,7 +89,10 @@ jobs:
     release:
         runs-on: ubuntu-latest
         needs: call-workflow-e2e-prod
-        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
+        if: |
+            !github.event.push.repository.fork &&
+            github.actor != 'dependabot[bot]' &&
+            github.event_name != 'pull_request'
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -89,9 +89,7 @@ jobs:
     release:
         runs-on: ubuntu-latest
         needs: call-workflow-e2e-prod
-        if: |
-            !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]'
+        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -7,6 +7,8 @@ on:
         branches:
             - 'master'
             - 'dev'
+        tags:
+            - '*'
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
@@ -89,8 +91,7 @@ jobs:
         needs: call-workflow-e2e-prod
         if: |
             !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]' &&
-            github.ref == 'refs/heads/master'
+            github.actor != 'dependabot[bot]'
         steps:
             - uses: actions/checkout@v3
               with:


### PR DESCRIPTION
Tag builds were not being pushed to d2-ci. The core apps-to-bundle depends on these.