### PR TITLE
fix: bump version to release 39.2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,8 @@
     "name": "data-visualizer",
     "description": "DHIS2 Data Visualizer",
     "private": true,
-    "version": "39.2.9",
-    "workspaces": [
-        "packages/*"
-    ],
+    "version": "39.2.15",
+    "workspaces": ["packages/*"],
     "license": "BSD-3-Clause",
     "devDependencies": {
         "@dhis2/cli-style": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
     "description": "DHIS2 Data Visualizer",
     "private": true,
     "version": "39.2.15",
-    "workspaces": ["packages/*"],
+    "workspaces": [
+        "packages/*"
+    ],
     "license": "BSD-3-Clause",
     "devDependencies": {
         "@dhis2/cli-style": "^10.4.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-visualizer-app",
-    "version": "39.2.9",
+    "version": "39.2.15",
     "description": "DHIS2 Data Visualizer app",
     "license": "BSD-3-Clause",
     "private": true,
@@ -47,8 +47,6 @@
         "transformIgnorePatterns": [
             "node_modules/(?!(lodash-es|@dhis2/d2-ui-[a-z-]+)/)"
         ],
-        "setupFilesAfterEnv": [
-            "../../config/testSetup.js"
-        ]
+        "setupFilesAfterEnv": ["../../config/testSetup.js"]
     }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,7 +18,7 @@
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",
         "@dhis2/d2-i18n": "^1.1.0",
-        "@dhis2/data-visualizer-plugin": "39.2.9",
+        "@dhis2/data-visualizer-plugin": "39.2.15",
         "@dhis2/ui": "^8.4.11",
         "d2": "^31.9.1",
         "history": "^5.3.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,6 +47,8 @@
         "transformIgnorePatterns": [
             "node_modules/(?!(lodash-es|@dhis2/d2-ui-[a-z-]+)/)"
         ],
-        "setupFilesAfterEnv": ["../../config/testSetup.js"]
+        "setupFilesAfterEnv": [
+            "../../config/testSetup.js"
+        ]
     }
 }

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -38,6 +38,8 @@
         "transformIgnorePatterns": [
             "node_modules/(?!(lodash-es|@dhis2/d2-ui-[a-z-]+)/)"
         ],
-        "setupFilesAfterEnv": ["../../config/testSetup.js"]
+        "setupFilesAfterEnv": [
+            "../../config/testSetup.js"
+        ]
     }
 }

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/data-visualizer-plugin",
-    "version": "39.2.9",
+    "version": "39.2.15",
     "description": "DHIS2 Data Visualizer plugin",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
@@ -38,8 +38,6 @@
         "transformIgnorePatterns": [
             "node_modules/(?!(lodash-es|@dhis2/d2-ui-[a-z-]+)/)"
         ],
-        "setupFilesAfterEnv": [
-            "../../config/testSetup.js"
-        ]
+        "setupFilesAfterEnv": ["../../config/testSetup.js"]
     }
 }


### PR DESCRIPTION

### Key features

1. bump version to unlock release

---

### Description

Release of 39.2.10 failed because the tag for it is already present.
Latest release was 39.2.15.
Bumping the version to 39.2.15 should unlock the semantic release process and 39.2.16 should be published.