### PR TITLE
chore: increase cypress default timeout for DOM activity

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,7 @@
     "baseUrl": "http://localhost:3000",
     "projectId": "sojh88",
     "testFiles": "**/*.cy.js",
+    "defaultCommandTimeout": 15000,
     "experimentalInteractiveRunEvents": true,
     "video": true,
     "viewportWidth": 1280,

--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -26,7 +26,7 @@ const rightHeaderEl = 'data-dimension-transfer-rightheader'
 const searchFieldEl = 'data-dimension-left-header-filter-input-field-content'
 const emptySourceEl = 'data-dimension-empty-source'
 
-const expectItemsToBeInSource = (items) => {
+export const expectDataItemsToBeInSource = (items) => {
     cy.getBySelLike('transfer-sourceoptions').should(($elems) => {
         const $container = $elems.first()
         expect($container).to.have.class('container')
@@ -57,7 +57,7 @@ export const scrollSourceToBottom = () => {
 export const selectDataElements = (dataElements) => {
     expectSourceToNotBeLoading()
     switchDataTypeTo('Data elements')
-    expectItemsToBeInSource(dataElements)
+    expectDataItemsToBeInSource(dataElements)
     dataElements.forEach((item) => selectItemByDoubleClick(item))
 }
 
@@ -67,7 +67,7 @@ export const selectFirstDataItem = () =>
 export const selectIndicators = (indicators) => {
     expectSourceToNotBeLoading()
     switchDataTypeTo('Indicators')
-    expectItemsToBeInSource(indicators)
+    expectDataItemsToBeInSource(indicators)
     indicators.forEach((item) => selectItemByDoubleClick(item))
 }
 

--- a/cypress/elements/dimensionModal/index.js
+++ b/cypress/elements/dimensionModal/index.js
@@ -131,6 +131,7 @@ export {
     clickEDIEditButton,
     expectSelectableDataItemsAmountToBeLeast,
     expectSelectableDataItemsAmountToBe,
+    expectDataItemsToBeInSource,
 } from './dataDimension.js'
 
 export {

--- a/cypress/integration/dimensions/data.cy.js
+++ b/cypress/integration/dimensions/data.cy.js
@@ -35,6 +35,7 @@ import {
     expectSourceToNotBeLoading,
     unselectAllItemsByButton,
     selectAllItemsByButton,
+    expectDataItemsToBeInSource,
 } from '../../elements/dimensionModal/index.js'
 import { openDimension } from '../../elements/dimensionsPanel.js'
 import { goToStartPage } from '../../elements/startScreen.js'
@@ -314,6 +315,7 @@ describe('Data dimension', () => {
                 })
             }
             it('an item can be selected', () => {
+                expectDataItemsToBeInSource([testDataType.testItem.name])
                 selectItemByDoubleClick(testDataType.testItem.name)
                 expectItemToBeSelected(testDataType.testItem.name)
             })

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -1,1 +1,1 @@
-export const EXTENDED_TIMEOUT = { timeout: 15000 }
+export const EXTENDED_TIMEOUT = { timeout: 25000 }


### PR DESCRIPTION
based on https://github.com/dhis2/maps-app/pull/2720

We seem to get random failures pretty regularly and they are often caused by slow instance. This will increase the default timeout for all DOM activity, which I hope will alleviate some of this.