### PR TITLE
test: rename AO-title to titlebar (DHIS2-15063)

### DIFF
--- a/cypress/elements/chart.js
+++ b/cypress/elements/chart.js
@@ -18,8 +18,8 @@ const highchartsSubtitleEl = '.highcharts-subtitle'
 const highchartsSeriesKeyItemEl = '.highcharts-legend-item'
 const highchartsChartItemEl = '.highcharts-series'
 const unsavedVisualizationTitleText = 'Unsaved visualization'
-const AOTitleEl = 'AO-title'
-const AOTitleDirtyEl = 'AO-title-dirty'
+const AOTitleEl = 'titlebar'
+const AOTitleDirtyEl = 'titlebar-dirty'
 const timeout = {
     timeout: 40000,
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -6,8 +6,14 @@ enableAutoLogin()
 
 const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
 Cypress.on('uncaught:exception', (err) => {
-    /* returning false here prevents Cypress from failing the test */
+    // This prevents a benign error:
+    //   This error means that ResizeObserver was not able to deliver all
+    //   observations within a single animation frame. It is benign (your site
+    //   will not break).
+    //
+    // Source: https://stackoverflow.com/a/50387233/1319140
     if (resizeObserverLoopErrRe.test(err.message)) {
+        // returning false here prevents Cypress from failing the test
         return false
     }
 })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -3,3 +3,11 @@ import { enableAutoLogin } from '@dhis2/cypress-commands'
 import './commands.js'
 
 enableAutoLogin()
+
+const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
+Cypress.on('uncaught:exception', (err) => {
+    /* returning false here prevents Cypress from failing the test */
+    if (resizeObserverLoopErrRe.test(err.message)) {
+        return false
+    }
+})

--- a/src/components/TitleBar/TitleBar.js
+++ b/src/components/TitleBar/TitleBar.js
@@ -50,7 +50,7 @@ const getSuffix = (titleState) => {
                         ...styles.suffix,
                         ...styles.titleDirty,
                     }}
-                    data-test="AO-title-dirty"
+                    data-test="titlebar-dirty"
                 >{`- ${getTitleDirty()}`}</div>
             )
         default:
@@ -65,7 +65,7 @@ export const UnconnectedTitleBar = ({ titleState, titleText }) => {
     }
 
     return titleText ? (
-        <div data-test="AO-title" style={styles.titleBar}>
+        <div data-test="titlebar" style={styles.titleBar}>
             <div style={titleStyle}>
                 {titleText}
                 {getSuffix(titleState)}


### PR DESCRIPTION
Implements [DHIS2-15063](https://dhis2.atlassian.net/browse/DHIS2-15063)

---

Renames `AO-title` to `titlebar` for consistency with other apps

Also, prevents ResizeObserver from failing the tests by utilising the check used in Dashboard - [dashboard-app/blob/dev/cypress/support/index.js#L12](https://github.com/dhis2/dashboard-app/blob/dev/cypress/support/index.js#L12)

[DHIS2-15063]: https://dhis2.atlassian.net/browse/DHIS2-15063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ