### PR TITLE
test: extend timeout after delete has been triggered

### DIFF
--- a/cypress/elements/calculationsModal.js
+++ b/cypress/elements/calculationsModal.js
@@ -1,3 +1,4 @@
+import { EXTENDED_TIMEOUT } from '../support/utils.js'
 import { clearInput, typeInput } from './common.js'
 
 const calculationModalEl = 'calculation-modal'
@@ -64,12 +65,13 @@ export const clickDeleteButton = () =>
         .contains('Delete calculation')
         .click()
 
-export const clickConfirmDeleteButton = () =>
-    cy
-        .getBySel('calculation-delete-modal')
+export const clickConfirmDeleteButton = () => {
+    cy.getBySel('calculation-delete-modal')
         .find('button')
         .contains('Yes, delete')
         .click()
+    cy.getBySel(calculationModalEl, EXTENDED_TIMEOUT).should('not.exist')
+}
 
 export const clickCheckFormulaButton = () =>
     cy

--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -1,4 +1,5 @@
 import { DIMENSION_ID_DATA } from '@dhis2/analytics'
+import { EXTENDED_TIMEOUT } from '../../support/utils.js'
 import { clearInput, typeInput } from '../common.js'
 import {
     expectDimensionModalToBeVisible,
@@ -39,7 +40,9 @@ export const expectDataDimensionModalToBeVisible = () =>
     expectDimensionModalToBeVisible(DIMENSION_ID_DATA)
 
 export const expectNoDataItemsToBeSelected = () =>
-    cy.getBySel(selectedItemsEl).should('contain', 'No items selected')
+    cy
+        .getBySel(selectedItemsEl, EXTENDED_TIMEOUT)
+        .should('contain', 'No items selected')
 
 export const expectDataDimensionModalWarningToContain = (text) =>
     cy.getBySel(rightHeaderEl).should('contain', text)

--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -1,5 +1,4 @@
 import { DIMENSION_ID_DATA } from '@dhis2/analytics'
-import { EXTENDED_TIMEOUT } from '../../support/utils.js'
 import { clearInput, typeInput } from '../common.js'
 import {
     expectDimensionModalToBeVisible,
@@ -40,9 +39,7 @@ export const expectDataDimensionModalToBeVisible = () =>
     expectDimensionModalToBeVisible(DIMENSION_ID_DATA)
 
 export const expectNoDataItemsToBeSelected = () =>
-    cy
-        .getBySel(selectedItemsEl, EXTENDED_TIMEOUT)
-        .should('contain', 'No items selected')
+    cy.getBySel(selectedItemsEl).should('contain', 'No items selected')
 
 export const expectDataDimensionModalWarningToContain = (text) =>
     cy.getBySel(rightHeaderEl).should('contain', text)


### PR DESCRIPTION
The `expectNoDataItemsToBeSelected` fails after delete has been triggered if the delete action takes longer than 4s, as seen in the test run here https://cloud.cypress.io/projects/sojh88/runs/3b386e3c-bd60-4ced-88fd-b17c90920846/test-results/c436fb6d-a505-4de0-b8e3-dd449b688a82/video
This PR adds the `EXTENDED_TIMEOUT` to prevent this by validating that the calculation modal has been closed.