### PR TITLE
test: prevent test names from being dynamic

### DIFF
--- a/cypress/integration/options/axes.cy.js
+++ b/cypress/integration/options/axes.cy.js
@@ -95,13 +95,16 @@ describe('Options - Vertical axis', () => {
             clickOptionsModalUpdateButton()
             expectChartTitleToBeVisible()
         })
-        it(`config has range min value "${TEST_MIN_VALUE}"`, () => {
+        it('config has range min value', () => {
+            cy.log(`Value: ${TEST_MIN_VALUE}`)
             expectWindowConfigYAxisToHaveRangeMinValue(TEST_MIN_VALUE)
         })
-        it(`config has range max value "${TEST_MAX_VALUE}"`, () => {
+        it('config has range max value', () => {
+            cy.log(`Value: ${TEST_MAX_VALUE}`)
             expectWindowConfigYAxisToHaveRangeMaxValue(TEST_MAX_VALUE)
         })
-        it(`config has steps value "${TEST_STEPS_VALUE}"`, () => {
+        it('config has steps value', () => {
+            cy.log(`Value: ${TEST_STEPS_VALUE}`)
             expectWindowConfigYAxisToHaveStepsValue(TEST_STEPS_VALUE)
         })
         // Note: the output of setting the decimals option can't be evaluated using the config
@@ -114,10 +117,12 @@ describe('Options - Vertical axis', () => {
         it(`title is "${TEST_TITLE}"`, () => {
             expectAxisTitleToBeValue(TEST_AXIS, TEST_TITLE)
         })
-        it(`range min is "${TEST_MIN_VALUE}"`, () => {
+        it('range min is set', () => {
+            cy.log(`Value: ${TEST_MIN_VALUE}`)
             expectAxisRangeMinToBeValue(TEST_AXIS, TEST_MIN_VALUE)
         })
-        it(`range max is "${TEST_MAX_VALUE}"`, () => {
+        it('range max is set', () => {
+            cy.log(`Value: ${TEST_MAX_VALUE}`)
             expectAxisRangeMaxToBeValue(TEST_AXIS, TEST_MAX_VALUE)
         })
     })

--- a/cypress/integration/options/fontStyles.cy.js
+++ b/cypress/integration/options/fontStyles.cy.js
@@ -223,7 +223,8 @@ describe('Options - Font styles', () => {
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_DATA)
         })
-        it(`sets target line to ${TEST_VALUE}: "${TEST_LABEL}"`, () => {
+        it('sets target line', () => {
+            cy.log(`Test value: ${TEST_VALUE}`)
             clickTargetLineCheckbox()
             setTargetLineLabel(TEST_LABEL)
             setTargetLineValue(TEST_VALUE)
@@ -282,7 +283,8 @@ describe('Options - Font styles', () => {
             clickMenuBarOptionsButton()
             clickOptionsTab(OPTIONS_TAB_DATA)
         })
-        it(`sets base line to ${TEST_VALUE}: "${TEST_LABEL}"`, () => {
+        it('sets base line', () => {
+            cy.log(`Test value: ${TEST_VALUE}`)
             clickBaseLineCheckbox()
             setBaseLineLabel(TEST_LABEL)
             setBaseLineValue(TEST_VALUE)


### PR DESCRIPTION
When a test case name is dynamic and based on a non-persistent variable, such as a randomly generated number, the Cypress dashboard will pick these tests up as a new test case and mark it with `First seen`. This can potentially disturb the test statistics for e.g. flaky tests (as each run generates "new" test cases which can't be compared between different runs). See example screenshot below.

Keeping track of a generated value is good for debugging, but instead of displaying it the name it will now be logged in the beginning of the test case.

_Example of test cases showing up as `First seen` due to having a randomly generated number in the name_
![image](https://github.com/dhis2/data-visualizer-app/assets/12590483/40b54328-ba60-4bf1-a23b-a589b0087aa3)
