### PR TITLE
fix: allow closing the interpretations modal when accessed via URL (DHIS2-15721)

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -42,7 +42,8 @@ export class UnconnectedApp extends Component {
 
     interpretationsUnitRef = React.createRef()
 
-    onInterpretationUpdate = () => this.interpretationsUnitRef.current.refresh()
+    onInterpretationUpdate = () =>
+        this.interpretationsUnitRef.current?.refresh()
 
     state = {
         previousLocation: null,

--- a/src/components/VisualizationPlugin/VisualizationPlugin.js
+++ b/src/components/VisualizationPlugin/VisualizationPlugin.js
@@ -44,7 +44,11 @@ export const VisualizationPlugin = ({
     const [size, setSize] = useState({ width: 0, height: 0 })
 
     const containerCallbackRef = useCallback((node) => {
-        if (node === null) {
+        if (
+            node === null ||
+            // This avoids a state update when closing the intepretations modal
+            (node.clientWidth === 0 && node.clientHeight === 0)
+        ) {
             return
         }
 


### PR DESCRIPTION
Implements [DHIS2-15721](https://dhis2.atlassian.net/browse/DHIS2-15721)

---

### Key features

1. Allow closing the interpretations modal when accessed from URL

---

### Description

There were actually two separate problems that needed fixing:
1. The main problem, which actually impacted the functionality was that when closing the modal, the interpretations panel on the right of the main page would always update. When accessing the interpretation via the URL, the panel on the right is actually closed (not in the DOM), so the ref to call `refresh` on was undefined. This would prevent the modal from closing.
2. When closing the modal, the resize-observer's callback would be called, which caused a state update on the `VisualizationPlugin` component, and this then triggered React to show a `console.error` message about potential memory leaks. I guess you could call this a race condition (the state update happens just before the component unmounts), and I don't actually think in this case it would have caused any real-world issues, but it was fairly easy to fix because the reported `clientHeight` and `clientWidth` on the node are both `0` when the modal is hiding. Not calling the state update when this is the case seems like a sensible fix to me: even if there are other circumstances to cause the width/height to be `0`, I don't think it would ever make sense to adjust the dimensions to `0`.

---

### Reproduction

The JIRA ticket mentions a few steps to reproduce the issue. These are all valid, but the first step mentioned is quite time consuming and there is an easier way:

The step described as follows:
> Open the interpretation modal from the url, can be done through the ui by clicking “Show details and interpretations” on a dashboard item in the dashboard app, then “Open in app” on an interpretation.

Can be replaced by this:
> Open the app, open a saved visualisation, open an interpretation or add a new one and then click "see interpretation". Now you will see the interpretation ID in the URL. After this it is a matter of hitting refresh, adding a reply, then closing the interpretation modal.

[DHIS2-15721]: https://dhis2.atlassian.net/browse/DHIS2-15721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ