### PR TITLE
chore: disable the scheduled nightly for now

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,8 +3,9 @@ name: 'dhis2: nightly'
 # This workflow runs the e2e tests on the default branch against dev at 6:50am M-F
 
 on:
-    schedule:
-        - cron: '50 4 * * 1-5'
+    # schedule:
+    # - cron: '50 4 * * 1-5'
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}


### PR DESCRIPTION
Disable for July as the tests are failing due to slow instances and nobody is around to look into it.