### PR TITLE
chore: update nightly workflow start time

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,10 +1,10 @@
 name: 'dhis2: nightly'
 
-# This workflow runs the e2e tests on the default branch against dev at 3:20am M-F
+# This workflow runs the e2e tests on the default branch against dev at 6:50am M-F
 
 on:
     schedule:
-        - cron: '20 3 * * 1-5'
+        - cron: '50 6 * * 1-5'
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}


### PR DESCRIPTION
Start tests later in the morning to avoid concurrently running the nightly workflow while instances are being reset