### PR TITLE
fix: visualization deleted when saving it after copy DHIS2-15722

### DIFF
--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -185,33 +185,33 @@ describe('saving an AO', () => {
         })
     })
 
-    // Specific test for DHIS2-15722
     describe('"save" a copied AO created by others', () => {
-        const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
-        const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
+        it('"save" a copied AO created by others works after editing', () => {
+            const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
+            const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
 
-        it('navigates to the start page and opens a random AO created by others', () => {
+            // navigates to the start page and opens an AO created by others
             goToStartPage()
             openAOByName(TEST_VIS_BY_OTHERS_NAME)
             expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME)
-        })
-        it('saves AO using "Save As"', () => {
+
+            // saves AO using "Save As"
             saveAOAs(TEST_VIS_BY_OTHERS_NAME_UPDATED)
             expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
             expectVisualizationToBeVisible()
-        })
-        it('edits the AO', () => {
+
+            // edits the AO
             openDimension(DIMENSION_ID_ORGUNIT)
             deselectOrgUnitTreeItem('Western Area')
             clickDimensionModalUpdateButton()
-        })
-        it('saves AO using "Save"', () => {
+
+            // saves AO using "Save"
             saveExistingAO()
             expectAOTitleToNotBeDirty()
             expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
             expectVisualizationToBeVisible()
-        })
-        it('deletes AO', () => {
+
+            // deletes AO
             deleteAO()
             expectRouteToBeEmpty()
             expectStartScreenToBeVisible()

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -1,5 +1,6 @@
 import {
     DIMENSION_ID_DATA,
+    DIMENSION_ID_ORGUNIT,
     visTypeDisplayNames,
     VIS_TYPE_SCATTER,
 } from '@dhis2/analytics'
@@ -16,10 +17,10 @@ import {
     selectIndicators,
     selectDataElements,
     clickDimensionModalUpdateButton,
+    deselectOrgUnitTreeItem,
 } from '../elements/dimensionModal/index.js'
 import { openDimension } from '../elements/dimensionsPanel.js'
 import {
-    //openRandomAOCreatedByOthers,
     saveNewAO,
     closeFileMenuWithClick,
     saveAOAs,
@@ -184,21 +185,36 @@ describe('saving an AO', () => {
         })
     })
 
-    /*
-    describe('"save" for a saved AO created by others', () => {
-        it('navigates to the start page', () => {
+    // Specific test for DHIS2-15722
+    describe('"save" a copied AO created by others', () => {
+        const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
+        const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
+
+        it('navigates to the start page and opens a random AO created by others', () => {
             goToStartPage()
+            openAOByName(TEST_VIS_BY_OTHERS_NAME)
+            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME)
         })
-        it('opens a random AO created by others', () => {
-            openRandomAOCreatedByOthers()
+        it('saves AO using "Save As"', () => {
+            saveAOAs(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+            expectVisualizationToBeVisible()
         })
-        it('checks that Save is disabled - WIP', () => {
-            clickMenuBarFileButton()
-            expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
-            // TODO: This is not always true, as different AOs can have different sharing settings.
-            // @edoardo will add additional tests here later
-            closeFileMenuWithClick()
+        it('edits the AO', () => {
+            openDimension(DIMENSION_ID_ORGUNIT)
+            deselectOrgUnitTreeItem('Western Area')
+            clickDimensionModalUpdateButton()
+        })
+        it('saves AO using "Save"', () => {
+            saveExistingAO()
+            expectAOTitleToNotBeDirty()
+            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+            expectVisualizationToBeVisible()
+        })
+        it('deletes AO', () => {
+            deleteAO()
+            expectRouteToBeEmpty()
+            expectStartScreenToBeVisible()
         })
     })
-    */
 })

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -186,7 +186,7 @@ describe('saving an AO', () => {
     })
 
     describe('"save" a copied AO created by others', () => {
-        it('"save" a copied AO created by others works after editing', () => {
+        it('works after editing', () => {
             const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
             const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -6,6 +6,7 @@ import {
     DIMENSION_ID_PERIOD,
     DIMENSION_ID_ORGUNIT,
     DIMENSION_ID_ASSIGNED_CATEGORIES,
+    preparePayloadForSaveAs,
 } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import { apiPostDataStatistics } from '../api/dataStatistics.js'
@@ -204,13 +205,13 @@ export const tDoSaveVisualization =
 
         try {
             dispatch(fromLoader.acSetPluginLoading(true))
-            const visualization = getVisualizationFromCurrent(
+            let visualization = getVisualizationFromCurrent(
                 sGetCurrent(getState())
             )
 
             // remove the id to trigger a POST request and save a new AO
             if (copy) {
-                delete visualization.id
+                visualization = preparePayloadForSaveAs(visualization)
             }
 
             visualization.name =


### PR DESCRIPTION
Fixes [DHIS2-15722](https://dhis2.atlassian.net/browse/DHIS2-15722)

**Requires https://github.com/dhis2/analytics/pull/1573**

---

### Key features

1. fix a bug that caused a newly copied visualization to be deleted when saving it again

---

### Description

Refer to the ticket for the explanation on why it happened.
The PR fixes the issue by cleaning up the payload passed to the POST request for copying an existing visualization.

[DHIS2-15722]: https://dhis2.atlassian.net/browse/DHIS2-15722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

### TODO

- [x] Cypress tests
- [x] Manual tests