### PR TITLE
fix: disable Save when vis not in unsaved/dirty state DHIS2-15373

### DIFF
--- a/src/components/MenuBar/MenuBar.js
+++ b/src/components/MenuBar/MenuBar.js
@@ -12,8 +12,14 @@ import { connect } from 'react-redux'
 import * as fromActions from '../../actions/index.js'
 import { getErrorVariantByStatusCode } from '../../modules/error.js'
 import history from '../../modules/history.js'
-import { visTypes } from '../../modules/visualization.js'
+import {
+    visTypes,
+    getVisualizationState,
+    STATE_UNSAVED,
+    STATE_DIRTY,
+} from '../../modules/visualization.js'
 import { sGetCurrent } from '../../reducers/current.js'
+import { sGetVisualization } from '../../reducers/visualization.js'
 import { ToolbarDownloadDropdown } from '../DownloadMenu/ToolbarDownloadDropdown.js'
 import UpdateVisualizationContainer from '../UpdateButton/UpdateVisualizationContainer.js'
 import VisualizationOptionsManager from '../VisualizationOptions/VisualizationOptionsManager.js'
@@ -70,7 +76,16 @@ const UnconnectedMenuBar = ({ dataTest, ...props }, context) => (
                 onOpen={onOpen}
                 onNew={onNew}
                 onRename={getOnRename(props)}
-                onSave={getOnSave(props)}
+                onSave={
+                    [STATE_UNSAVED, STATE_DIRTY].includes(
+                        getVisualizationState(
+                            props.visualization,
+                            props.current
+                        )
+                    )
+                        ? getOnSave(props)
+                        : undefined
+                }
                 onSaveAs={getOnSaveAs(props)}
                 onDelete={getOnDelete(props)}
                 onError={getOnError(props)}
@@ -87,6 +102,7 @@ UnconnectedMenuBar.propTypes = {
     apiObjectName: PropTypes.string,
     current: PropTypes.object,
     dataTest: PropTypes.string,
+    visualization: PropTypes.object,
 }
 
 UnconnectedMenuBar.contextTypes = {
@@ -95,6 +111,7 @@ UnconnectedMenuBar.contextTypes = {
 
 const mapStateToProps = (state) => ({
     current: sGetCurrent(state),
+    visualization: sGetVisualization(state),
 })
 
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
Fixes [DHIS2-15373](https://jira.dhis2.org/browse/DHIS2-15373)

---

### Key features

1. disable Save button when visualization is *not* in unsaved/dirty state

---

### Description

This is the same logic used in LL, where the buttons behaves correctly.
By not passing the `onSave` callback when the vis is *not* in unsaved or dirty state, the `Save` button is disabled.

---

### Screenshots

Before:
<img width="267" alt="Screenshot 2023-09-08 at 15 00 07" src="https://github.com/dhis2/data-visualizer-app/assets/150978/cd2ecbeb-9658-4841-8182-115fe34aa3c1">

After:
<img width="253" alt="Screenshot 2023-09-08 at 15 00 15" src="https://github.com/dhis2/data-visualizer-app/assets/150978/250c98f5-d77e-4608-a947-868360dc3c7a">
