### PR TITLE
chore: consolidate cypress tests

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -83,7 +83,7 @@ jobs:
 
     call-workflow-e2e-prod:
         needs: [build, lint, test]
-        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests.yml@master
+        uses: dhis2/line-listing-app/.github/workflows/e2e-prod.yml@e2e-prod-maps
         secrets:
             baseurl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_DEV }}
             username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -83,7 +83,7 @@ jobs:
 
     call-workflow-e2e-prod:
         needs: [build, lint, test]
-        uses: dhis2/line-listing-app/.github/workflows/e2e-prod.yml@chore/e2e-prod-maps
+        uses: dhis2/line-listing-app/.github/workflows/e2e-prod.yml@e2e-prod-maps
         secrets:
             baseurl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_DEV }}
             username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -83,7 +83,7 @@ jobs:
 
     call-workflow-e2e-prod:
         needs: [build, lint, test]
-        uses: dhis2/line-listing-app/.github/workflows/e2e-prod.yml@e2e-prod-maps
+        uses: dhis2/line-listing-app/.github/workflows/e2e-prod.yml@chore/e2e-prod-maps
         secrets:
             baseurl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_DEV }}
             username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -83,7 +83,7 @@ jobs:
 
     call-workflow-e2e-prod:
         needs: [build, lint, test]
-        uses: dhis2/line-listing-app/.github/workflows/e2e-prod.yml@e2e-prod-maps
+        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests.yml@master
         secrets:
             baseurl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_DEV }}
             username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}

--- a/cypress/integration/confirmLeave.cy.js
+++ b/cypress/integration/confirmLeave.cy.js
@@ -17,35 +17,37 @@ import {
 import { TEST_AOS } from '../utils/data.js'
 import { getRandomArrayItem } from '../utils/random.js'
 
-test('Confirm leave modal preserves AO changes when user cancels leave, and discards changes when user approves leave', () => {
-    const TEST_AO = getRandomArrayItem(TEST_AOS)
-    // navigates to the start page and loads a random saved AO
-    goToStartPage()
-    openAOByName(TEST_AO.name)
-    expectVisualizationToBeVisible(TEST_AO.type)
-    expectAOTitleToNotBeDirty()
+describe('Confirm leave modal', () => {
+    it('Confirm leave modal preserves AO changes when user cancels leave, and discards changes when user approves leave', () => {
+        const TEST_AO = getRandomArrayItem(TEST_AOS)
+        // navigates to the start page and loads a random saved AO
+        goToStartPage()
+        openAOByName(TEST_AO.name)
+        expectVisualizationToBeVisible(TEST_AO.type)
+        expectAOTitleToNotBeDirty()
 
-    // replaces the selected period
-    replacePeriodItems(TEST_AO.type)
-    expectVisualizationToBeVisible(TEST_AO.type)
-    expectAOTitleToBeDirty()
+        // replaces the selected period
+        replacePeriodItems(TEST_AO.type)
+        expectVisualizationToBeVisible(TEST_AO.type)
+        expectAOTitleToBeDirty()
 
-    // tries to open a new AO
-    createNewAO()
-    expectConfirmLeaveModalToBeVisible()
+        // tries to open a new AO
+        createNewAO()
+        expectConfirmLeaveModalToBeVisible()
 
-    // cancels leave
-    confirmLeave(false)
-    expectVisualizationToBeVisible(TEST_AO.type)
-    expectAOTitleToBeDirty()
+        // cancels leave
+        confirmLeave(false)
+        expectVisualizationToBeVisible(TEST_AO.type)
+        expectAOTitleToBeDirty()
 
-    // tries to open a new AO
-    createNewAO()
-    expectConfirmLeaveModalToBeVisible()
+        // tries to open a new AO
+        createNewAO()
+        expectConfirmLeaveModalToBeVisible()
 
-    // confirms leave
-    confirmLeave(true)
-    expectStartScreenToBeVisible()
-    expectVisualizationToNotBeVisible()
-    expectAOTitleToNotBeDirty()
+        // confirms leave
+        confirmLeave(true)
+        expectStartScreenToBeVisible()
+        expectVisualizationToNotBeVisible()
+        expectAOTitleToNotBeDirty()
+    })
 })

--- a/cypress/integration/confirmLeave.cy.js
+++ b/cypress/integration/confirmLeave.cy.js
@@ -17,7 +17,7 @@ import {
 import { TEST_AOS } from '../utils/data.js'
 import { getRandomArrayItem } from '../utils/random.js'
 
-test('confirm leave modal', () => {
+test('Confirm leave modal preserves AO changes when user cancels leave, and discards changes when user approves leave', () => {
     const TEST_AO = getRandomArrayItem(TEST_AOS)
     // navigates to the start page and loads a random saved AO
     goToStartPage()

--- a/cypress/integration/confirmLeave.cy.js
+++ b/cypress/integration/confirmLeave.cy.js
@@ -17,37 +17,35 @@ import {
 import { TEST_AOS } from '../utils/data.js'
 import { getRandomArrayItem } from '../utils/random.js'
 
-describe('confirm leave modal', () => {
+test('confirm leave modal', () => {
     const TEST_AO = getRandomArrayItem(TEST_AOS)
+    // navigates to the start page and loads a random saved AO
+    goToStartPage()
+    openAOByName(TEST_AO.name)
+    expectVisualizationToBeVisible(TEST_AO.type)
+    expectAOTitleToNotBeDirty()
 
-    it('navigates to the start page and loads a random saved AO', () => {
-        goToStartPage()
-        openAOByName(TEST_AO.name)
-        expectVisualizationToBeVisible(TEST_AO.type)
-        expectAOTitleToNotBeDirty()
-    })
-    it(`replaces the selected period`, () => {
-        replacePeriodItems(TEST_AO.type)
-        expectVisualizationToBeVisible(TEST_AO.type)
-        expectAOTitleToBeDirty()
-    })
-    it('tries to open a new AO', () => {
-        createNewAO()
-        expectConfirmLeaveModalToBeVisible()
-    })
-    it('cancels leave', () => {
-        confirmLeave(false)
-        expectVisualizationToBeVisible(TEST_AO.type)
-        expectAOTitleToBeDirty()
-    })
-    it('tries to open a new AO', () => {
-        createNewAO()
-        expectConfirmLeaveModalToBeVisible()
-    })
-    it('confirms leave', () => {
-        confirmLeave(true)
-        expectStartScreenToBeVisible()
-        expectVisualizationToNotBeVisible()
-        expectAOTitleToNotBeDirty()
-    })
+    // replaces the selected period
+    replacePeriodItems(TEST_AO.type)
+    expectVisualizationToBeVisible(TEST_AO.type)
+    expectAOTitleToBeDirty()
+
+    // tries to open a new AO
+    createNewAO()
+    expectConfirmLeaveModalToBeVisible()
+
+    // cancels leave
+    confirmLeave(false)
+    expectVisualizationToBeVisible(TEST_AO.type)
+    expectAOTitleToBeDirty()
+
+    // tries to open a new AO
+    createNewAO()
+    expectConfirmLeaveModalToBeVisible()
+
+    // confirms leave
+    confirmLeave(true)
+    expectStartScreenToBeVisible()
+    expectVisualizationToNotBeVisible()
+    expectAOTitleToNotBeDirty()
 })

--- a/cypress/integration/new.cy.js
+++ b/cypress/integration/new.cy.js
@@ -41,64 +41,61 @@ const TEST_INDICATOR_NAMES = TEST_INDICATORS.slice(1, 3).map(
 )
 
 describe('creating a new AO', () => {
-    it('navigates to the start page', () => {
-        goToStartPage()
-    })
     visTypes.forEach((visType) => {
         const visTypeName = visTypeDisplayNames[visType]
-        describe(visTypeName, () => {
-            it(`create AO of type ${visTypeName}`, () => {
-                // creates a new AO
-                createNewAO()
-                expectStoreCurrentToBeEmpty()
-                expectVisualizationToNotBeVisible()
-                expectVisTypeToBeDefault()
+        it(`create AO of type ${visTypeName}`, () => {
+            // navigates to start page
+            goToStartPage()
 
-                // changes vis type
-                changeVisType(visTypeName)
-                expectVisTypeToBeValue(visTypeName)
+            // creates a new AO
+            createNewAO()
+            expectStoreCurrentToBeEmpty()
+            expectVisualizationToNotBeVisible()
+            expectVisTypeToBeDefault()
 
-                // adds dimensions
-                openDimension(DIMENSION_ID_DATA)
+            // changes vis type
+            changeVisType(visTypeName)
+            expectVisTypeToBeValue(visTypeName)
 
-                if (visType === VIS_TYPE_SCATTER) {
-                    selectIndicators(TEST_INDICATOR_NAMES.slice(0, 1))
-                    switchDataTab('Horizontal')
-                    selectDataElements(TEST_DATA_ELEMENT_NAMES.slice(0, 1))
-                } else {
-                    if (getAxisMaxNumberOfItems(visType, TEST_AXIS_ID) === 1) {
-                        // Gauge and SV can only have 1 data item
-                        TEST_DATA_ELEMENT_NAMES.splice(1)
-                    }
+            // adds dimensions
+            openDimension(DIMENSION_ID_DATA)
 
-                    selectDataElements(TEST_DATA_ELEMENT_NAMES)
+            if (visType === VIS_TYPE_SCATTER) {
+                selectIndicators(TEST_INDICATOR_NAMES.slice(0, 1))
+                switchDataTab('Horizontal')
+                selectDataElements(TEST_DATA_ELEMENT_NAMES.slice(0, 1))
+            } else {
+                if (getAxisMaxNumberOfItems(visType, TEST_AXIS_ID) === 1) {
+                    // Gauge and SV can only have 1 data item
+                    TEST_DATA_ELEMENT_NAMES.splice(1)
                 }
 
-                clickDimensionModalUpdateButton()
+                selectDataElements(TEST_DATA_ELEMENT_NAMES)
+            }
 
-                expectVisualizationToBeVisible(visType)
+            clickDimensionModalUpdateButton()
 
-                isYearOverYear(visType) && expectAOTitleToBeUnsaved()
+            expectVisualizationToBeVisible(visType)
 
-                // FIXME: Store is always in default state
-                /* !isYearOverYear(visType)
+            isYearOverYear(visType) && expectAOTitleToBeUnsaved()
+
+            // FIXME: Store is always in default state
+            /* !isYearOverYear(visType)
                     ? expectStoreCurrentColumnsToHaveLength(1)
                     : expectAOTitleToBeUnsaved() */
 
-                if (visType !== VIS_TYPE_SCATTER) {
-                    TEST_DATA_ELEMENT_NAMES.forEach((item) =>
-                        expectChartToContainDimensionItem(visType, item)
-                    )
-                }
-            })
+            if (visType !== VIS_TYPE_SCATTER) {
+                TEST_DATA_ELEMENT_NAMES.forEach((item) =>
+                    expectChartToContainDimensionItem(visType, item)
+                )
+            }
 
             if ([VIS_TYPE_SINGLE_VALUE, VIS_TYPE_GAUGE].includes(visType)) {
-                it('Data is locked to Series', () => {
-                    expectDimensionOnAxisToHaveLockIcon(
-                        DIMENSION_ID_DATA,
-                        AXIS_ID_COLUMNS
-                    )
-                })
+                // Data is locked to Series
+                expectDimensionOnAxisToHaveLockIcon(
+                    DIMENSION_ID_DATA,
+                    AXIS_ID_COLUMNS
+                )
             }
         })
     })

--- a/cypress/integration/new.cy.js
+++ b/cypress/integration/new.cy.js
@@ -41,61 +41,64 @@ const TEST_INDICATOR_NAMES = TEST_INDICATORS.slice(1, 3).map(
 )
 
 describe('creating a new AO', () => {
+    it('navigates to the start page', () => {
+        goToStartPage()
+    })
     visTypes.forEach((visType) => {
         const visTypeName = visTypeDisplayNames[visType]
-        it(`create AO of type ${visTypeName}`, () => {
-            // navigates to start page
-            goToStartPage()
+        describe(visTypeName, () => {
+            it(`create AO of type ${visTypeName}`, () => {
+                // creates a new AO
+                createNewAO()
+                expectStoreCurrentToBeEmpty()
+                expectVisualizationToNotBeVisible()
+                expectVisTypeToBeDefault()
 
-            // creates a new AO
-            createNewAO()
-            expectStoreCurrentToBeEmpty()
-            expectVisualizationToNotBeVisible()
-            expectVisTypeToBeDefault()
+                // changes vis type
+                changeVisType(visTypeName)
+                expectVisTypeToBeValue(visTypeName)
 
-            // changes vis type
-            changeVisType(visTypeName)
-            expectVisTypeToBeValue(visTypeName)
+                // adds dimensions
+                openDimension(DIMENSION_ID_DATA)
 
-            // adds dimensions
-            openDimension(DIMENSION_ID_DATA)
+                if (visType === VIS_TYPE_SCATTER) {
+                    selectIndicators(TEST_INDICATOR_NAMES.slice(0, 1))
+                    switchDataTab('Horizontal')
+                    selectDataElements(TEST_DATA_ELEMENT_NAMES.slice(0, 1))
+                } else {
+                    if (getAxisMaxNumberOfItems(visType, TEST_AXIS_ID) === 1) {
+                        // Gauge and SV can only have 1 data item
+                        TEST_DATA_ELEMENT_NAMES.splice(1)
+                    }
 
-            if (visType === VIS_TYPE_SCATTER) {
-                selectIndicators(TEST_INDICATOR_NAMES.slice(0, 1))
-                switchDataTab('Horizontal')
-                selectDataElements(TEST_DATA_ELEMENT_NAMES.slice(0, 1))
-            } else {
-                if (getAxisMaxNumberOfItems(visType, TEST_AXIS_ID) === 1) {
-                    // Gauge and SV can only have 1 data item
-                    TEST_DATA_ELEMENT_NAMES.splice(1)
+                    selectDataElements(TEST_DATA_ELEMENT_NAMES)
                 }
 
-                selectDataElements(TEST_DATA_ELEMENT_NAMES)
-            }
+                clickDimensionModalUpdateButton()
 
-            clickDimensionModalUpdateButton()
+                expectVisualizationToBeVisible(visType)
 
-            expectVisualizationToBeVisible(visType)
+                isYearOverYear(visType) && expectAOTitleToBeUnsaved()
 
-            isYearOverYear(visType) && expectAOTitleToBeUnsaved()
-
-            // FIXME: Store is always in default state
-            /* !isYearOverYear(visType)
+                // FIXME: Store is always in default state
+                /* !isYearOverYear(visType)
                     ? expectStoreCurrentColumnsToHaveLength(1)
                     : expectAOTitleToBeUnsaved() */
 
-            if (visType !== VIS_TYPE_SCATTER) {
-                TEST_DATA_ELEMENT_NAMES.forEach((item) =>
-                    expectChartToContainDimensionItem(visType, item)
-                )
-            }
+                if (visType !== VIS_TYPE_SCATTER) {
+                    TEST_DATA_ELEMENT_NAMES.forEach((item) =>
+                        expectChartToContainDimensionItem(visType, item)
+                    )
+                }
+            })
 
             if ([VIS_TYPE_SINGLE_VALUE, VIS_TYPE_GAUGE].includes(visType)) {
-                // Data is locked to Series
-                expectDimensionOnAxisToHaveLockIcon(
-                    DIMENSION_ID_DATA,
-                    AXIS_ID_COLUMNS
-                )
+                it('Data is locked to Series', () => {
+                    expectDimensionOnAxisToHaveLockIcon(
+                        DIMENSION_ID_DATA,
+                        AXIS_ID_COLUMNS
+                    )
+                })
             }
         })
     })

--- a/cypress/integration/new.cy.js
+++ b/cypress/integration/new.cy.js
@@ -41,64 +41,61 @@ const TEST_INDICATOR_NAMES = TEST_INDICATORS.slice(1, 3).map(
 )
 
 describe('creating a new AO', () => {
-    it('navigates to the start page', () => {
-        goToStartPage()
-    })
     visTypes.forEach((visType) => {
         const visTypeName = visTypeDisplayNames[visType]
-        describe(visTypeName, () => {
-            it(`create AO of type ${visTypeName}`, () => {
-                // creates a new AO
-                createNewAO()
-                expectStoreCurrentToBeEmpty()
-                expectVisualizationToNotBeVisible()
-                expectVisTypeToBeDefault()
 
-                // changes vis type
-                changeVisType(visTypeName)
-                expectVisTypeToBeValue(visTypeName)
+        it(`create AO of type ${visTypeName}`, () => {
+            // navigates to start page
+            goToStartPage()
 
-                // adds dimensions
-                openDimension(DIMENSION_ID_DATA)
+            // creates a new AO
+            createNewAO()
+            expectStoreCurrentToBeEmpty()
+            expectVisualizationToNotBeVisible()
+            expectVisTypeToBeDefault()
 
-                if (visType === VIS_TYPE_SCATTER) {
-                    selectIndicators(TEST_INDICATOR_NAMES.slice(0, 1))
-                    switchDataTab('Horizontal')
-                    selectDataElements(TEST_DATA_ELEMENT_NAMES.slice(0, 1))
-                } else {
-                    if (getAxisMaxNumberOfItems(visType, TEST_AXIS_ID) === 1) {
-                        // Gauge and SV can only have 1 data item
-                        TEST_DATA_ELEMENT_NAMES.splice(1)
-                    }
+            // changes vis type
+            changeVisType(visTypeName)
+            expectVisTypeToBeValue(visTypeName)
 
-                    selectDataElements(TEST_DATA_ELEMENT_NAMES)
+            // adds dimensions
+            openDimension(DIMENSION_ID_DATA)
+
+            if (visType === VIS_TYPE_SCATTER) {
+                selectIndicators(TEST_INDICATOR_NAMES.slice(0, 1))
+                switchDataTab('Horizontal')
+                selectDataElements(TEST_DATA_ELEMENT_NAMES.slice(0, 1))
+            } else {
+                if (getAxisMaxNumberOfItems(visType, TEST_AXIS_ID) === 1) {
+                    // Gauge and SV can only have 1 data item
+                    TEST_DATA_ELEMENT_NAMES.splice(1)
                 }
 
-                clickDimensionModalUpdateButton()
+                selectDataElements(TEST_DATA_ELEMENT_NAMES)
+            }
 
-                expectVisualizationToBeVisible(visType)
+            clickDimensionModalUpdateButton()
 
-                isYearOverYear(visType) && expectAOTitleToBeUnsaved()
+            expectVisualizationToBeVisible(visType)
 
-                // FIXME: Store is always in default state
-                /* !isYearOverYear(visType)
+            isYearOverYear(visType) && expectAOTitleToBeUnsaved()
+
+            // FIXME: Store is always in default state
+            /* !isYearOverYear(visType)
                     ? expectStoreCurrentColumnsToHaveLength(1)
                     : expectAOTitleToBeUnsaved() */
 
-                if (visType !== VIS_TYPE_SCATTER) {
-                    TEST_DATA_ELEMENT_NAMES.forEach((item) =>
-                        expectChartToContainDimensionItem(visType, item)
-                    )
-                }
-            })
+            if (visType !== VIS_TYPE_SCATTER) {
+                TEST_DATA_ELEMENT_NAMES.forEach((item) =>
+                    expectChartToContainDimensionItem(visType, item)
+                )
+            }
 
             if ([VIS_TYPE_SINGLE_VALUE, VIS_TYPE_GAUGE].includes(visType)) {
-                it('Data is locked to Series', () => {
-                    expectDimensionOnAxisToHaveLockIcon(
-                        DIMENSION_ID_DATA,
-                        AXIS_ID_COLUMNS
-                    )
-                })
+                expectDimensionOnAxisToHaveLockIcon(
+                    DIMENSION_ID_DATA,
+                    AXIS_ID_COLUMNS
+                )
             }
         })
     })

--- a/cypress/integration/new.cy.js
+++ b/cypress/integration/new.cy.js
@@ -47,17 +47,18 @@ describe('creating a new AO', () => {
     visTypes.forEach((visType) => {
         const visTypeName = visTypeDisplayNames[visType]
         describe(visTypeName, () => {
-            it('creates a new AO', () => {
+            it(`create AO of type ${visTypeName}`, () => {
+                // creates a new AO
                 createNewAO()
                 expectStoreCurrentToBeEmpty()
                 expectVisualizationToNotBeVisible()
                 expectVisTypeToBeDefault()
-            })
-            it('changes vis type', () => {
+
+                // changes vis type
                 changeVisType(visTypeName)
                 expectVisTypeToBeValue(visTypeName)
-            })
-            it('adds dimensions', () => {
+
+                // adds dimensions
                 openDimension(DIMENSION_ID_DATA)
 
                 if (visType === VIS_TYPE_SCATTER) {
@@ -90,6 +91,7 @@ describe('creating a new AO', () => {
                     )
                 }
             })
+
             if ([VIS_TYPE_SINGLE_VALUE, VIS_TYPE_GAUGE].includes(visType)) {
                 it('Data is locked to Series', () => {
                     expectDimensionOnAxisToHaveLockIcon(

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -62,18 +62,19 @@ const TEST_INDICATOR_NAMES = TEST_INDICATORS.slice(1, 4).map(
 
 describe('saving an AO', () => {
     describe('"save" and "save as" for a new AO', () => {
-        it('navigates to the start page', () => {
+        it('"save" and "save as" for a new AO', () => {
+            // navigates to the start page
             goToStartPage()
-        })
-        it('checks that Save is disabled', () => {
+
+            // checks that Save is disabled
             clickMenuBarFileButton()
             expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVE_EXISTING)
             closeFileMenuWithClick()
-        })
-        it(`changes vis type to ${TEST_VIS_TYPE_NAME}`, () => {
+
+            // changes vis type to ${TEST_VIS_TYPE_NAME}
             changeVisType(TEST_VIS_TYPE_NAME)
-        })
-        it('adds Data dimension items', () => {
+
+            // adds Data dimension items
             if (TEST_VIS_TYPE === VIS_TYPE_SCATTER) {
                 openDimension(DIMENSION_ID_DATA)
                 switchDataTab('Vertical')
@@ -90,31 +91,31 @@ describe('saving an AO', () => {
                 )
                 clickDimensionModalUpdateButton()
             }
-        })
-        it('displays an unsaved visualization', () => {
+
+            // displays an unsaved visualization
             expectVisualizationToBeVisible(TEST_VIS_TYPE)
             expectAOTitleToBeUnsaved()
             expectRouteToBeEmpty()
-        })
-        it('checks that Save is enabled', () => {
+
+            // checks that Save is enabled
             clickMenuBarFileButton()
             expectFileMenuButtonToBeEnabled(FILE_MENU_BUTTON_SAVE_EXISTING)
             closeFileMenuWithClick()
-        })
-        it('checks that Save as is disabled', () => {
+
+            // checks that Save as is disabled
             clickMenuBarFileButton()
             expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
             closeFileMenuWithClick()
-        })
-        it('saves new AO using "Save"', () => {
+
+            // saves new AO using "Save"
             saveNewAO(TEST_VIS_NAME, TEST_VIS_DESCRIPTION)
             expectAOTitleToBeValue(TEST_VIS_NAME)
             expectVisualizationToBeVisible(TEST_VIS_TYPE)
-        })
-        it('checks that the url was changed', () => {
+
+            // checks that the url was changed
             expectRouteToBeAOId()
-        })
-        it('all File menu buttons but Save are enabled', () => {
+
+            // all File menu buttons but Save are enabled
             clickMenuBarFileButton()
             const enabledButtons = [
                 FILE_MENU_BUTTON_NEW,
@@ -130,19 +131,19 @@ describe('saving an AO', () => {
                 expectFileMenuButtonToBeEnabled(button)
             )
             closeFileMenuWithClick()
-        })
-        it(`replaces the selected period`, () => {
+
+            // replaces the selected period
             replacePeriodItems(TEST_VIS_TYPE)
             expectAOTitleToBeDirty()
             expectVisualizationToBeVisible(TEST_VIS_TYPE)
-        })
-        it('saves AO using "Save"', () => {
+
+            // saves AO using "Save"
             saveExistingAO()
             expectAOTitleToNotBeDirty()
             expectAOTitleToBeValue(TEST_VIS_NAME)
             expectVisualizationToBeVisible(TEST_VIS_TYPE)
-        })
-        it('saves AO using "Save As"', () => {
+
+            // saves AO using "Save As"
             saveAOAs(TEST_VIS_NAME_UPDATED)
             expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
             expectVisualizationToBeVisible(TEST_VIS_TYPE)
@@ -151,6 +152,7 @@ describe('saving an AO', () => {
 
     describe('"save" and "save as" for a saved AO created by you', () => {
         it('navigates to the start page and opens a saved AO', () => {
+            // navigates to the start page and opens a saved AO
             cy.intercept(
                 /systemSettings(\S)*keyAnalysisRelativePeriod(\S)*/,
                 (req) => {
@@ -167,18 +169,18 @@ describe('saving an AO', () => {
             goToStartPage()
             openAOByName(TEST_VIS_NAME_UPDATED)
             expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
-        })
-        it(`replaces the selected period`, () => {
+
+            // replaces the selected period
             replacePeriodItems(TEST_VIS_TYPE, { useAltData: true })
             expectAOTitleToBeDirty()
-        })
-        it('saves AO using "Save"', () => {
+
+            // saves AO using "Save"
             saveExistingAO()
             expectAOTitleToNotBeDirty()
             expectAOTitleToBeValue(TEST_VIS_NAME)
             expectVisualizationToBeVisible(TEST_VIS_TYPE)
-        })
-        it('deletes AO', () => {
+
+            // deletes AO
             deleteAO()
             expectRouteToBeEmpty()
             expectStartScreenToBeVisible()

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -61,162 +61,157 @@ const TEST_INDICATOR_NAMES = TEST_INDICATORS.slice(1, 4).map(
 // TODO: Add test to check that the description is saved and shown in the interpretations panel
 
 describe('saving an AO', () => {
-    describe('"save" and "save as" for a new AO', () => {
-        it('"save" and "save as" for a new AO', () => {
-            // navigates to the start page
-            goToStartPage()
+    it('"save" and "save as" for a new AO', () => {
+        // navigates to the start page
+        goToStartPage()
 
-            // checks that Save is disabled
-            clickMenuBarFileButton()
-            expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVE_EXISTING)
-            closeFileMenuWithClick()
+        // checks that Save is disabled
+        clickMenuBarFileButton()
+        expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVE_EXISTING)
+        closeFileMenuWithClick()
 
-            // changes vis type to ${TEST_VIS_TYPE_NAME}
-            changeVisType(TEST_VIS_TYPE_NAME)
+        // changes vis type
+        cy.log(`changes vis type to ${TEST_VIS_TYPE_NAME}`)
+        changeVisType(TEST_VIS_TYPE_NAME)
 
-            // adds Data dimension items
-            if (TEST_VIS_TYPE === VIS_TYPE_SCATTER) {
-                openDimension(DIMENSION_ID_DATA)
-                switchDataTab('Vertical')
-                selectIndicators([TEST_INDICATOR_NAMES[0]])
-                clickDimensionModalUpdateButton()
-                openDimension(DIMENSION_ID_DATA)
-                switchDataTab('Horizontal')
-                selectIndicators([TEST_INDICATOR_NAMES[1]])
-                clickDimensionModalUpdateButton()
-            } else {
-                openDimension(DIMENSION_ID_DATA)
-                selectDataElements(
-                    TEST_DATA_ELEMENTS.slice(1, 2).map((item) => item.name)
-                )
-                clickDimensionModalUpdateButton()
-            }
-
-            // displays an unsaved visualization
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-            expectAOTitleToBeUnsaved()
-            expectRouteToBeEmpty()
-
-            // checks that Save is enabled
-            clickMenuBarFileButton()
-            expectFileMenuButtonToBeEnabled(FILE_MENU_BUTTON_SAVE_EXISTING)
-            closeFileMenuWithClick()
-
-            // checks that Save as is disabled
-            clickMenuBarFileButton()
-            expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
-            closeFileMenuWithClick()
-
-            // saves new AO using "Save"
-            saveNewAO(TEST_VIS_NAME, TEST_VIS_DESCRIPTION)
-            expectAOTitleToBeValue(TEST_VIS_NAME)
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-            // checks that the url was changed
-            expectRouteToBeAOId()
-
-            // all File menu buttons but Save are enabled
-            clickMenuBarFileButton()
-            const enabledButtons = [
-                FILE_MENU_BUTTON_NEW,
-                FILE_MENU_BUTTON_OPEN,
-                FILE_MENU_BUTTON_SAVEAS,
-                FILE_MENU_BUTTON_RENAME,
-                FILE_MENU_BUTTON_TRANSLATE,
-                FILE_MENU_BUTTON_SHARE,
-                FILE_MENU_BUTTON_GETLINK,
-                FILE_MENU_BUTTON_DELETE,
-            ]
-            enabledButtons.forEach((button) =>
-                expectFileMenuButtonToBeEnabled(button)
-            )
-            closeFileMenuWithClick()
-
-            // replaces the selected period
-            replacePeriodItems(TEST_VIS_TYPE)
-            expectAOTitleToBeDirty()
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-            // saves AO using "Save"
-            saveExistingAO()
-            expectAOTitleToNotBeDirty()
-            expectAOTitleToBeValue(TEST_VIS_NAME)
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-            // saves AO using "Save As"
-            saveAOAs(TEST_VIS_NAME_UPDATED)
-            expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-        })
-    })
-
-    describe('"save" and "save as" for a saved AO created by you', () => {
-        it('navigates to the start page and opens a saved AO', () => {
-            // navigates to the start page and opens a saved AO
-            cy.intercept(
-                /systemSettings(\S)*keyAnalysisRelativePeriod(\S)*/,
-                (req) => {
-                    req.reply((res) => {
-                        res.send({
-                            body: {
-                                ...res.body,
-                                keyHideMonthlyPeriods: false,
-                            },
-                        })
-                    })
-                }
-            )
-            goToStartPage()
-            openAOByName(TEST_VIS_NAME_UPDATED)
-            expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
-
-            // replaces the selected period
-            replacePeriodItems(TEST_VIS_TYPE, { useAltData: true })
-            expectAOTitleToBeDirty()
-
-            // saves AO using "Save"
-            saveExistingAO()
-            expectAOTitleToNotBeDirty()
-            expectAOTitleToBeValue(TEST_VIS_NAME)
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-            // deletes AO
-            deleteAO()
-            expectRouteToBeEmpty()
-            expectStartScreenToBeVisible()
-        })
-    })
-
-    describe('"save" a copied AO created by others', () => {
-        it('works after editing', () => {
-            const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
-            const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
-
-            // navigates to the start page and opens an AO created by others
-            goToStartPage()
-            openAOByName(TEST_VIS_BY_OTHERS_NAME)
-            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME)
-
-            // saves AO using "Save As"
-            saveAOAs(TEST_VIS_BY_OTHERS_NAME_UPDATED)
-            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
-            expectVisualizationToBeVisible()
-
-            // edits the AO
-            openDimension(DIMENSION_ID_ORGUNIT)
-            deselectOrgUnitTreeItem('Western Area')
+        // adds Data dimension items
+        if (TEST_VIS_TYPE === VIS_TYPE_SCATTER) {
+            openDimension(DIMENSION_ID_DATA)
+            switchDataTab('Vertical')
+            selectIndicators([TEST_INDICATOR_NAMES[0]])
             clickDimensionModalUpdateButton()
+            openDimension(DIMENSION_ID_DATA)
+            switchDataTab('Horizontal')
+            selectIndicators([TEST_INDICATOR_NAMES[1]])
+            clickDimensionModalUpdateButton()
+        } else {
+            openDimension(DIMENSION_ID_DATA)
+            selectDataElements(
+                TEST_DATA_ELEMENTS.slice(1, 2).map((item) => item.name)
+            )
+            clickDimensionModalUpdateButton()
+        }
 
-            // saves AO using "Save"
-            saveExistingAO()
-            expectAOTitleToNotBeDirty()
-            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
-            expectVisualizationToBeVisible()
+        // displays an unsaved visualization
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+        expectAOTitleToBeUnsaved()
+        expectRouteToBeEmpty()
 
-            // deletes AO
-            deleteAO()
-            expectRouteToBeEmpty()
-            expectStartScreenToBeVisible()
-        })
+        // checks that Save is enabled
+        clickMenuBarFileButton()
+        expectFileMenuButtonToBeEnabled(FILE_MENU_BUTTON_SAVE_EXISTING)
+        closeFileMenuWithClick()
+
+        // checks that Save as is disabled
+        clickMenuBarFileButton()
+        expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
+        closeFileMenuWithClick()
+
+        // saves new AO using "Save"
+        saveNewAO(TEST_VIS_NAME, TEST_VIS_DESCRIPTION)
+        expectAOTitleToBeValue(TEST_VIS_NAME)
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+        // checks that the url was changed
+        expectRouteToBeAOId()
+
+        // all File menu buttons but Save are enabled
+        clickMenuBarFileButton()
+        const enabledButtons = [
+            FILE_MENU_BUTTON_NEW,
+            FILE_MENU_BUTTON_OPEN,
+            FILE_MENU_BUTTON_SAVEAS,
+            FILE_MENU_BUTTON_RENAME,
+            FILE_MENU_BUTTON_TRANSLATE,
+            FILE_MENU_BUTTON_SHARE,
+            FILE_MENU_BUTTON_GETLINK,
+            FILE_MENU_BUTTON_DELETE,
+        ]
+        enabledButtons.forEach((button) =>
+            expectFileMenuButtonToBeEnabled(button)
+        )
+        closeFileMenuWithClick()
+
+        // replaces the selected period
+        replacePeriodItems(TEST_VIS_TYPE)
+        expectAOTitleToBeDirty()
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+        // saves AO using "Save"
+        saveExistingAO()
+        expectAOTitleToNotBeDirty()
+        expectAOTitleToBeValue(TEST_VIS_NAME)
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+        // saves AO using "Save As"
+        saveAOAs(TEST_VIS_NAME_UPDATED)
+        expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+    })
+
+    it('navigates to the start page and opens a saved AO created by you', () => {
+        // navigates to the start page and opens a saved AO
+        cy.intercept(
+            /systemSettings(\S)*keyAnalysisRelativePeriod(\S)*/,
+            (req) => {
+                req.reply((res) => {
+                    res.send({
+                        body: {
+                            ...res.body,
+                            keyHideMonthlyPeriods: false,
+                        },
+                    })
+                })
+            }
+        )
+        goToStartPage()
+        openAOByName(TEST_VIS_NAME_UPDATED)
+        expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
+
+        // replaces the selected period
+        replacePeriodItems(TEST_VIS_TYPE, { useAltData: true })
+        expectAOTitleToBeDirty()
+
+        // saves AO using "Save"
+        saveExistingAO()
+        expectAOTitleToNotBeDirty()
+        expectAOTitleToBeValue(TEST_VIS_NAME)
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+        // deletes AO
+        deleteAO()
+        expectRouteToBeEmpty()
+        expectStartScreenToBeVisible()
+    })
+
+    it('"save" a copied AO created by others works after editing', () => {
+        const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
+        const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
+
+        // navigates to the start page and opens an AO created by others
+        goToStartPage()
+        openAOByName(TEST_VIS_BY_OTHERS_NAME)
+        expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME)
+
+        // saves AO using "Save As"
+        saveAOAs(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+        expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+        expectVisualizationToBeVisible()
+
+        // edits the AO
+        openDimension(DIMENSION_ID_ORGUNIT)
+        deselectOrgUnitTreeItem('Western Area')
+        clickDimensionModalUpdateButton()
+
+        // saves AO using "Save"
+        saveExistingAO()
+        expectAOTitleToNotBeDirty()
+        expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+        expectVisualizationToBeVisible()
+
+        // deletes AO
+        deleteAO()
+        expectRouteToBeEmpty()
+        expectStartScreenToBeVisible()
     })
 })

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -149,7 +149,7 @@ describe('saving an AO', () => {
         expectVisualizationToBeVisible(TEST_VIS_TYPE)
     })
 
-    it('navigates to the start page and opens a saved AO created by you', () => {
+    it('"save" and "save as" for a saved AO created by you', () => {
         // navigates to the start page and opens a saved AO
         cy.intercept(
             /systemSettings(\S)*keyAnalysisRelativePeriod(\S)*/,

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -61,157 +61,162 @@ const TEST_INDICATOR_NAMES = TEST_INDICATORS.slice(1, 4).map(
 // TODO: Add test to check that the description is saved and shown in the interpretations panel
 
 describe('saving an AO', () => {
-    it('"save" and "save as" for a new AO', () => {
-        // navigates to the start page
-        goToStartPage()
+    describe('"save" and "save as" for a new AO', () => {
+        it('"save" and "save as" for a new AO', () => {
+            // navigates to the start page
+            goToStartPage()
 
-        // checks that Save is disabled
-        clickMenuBarFileButton()
-        expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVE_EXISTING)
-        closeFileMenuWithClick()
+            // checks that Save is disabled
+            clickMenuBarFileButton()
+            expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVE_EXISTING)
+            closeFileMenuWithClick()
 
-        // changes vis type
-        cy.log('change vis type to', TEST_VIS_TYPE_NAME)
-        changeVisType(TEST_VIS_TYPE_NAME)
+            // changes vis type to ${TEST_VIS_TYPE_NAME}
+            changeVisType(TEST_VIS_TYPE_NAME)
 
-        // adds Data dimension items
-        if (TEST_VIS_TYPE === VIS_TYPE_SCATTER) {
-            openDimension(DIMENSION_ID_DATA)
-            switchDataTab('Vertical')
-            selectIndicators([TEST_INDICATOR_NAMES[0]])
-            clickDimensionModalUpdateButton()
-            openDimension(DIMENSION_ID_DATA)
-            switchDataTab('Horizontal')
-            selectIndicators([TEST_INDICATOR_NAMES[1]])
-            clickDimensionModalUpdateButton()
-        } else {
-            openDimension(DIMENSION_ID_DATA)
-            selectDataElements(
-                TEST_DATA_ELEMENTS.slice(1, 2).map((item) => item.name)
-            )
-            clickDimensionModalUpdateButton()
-        }
-
-        // displays an unsaved visualization
-        expectVisualizationToBeVisible(TEST_VIS_TYPE)
-        expectAOTitleToBeUnsaved()
-        expectRouteToBeEmpty()
-
-        // checks that Save is enabled
-        clickMenuBarFileButton()
-        expectFileMenuButtonToBeEnabled(FILE_MENU_BUTTON_SAVE_EXISTING)
-        closeFileMenuWithClick()
-
-        // checks that Save as is disabled
-        clickMenuBarFileButton()
-        expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
-        closeFileMenuWithClick()
-
-        // saves new AO using "Save"
-        saveNewAO(TEST_VIS_NAME, TEST_VIS_DESCRIPTION)
-        expectAOTitleToBeValue(TEST_VIS_NAME)
-        expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-        // checks that the url was changed
-        expectRouteToBeAOId()
-
-        // all File menu buttons but Save are enabled
-        clickMenuBarFileButton()
-        const enabledButtons = [
-            FILE_MENU_BUTTON_NEW,
-            FILE_MENU_BUTTON_OPEN,
-            FILE_MENU_BUTTON_SAVEAS,
-            FILE_MENU_BUTTON_RENAME,
-            FILE_MENU_BUTTON_TRANSLATE,
-            FILE_MENU_BUTTON_SHARE,
-            FILE_MENU_BUTTON_GETLINK,
-            FILE_MENU_BUTTON_DELETE,
-        ]
-        enabledButtons.forEach((button) =>
-            expectFileMenuButtonToBeEnabled(button)
-        )
-        closeFileMenuWithClick()
-
-        // replaces the selected period
-        replacePeriodItems(TEST_VIS_TYPE)
-        expectAOTitleToBeDirty()
-        expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-        // saves AO using "Save"
-        saveExistingAO()
-        expectAOTitleToNotBeDirty()
-        expectAOTitleToBeValue(TEST_VIS_NAME)
-        expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-        // saves AO using "Save As"
-        saveAOAs(TEST_VIS_NAME_UPDATED)
-        expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
-        expectVisualizationToBeVisible(TEST_VIS_TYPE)
-    })
-
-    it('navigates to the start page and opens a saved AO created by you', () => {
-        // navigates to the start page and opens a saved AO
-        cy.intercept(
-            /systemSettings(\S)*keyAnalysisRelativePeriod(\S)*/,
-            (req) => {
-                req.reply((res) => {
-                    res.send({
-                        body: {
-                            ...res.body,
-                            keyHideMonthlyPeriods: false,
-                        },
-                    })
-                })
+            // adds Data dimension items
+            if (TEST_VIS_TYPE === VIS_TYPE_SCATTER) {
+                openDimension(DIMENSION_ID_DATA)
+                switchDataTab('Vertical')
+                selectIndicators([TEST_INDICATOR_NAMES[0]])
+                clickDimensionModalUpdateButton()
+                openDimension(DIMENSION_ID_DATA)
+                switchDataTab('Horizontal')
+                selectIndicators([TEST_INDICATOR_NAMES[1]])
+                clickDimensionModalUpdateButton()
+            } else {
+                openDimension(DIMENSION_ID_DATA)
+                selectDataElements(
+                    TEST_DATA_ELEMENTS.slice(1, 2).map((item) => item.name)
+                )
+                clickDimensionModalUpdateButton()
             }
-        )
-        goToStartPage()
-        openAOByName(TEST_VIS_NAME_UPDATED)
-        expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
 
-        // replaces the selected period
-        replacePeriodItems(TEST_VIS_TYPE, { useAltData: true })
-        expectAOTitleToBeDirty()
+            // displays an unsaved visualization
+            expectVisualizationToBeVisible(TEST_VIS_TYPE)
+            expectAOTitleToBeUnsaved()
+            expectRouteToBeEmpty()
 
-        // saves AO using "Save"
-        saveExistingAO()
-        expectAOTitleToNotBeDirty()
-        expectAOTitleToBeValue(TEST_VIS_NAME)
-        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+            // checks that Save is enabled
+            clickMenuBarFileButton()
+            expectFileMenuButtonToBeEnabled(FILE_MENU_BUTTON_SAVE_EXISTING)
+            closeFileMenuWithClick()
 
-        // deletes AO
-        deleteAO()
-        expectRouteToBeEmpty()
-        expectStartScreenToBeVisible()
+            // checks that Save as is disabled
+            clickMenuBarFileButton()
+            expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
+            closeFileMenuWithClick()
+
+            // saves new AO using "Save"
+            saveNewAO(TEST_VIS_NAME, TEST_VIS_DESCRIPTION)
+            expectAOTitleToBeValue(TEST_VIS_NAME)
+            expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+            // checks that the url was changed
+            expectRouteToBeAOId()
+
+            // all File menu buttons but Save are enabled
+            clickMenuBarFileButton()
+            const enabledButtons = [
+                FILE_MENU_BUTTON_NEW,
+                FILE_MENU_BUTTON_OPEN,
+                FILE_MENU_BUTTON_SAVEAS,
+                FILE_MENU_BUTTON_RENAME,
+                FILE_MENU_BUTTON_TRANSLATE,
+                FILE_MENU_BUTTON_SHARE,
+                FILE_MENU_BUTTON_GETLINK,
+                FILE_MENU_BUTTON_DELETE,
+            ]
+            enabledButtons.forEach((button) =>
+                expectFileMenuButtonToBeEnabled(button)
+            )
+            closeFileMenuWithClick()
+
+            // replaces the selected period
+            replacePeriodItems(TEST_VIS_TYPE)
+            expectAOTitleToBeDirty()
+            expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+            // saves AO using "Save"
+            saveExistingAO()
+            expectAOTitleToNotBeDirty()
+            expectAOTitleToBeValue(TEST_VIS_NAME)
+            expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+            // saves AO using "Save As"
+            saveAOAs(TEST_VIS_NAME_UPDATED)
+            expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
+            expectVisualizationToBeVisible(TEST_VIS_TYPE)
+        })
     })
 
-    it('"save" a copied AO created by others works after editing', () => {
-        const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
-        const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
+    describe('"save" and "save as" for a saved AO created by you', () => {
+        it('navigates to the start page and opens a saved AO', () => {
+            // navigates to the start page and opens a saved AO
+            cy.intercept(
+                /systemSettings(\S)*keyAnalysisRelativePeriod(\S)*/,
+                (req) => {
+                    req.reply((res) => {
+                        res.send({
+                            body: {
+                                ...res.body,
+                                keyHideMonthlyPeriods: false,
+                            },
+                        })
+                    })
+                }
+            )
+            goToStartPage()
+            openAOByName(TEST_VIS_NAME_UPDATED)
+            expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
 
-        // navigates to the start page and opens an AO created by others
-        goToStartPage()
-        openAOByName(TEST_VIS_BY_OTHERS_NAME)
-        expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME)
+            // replaces the selected period
+            replacePeriodItems(TEST_VIS_TYPE, { useAltData: true })
+            expectAOTitleToBeDirty()
 
-        // saves AO using "Save As"
-        saveAOAs(TEST_VIS_BY_OTHERS_NAME_UPDATED)
-        expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
-        expectVisualizationToBeVisible()
+            // saves AO using "Save"
+            saveExistingAO()
+            expectAOTitleToNotBeDirty()
+            expectAOTitleToBeValue(TEST_VIS_NAME)
+            expectVisualizationToBeVisible(TEST_VIS_TYPE)
 
-        // edits the AO
-        openDimension(DIMENSION_ID_ORGUNIT)
-        deselectOrgUnitTreeItem('Western Area')
-        clickDimensionModalUpdateButton()
+            // deletes AO
+            deleteAO()
+            expectRouteToBeEmpty()
+            expectStartScreenToBeVisible()
+        })
+    })
 
-        // saves AO using "Save"
-        saveExistingAO()
-        expectAOTitleToNotBeDirty()
-        expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
-        expectVisualizationToBeVisible()
+    describe('"save" a copied AO created by others', () => {
+        it('works after editing', () => {
+            const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
+            const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
 
-        // deletes AO
-        deleteAO()
-        expectRouteToBeEmpty()
-        expectStartScreenToBeVisible()
+            // navigates to the start page and opens an AO created by others
+            goToStartPage()
+            openAOByName(TEST_VIS_BY_OTHERS_NAME)
+            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME)
+
+            // saves AO using "Save As"
+            saveAOAs(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+            expectVisualizationToBeVisible()
+
+            // edits the AO
+            openDimension(DIMENSION_ID_ORGUNIT)
+            deselectOrgUnitTreeItem('Western Area')
+            clickDimensionModalUpdateButton()
+
+            // saves AO using "Save"
+            saveExistingAO()
+            expectAOTitleToNotBeDirty()
+            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+            expectVisualizationToBeVisible()
+
+            // deletes AO
+            deleteAO()
+            expectRouteToBeEmpty()
+            expectStartScreenToBeVisible()
+        })
     })
 })

--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -61,162 +61,157 @@ const TEST_INDICATOR_NAMES = TEST_INDICATORS.slice(1, 4).map(
 // TODO: Add test to check that the description is saved and shown in the interpretations panel
 
 describe('saving an AO', () => {
-    describe('"save" and "save as" for a new AO', () => {
-        it('"save" and "save as" for a new AO', () => {
-            // navigates to the start page
-            goToStartPage()
+    it('"save" and "save as" for a new AO', () => {
+        // navigates to the start page
+        goToStartPage()
 
-            // checks that Save is disabled
-            clickMenuBarFileButton()
-            expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVE_EXISTING)
-            closeFileMenuWithClick()
+        // checks that Save is disabled
+        clickMenuBarFileButton()
+        expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVE_EXISTING)
+        closeFileMenuWithClick()
 
-            // changes vis type to ${TEST_VIS_TYPE_NAME}
-            changeVisType(TEST_VIS_TYPE_NAME)
+        // changes vis type
+        cy.log('change vis type to', TEST_VIS_TYPE_NAME)
+        changeVisType(TEST_VIS_TYPE_NAME)
 
-            // adds Data dimension items
-            if (TEST_VIS_TYPE === VIS_TYPE_SCATTER) {
-                openDimension(DIMENSION_ID_DATA)
-                switchDataTab('Vertical')
-                selectIndicators([TEST_INDICATOR_NAMES[0]])
-                clickDimensionModalUpdateButton()
-                openDimension(DIMENSION_ID_DATA)
-                switchDataTab('Horizontal')
-                selectIndicators([TEST_INDICATOR_NAMES[1]])
-                clickDimensionModalUpdateButton()
-            } else {
-                openDimension(DIMENSION_ID_DATA)
-                selectDataElements(
-                    TEST_DATA_ELEMENTS.slice(1, 2).map((item) => item.name)
-                )
-                clickDimensionModalUpdateButton()
-            }
-
-            // displays an unsaved visualization
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-            expectAOTitleToBeUnsaved()
-            expectRouteToBeEmpty()
-
-            // checks that Save is enabled
-            clickMenuBarFileButton()
-            expectFileMenuButtonToBeEnabled(FILE_MENU_BUTTON_SAVE_EXISTING)
-            closeFileMenuWithClick()
-
-            // checks that Save as is disabled
-            clickMenuBarFileButton()
-            expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
-            closeFileMenuWithClick()
-
-            // saves new AO using "Save"
-            saveNewAO(TEST_VIS_NAME, TEST_VIS_DESCRIPTION)
-            expectAOTitleToBeValue(TEST_VIS_NAME)
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-            // checks that the url was changed
-            expectRouteToBeAOId()
-
-            // all File menu buttons but Save are enabled
-            clickMenuBarFileButton()
-            const enabledButtons = [
-                FILE_MENU_BUTTON_NEW,
-                FILE_MENU_BUTTON_OPEN,
-                FILE_MENU_BUTTON_SAVEAS,
-                FILE_MENU_BUTTON_RENAME,
-                FILE_MENU_BUTTON_TRANSLATE,
-                FILE_MENU_BUTTON_SHARE,
-                FILE_MENU_BUTTON_GETLINK,
-                FILE_MENU_BUTTON_DELETE,
-            ]
-            enabledButtons.forEach((button) =>
-                expectFileMenuButtonToBeEnabled(button)
-            )
-            closeFileMenuWithClick()
-
-            // replaces the selected period
-            replacePeriodItems(TEST_VIS_TYPE)
-            expectAOTitleToBeDirty()
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-            // saves AO using "Save"
-            saveExistingAO()
-            expectAOTitleToNotBeDirty()
-            expectAOTitleToBeValue(TEST_VIS_NAME)
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-            // saves AO using "Save As"
-            saveAOAs(TEST_VIS_NAME_UPDATED)
-            expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-        })
-    })
-
-    describe('"save" and "save as" for a saved AO created by you', () => {
-        it('navigates to the start page and opens a saved AO', () => {
-            // navigates to the start page and opens a saved AO
-            cy.intercept(
-                /systemSettings(\S)*keyAnalysisRelativePeriod(\S)*/,
-                (req) => {
-                    req.reply((res) => {
-                        res.send({
-                            body: {
-                                ...res.body,
-                                keyHideMonthlyPeriods: false,
-                            },
-                        })
-                    })
-                }
-            )
-            goToStartPage()
-            openAOByName(TEST_VIS_NAME_UPDATED)
-            expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
-
-            // replaces the selected period
-            replacePeriodItems(TEST_VIS_TYPE, { useAltData: true })
-            expectAOTitleToBeDirty()
-
-            // saves AO using "Save"
-            saveExistingAO()
-            expectAOTitleToNotBeDirty()
-            expectAOTitleToBeValue(TEST_VIS_NAME)
-            expectVisualizationToBeVisible(TEST_VIS_TYPE)
-
-            // deletes AO
-            deleteAO()
-            expectRouteToBeEmpty()
-            expectStartScreenToBeVisible()
-        })
-    })
-
-    describe('"save" a copied AO created by others', () => {
-        it('works after editing', () => {
-            const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
-            const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
-
-            // navigates to the start page and opens an AO created by others
-            goToStartPage()
-            openAOByName(TEST_VIS_BY_OTHERS_NAME)
-            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME)
-
-            // saves AO using "Save As"
-            saveAOAs(TEST_VIS_BY_OTHERS_NAME_UPDATED)
-            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
-            expectVisualizationToBeVisible()
-
-            // edits the AO
-            openDimension(DIMENSION_ID_ORGUNIT)
-            deselectOrgUnitTreeItem('Western Area')
+        // adds Data dimension items
+        if (TEST_VIS_TYPE === VIS_TYPE_SCATTER) {
+            openDimension(DIMENSION_ID_DATA)
+            switchDataTab('Vertical')
+            selectIndicators([TEST_INDICATOR_NAMES[0]])
             clickDimensionModalUpdateButton()
+            openDimension(DIMENSION_ID_DATA)
+            switchDataTab('Horizontal')
+            selectIndicators([TEST_INDICATOR_NAMES[1]])
+            clickDimensionModalUpdateButton()
+        } else {
+            openDimension(DIMENSION_ID_DATA)
+            selectDataElements(
+                TEST_DATA_ELEMENTS.slice(1, 2).map((item) => item.name)
+            )
+            clickDimensionModalUpdateButton()
+        }
 
-            // saves AO using "Save"
-            saveExistingAO()
-            expectAOTitleToNotBeDirty()
-            expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
-            expectVisualizationToBeVisible()
+        // displays an unsaved visualization
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+        expectAOTitleToBeUnsaved()
+        expectRouteToBeEmpty()
 
-            // deletes AO
-            deleteAO()
-            expectRouteToBeEmpty()
-            expectStartScreenToBeVisible()
-        })
+        // checks that Save is enabled
+        clickMenuBarFileButton()
+        expectFileMenuButtonToBeEnabled(FILE_MENU_BUTTON_SAVE_EXISTING)
+        closeFileMenuWithClick()
+
+        // checks that Save as is disabled
+        clickMenuBarFileButton()
+        expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
+        closeFileMenuWithClick()
+
+        // saves new AO using "Save"
+        saveNewAO(TEST_VIS_NAME, TEST_VIS_DESCRIPTION)
+        expectAOTitleToBeValue(TEST_VIS_NAME)
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+        // checks that the url was changed
+        expectRouteToBeAOId()
+
+        // all File menu buttons but Save are enabled
+        clickMenuBarFileButton()
+        const enabledButtons = [
+            FILE_MENU_BUTTON_NEW,
+            FILE_MENU_BUTTON_OPEN,
+            FILE_MENU_BUTTON_SAVEAS,
+            FILE_MENU_BUTTON_RENAME,
+            FILE_MENU_BUTTON_TRANSLATE,
+            FILE_MENU_BUTTON_SHARE,
+            FILE_MENU_BUTTON_GETLINK,
+            FILE_MENU_BUTTON_DELETE,
+        ]
+        enabledButtons.forEach((button) =>
+            expectFileMenuButtonToBeEnabled(button)
+        )
+        closeFileMenuWithClick()
+
+        // replaces the selected period
+        replacePeriodItems(TEST_VIS_TYPE)
+        expectAOTitleToBeDirty()
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+        // saves AO using "Save"
+        saveExistingAO()
+        expectAOTitleToNotBeDirty()
+        expectAOTitleToBeValue(TEST_VIS_NAME)
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+        // saves AO using "Save As"
+        saveAOAs(TEST_VIS_NAME_UPDATED)
+        expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+    })
+
+    it('navigates to the start page and opens a saved AO created by you', () => {
+        // navigates to the start page and opens a saved AO
+        cy.intercept(
+            /systemSettings(\S)*keyAnalysisRelativePeriod(\S)*/,
+            (req) => {
+                req.reply((res) => {
+                    res.send({
+                        body: {
+                            ...res.body,
+                            keyHideMonthlyPeriods: false,
+                        },
+                    })
+                })
+            }
+        )
+        goToStartPage()
+        openAOByName(TEST_VIS_NAME_UPDATED)
+        expectAOTitleToBeValue(TEST_VIS_NAME_UPDATED)
+
+        // replaces the selected period
+        replacePeriodItems(TEST_VIS_TYPE, { useAltData: true })
+        expectAOTitleToBeDirty()
+
+        // saves AO using "Save"
+        saveExistingAO()
+        expectAOTitleToNotBeDirty()
+        expectAOTitleToBeValue(TEST_VIS_NAME)
+        expectVisualizationToBeVisible(TEST_VIS_TYPE)
+
+        // deletes AO
+        deleteAO()
+        expectRouteToBeEmpty()
+        expectStartScreenToBeVisible()
+    })
+
+    it('"save" a copied AO created by others works after editing', () => {
+        const TEST_VIS_BY_OTHERS_NAME = 'ANC: 1-3 dropout rate Yearly'
+        const TEST_VIS_BY_OTHERS_NAME_UPDATED = `${TEST_VIS_BY_OTHERS_NAME} - updated`
+
+        // navigates to the start page and opens an AO created by others
+        goToStartPage()
+        openAOByName(TEST_VIS_BY_OTHERS_NAME)
+        expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME)
+
+        // saves AO using "Save As"
+        saveAOAs(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+        expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+        expectVisualizationToBeVisible()
+
+        // edits the AO
+        openDimension(DIMENSION_ID_ORGUNIT)
+        deselectOrgUnitTreeItem('Western Area')
+        clickDimensionModalUpdateButton()
+
+        // saves AO using "Save"
+        saveExistingAO()
+        expectAOTitleToNotBeDirty()
+        expectAOTitleToBeValue(TEST_VIS_BY_OTHERS_NAME_UPDATED)
+        expectVisualizationToBeVisible()
+
+        // deletes AO
+        deleteAO()
+        expectRouteToBeEmpty()
+        expectStartScreenToBeVisible()
     })
 })

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -35,68 +35,65 @@ import { expectVisTypeToBeDefault } from '../elements/visualizationTypeSelector.
 import { expectWindowTitleToBeDefault } from '../elements/window.js'
 import { expectStoreCurrentToBeEmpty } from '../utils/store.js'
 
-describe('viewing the start screen', () => {
-    it('navigates to the start page', () => {
-        goToStartPage()
-    })
-    it('window has a title', () => {
-        expectWindowTitleToBeDefault()
-    })
-    it('store is empty', () => {
-        expectStoreCurrentToBeEmpty()
-    })
-    it('no chart is visible', () => {
-        expectVisualizationToNotBeVisible()
-    })
-    it('displays most viewed section', () => {
-        expectMostViewedToBeVisible()
-    })
-    it('vis type is default', () => {
-        expectVisTypeToBeDefault()
-    })
-    it('axis series has data dimension', () => {
-        expectAxisToHaveDimension(AXIS_ID_COLUMNS, DIMENSION_ID_DATA)
-    })
-    it('data dimension has no items', () => {
-        expectDimensionToNotHaveItems(DIMENSION_ID_DATA)
-    })
-    it('axis category has period dimension', () => {
-        expectAxisToHaveDimension(AXIS_ID_ROWS, DIMENSION_ID_PERIOD)
-    })
-    it('period dimension has 1 item', () => {
-        expectDimensionToHaveItemAmount(DIMENSION_ID_PERIOD, 1)
-    })
-    it('axis filter has orgunit dimension', () => {
-        expectAxisToHaveDimension(AXIS_ID_FILTERS, DIMENSION_ID_ORGUNIT)
-    })
-    it('orgunit dimension has 1 item', () => {
-        expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
-    })
-    it('primary File menu buttons are enabled and menu is closed with click', () => {
-        clickMenuBarFileButton()
-        const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
-        enabledButtons.forEach((button) =>
-            expectFileMenuButtonToBeEnabled(button)
-        )
-        closeFileMenuWithClick()
-    })
-    it('secondary File menu buttons are disabled and menu is closed with click', () => {
-        clickMenuBarFileButton()
-        const disabledButtons = [
-            FILE_MENU_BUTTON_SAVEAS,
-            FILE_MENU_BUTTON_RENAME,
-            FILE_MENU_BUTTON_TRANSLATE,
-            FILE_MENU_BUTTON_SHARE,
-            FILE_MENU_BUTTON_GETLINK,
-            FILE_MENU_BUTTON_DELETE,
-        ]
-        disabledButtons.forEach((button) =>
-            expectFileMenuButtonToBeDisabled(button)
-        )
-        closeFileMenuWithClick()
-    })
-    it('File menu is closed with Escape', () => {
-        clickMenuBarFileButton()
-        closeFileMenuWithEsc()
-    })
+test('viewing the start screen', () => {
+    //navigates to the start page
+    goToStartPage()
+
+    //window has a title
+    expectWindowTitleToBeDefault()
+
+    //store is empty
+    expectStoreCurrentToBeEmpty()
+
+    //no chart is visible
+    expectVisualizationToNotBeVisible()
+
+    //displays most viewed section
+    expectMostViewedToBeVisible()
+
+    //vis type is default
+    expectVisTypeToBeDefault()
+
+    //axis series has data dimension
+    expectAxisToHaveDimension(AXIS_ID_COLUMNS, DIMENSION_ID_DATA)
+
+    //data dimension has no items
+    expectDimensionToNotHaveItems(DIMENSION_ID_DATA)
+
+    //axis category has period dimension
+    expectAxisToHaveDimension(AXIS_ID_ROWS, DIMENSION_ID_PERIOD)
+
+    //period dimension has 1 item
+    expectDimensionToHaveItemAmount(DIMENSION_ID_PERIOD, 1)
+
+    //axis filter has orgunit dimension
+    expectAxisToHaveDimension(AXIS_ID_FILTERS, DIMENSION_ID_ORGUNIT)
+
+    //orgunit dimension has 1 item
+    expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
+
+    //primary File menu buttons are enabled and menu is closed with click
+    clickMenuBarFileButton()
+    const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
+    enabledButtons.forEach((button) => expectFileMenuButtonToBeEnabled(button))
+    closeFileMenuWithClick()
+
+    //secondary File menu buttons are disabled and menu is closed with click
+    clickMenuBarFileButton()
+    const disabledButtons = [
+        FILE_MENU_BUTTON_SAVEAS,
+        FILE_MENU_BUTTON_RENAME,
+        FILE_MENU_BUTTON_TRANSLATE,
+        FILE_MENU_BUTTON_SHARE,
+        FILE_MENU_BUTTON_GETLINK,
+        FILE_MENU_BUTTON_DELETE,
+    ]
+    disabledButtons.forEach((button) =>
+        expectFileMenuButtonToBeDisabled(button)
+    )
+    closeFileMenuWithClick()
+
+    //File menu is closed with Escape
+    clickMenuBarFileButton()
+    closeFileMenuWithEsc()
 })

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -37,43 +37,43 @@ import { expectStoreCurrentToBeEmpty } from '../utils/store.js'
 
 describe('Start screen', () => {
     it('Start screen shows the correct initial state', () => {
-        //navigates to the start page
+        // navigates to the start page
         goToStartPage()
 
-        //window has a title
+        // window has a title
         expectWindowTitleToBeDefault()
 
-        //store is empty
+        // store is empty
         expectStoreCurrentToBeEmpty()
 
-        //no chart is visible
+        // no chart is visible
         expectVisualizationToNotBeVisible()
 
-        //displays most viewed section
+        // displays most viewed section
         expectMostViewedToBeVisible()
 
-        //vis type is default
+        // vis type is default
         expectVisTypeToBeDefault()
 
-        //axis series has data dimension
+        // axis series has data dimension
         expectAxisToHaveDimension(AXIS_ID_COLUMNS, DIMENSION_ID_DATA)
 
-        //data dimension has no items
+        // data dimension has no items
         expectDimensionToNotHaveItems(DIMENSION_ID_DATA)
 
-        //axis category has period dimension
+        // axis category has period dimension
         expectAxisToHaveDimension(AXIS_ID_ROWS, DIMENSION_ID_PERIOD)
 
-        //period dimension has 1 item
+        // period dimension has 1 item
         expectDimensionToHaveItemAmount(DIMENSION_ID_PERIOD, 1)
 
-        //axis filter has orgunit dimension
+        // axis filter has orgunit dimension
         expectAxisToHaveDimension(AXIS_ID_FILTERS, DIMENSION_ID_ORGUNIT)
 
-        //orgunit dimension has 1 item
+        // orgunit dimension has 1 item
         expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
 
-        //primary File menu buttons are enabled and menu is closed with click
+        // primary File menu buttons are enabled and menu is closed with click
         clickMenuBarFileButton()
         const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
         enabledButtons.forEach((button) =>
@@ -81,7 +81,7 @@ describe('Start screen', () => {
         )
         closeFileMenuWithClick()
 
-        //secondary File menu buttons are disabled and menu is closed with click
+        // secondary File menu buttons are disabled and menu is closed with click
         clickMenuBarFileButton()
         const disabledButtons = [
             FILE_MENU_BUTTON_SAVEAS,
@@ -96,7 +96,7 @@ describe('Start screen', () => {
         )
         closeFileMenuWithClick()
 
-        //File menu is closed with Escape
+        // File menu is closed with Escape
         clickMenuBarFileButton()
         closeFileMenuWithEsc()
     })

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -35,7 +35,7 @@ import { expectVisTypeToBeDefault } from '../elements/visualizationTypeSelector.
 import { expectWindowTitleToBeDefault } from '../elements/window.js'
 import { expectStoreCurrentToBeEmpty } from '../utils/store.js'
 
-test('viewing the start screen', () => {
+test('Start screen shows the correct initial state', () => {
     //navigates to the start page
     goToStartPage()
 

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -35,65 +35,69 @@ import { expectVisTypeToBeDefault } from '../elements/visualizationTypeSelector.
 import { expectWindowTitleToBeDefault } from '../elements/window.js'
 import { expectStoreCurrentToBeEmpty } from '../utils/store.js'
 
-test('Start screen shows the correct initial state', () => {
-    //navigates to the start page
-    goToStartPage()
+describe('Start screen', () => {
+    it('Start screen shows the correct initial state', () => {
+        //navigates to the start page
+        goToStartPage()
 
-    //window has a title
-    expectWindowTitleToBeDefault()
+        //window has a title
+        expectWindowTitleToBeDefault()
 
-    //store is empty
-    expectStoreCurrentToBeEmpty()
+        //store is empty
+        expectStoreCurrentToBeEmpty()
 
-    //no chart is visible
-    expectVisualizationToNotBeVisible()
+        //no chart is visible
+        expectVisualizationToNotBeVisible()
 
-    //displays most viewed section
-    expectMostViewedToBeVisible()
+        //displays most viewed section
+        expectMostViewedToBeVisible()
 
-    //vis type is default
-    expectVisTypeToBeDefault()
+        //vis type is default
+        expectVisTypeToBeDefault()
 
-    //axis series has data dimension
-    expectAxisToHaveDimension(AXIS_ID_COLUMNS, DIMENSION_ID_DATA)
+        //axis series has data dimension
+        expectAxisToHaveDimension(AXIS_ID_COLUMNS, DIMENSION_ID_DATA)
 
-    //data dimension has no items
-    expectDimensionToNotHaveItems(DIMENSION_ID_DATA)
+        //data dimension has no items
+        expectDimensionToNotHaveItems(DIMENSION_ID_DATA)
 
-    //axis category has period dimension
-    expectAxisToHaveDimension(AXIS_ID_ROWS, DIMENSION_ID_PERIOD)
+        //axis category has period dimension
+        expectAxisToHaveDimension(AXIS_ID_ROWS, DIMENSION_ID_PERIOD)
 
-    //period dimension has 1 item
-    expectDimensionToHaveItemAmount(DIMENSION_ID_PERIOD, 1)
+        //period dimension has 1 item
+        expectDimensionToHaveItemAmount(DIMENSION_ID_PERIOD, 1)
 
-    //axis filter has orgunit dimension
-    expectAxisToHaveDimension(AXIS_ID_FILTERS, DIMENSION_ID_ORGUNIT)
+        //axis filter has orgunit dimension
+        expectAxisToHaveDimension(AXIS_ID_FILTERS, DIMENSION_ID_ORGUNIT)
 
-    //orgunit dimension has 1 item
-    expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
+        //orgunit dimension has 1 item
+        expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
 
-    //primary File menu buttons are enabled and menu is closed with click
-    clickMenuBarFileButton()
-    const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
-    enabledButtons.forEach((button) => expectFileMenuButtonToBeEnabled(button))
-    closeFileMenuWithClick()
+        //primary File menu buttons are enabled and menu is closed with click
+        clickMenuBarFileButton()
+        const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
+        enabledButtons.forEach((button) =>
+            expectFileMenuButtonToBeEnabled(button)
+        )
+        closeFileMenuWithClick()
 
-    //secondary File menu buttons are disabled and menu is closed with click
-    clickMenuBarFileButton()
-    const disabledButtons = [
-        FILE_MENU_BUTTON_SAVEAS,
-        FILE_MENU_BUTTON_RENAME,
-        FILE_MENU_BUTTON_TRANSLATE,
-        FILE_MENU_BUTTON_SHARE,
-        FILE_MENU_BUTTON_GETLINK,
-        FILE_MENU_BUTTON_DELETE,
-    ]
-    disabledButtons.forEach((button) =>
-        expectFileMenuButtonToBeDisabled(button)
-    )
-    closeFileMenuWithClick()
+        //secondary File menu buttons are disabled and menu is closed with click
+        clickMenuBarFileButton()
+        const disabledButtons = [
+            FILE_MENU_BUTTON_SAVEAS,
+            FILE_MENU_BUTTON_RENAME,
+            FILE_MENU_BUTTON_TRANSLATE,
+            FILE_MENU_BUTTON_SHARE,
+            FILE_MENU_BUTTON_GETLINK,
+            FILE_MENU_BUTTON_DELETE,
+        ]
+        disabledButtons.forEach((button) =>
+            expectFileMenuButtonToBeDisabled(button)
+        )
+        closeFileMenuWithClick()
 
-    //File menu is closed with Escape
-    clickMenuBarFileButton()
-    closeFileMenuWithEsc()
+        //File menu is closed with Escape
+        clickMenuBarFileButton()
+        closeFileMenuWithEsc()
+    })
 })

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -35,65 +35,69 @@ import { expectVisTypeToBeDefault } from '../elements/visualizationTypeSelector.
 import { expectWindowTitleToBeDefault } from '../elements/window.js'
 import { expectStoreCurrentToBeEmpty } from '../utils/store.js'
 
-test('Start screen shows the correct initial state', () => {
-    //navigates to the start page
-    goToStartPage()
+describe('Start screen', () => {
+    it('Start screen shows the correct initial state', () => {
+        // navigates to the start page
+        goToStartPage()
 
-    //window has a title
-    expectWindowTitleToBeDefault()
+        // window has a title
+        expectWindowTitleToBeDefault()
 
-    //store is empty
-    expectStoreCurrentToBeEmpty()
+        // store is empty
+        expectStoreCurrentToBeEmpty()
 
-    //no chart is visible
-    expectVisualizationToNotBeVisible()
+        // no chart is visible
+        expectVisualizationToNotBeVisible()
 
-    //displays most viewed section
-    expectMostViewedToBeVisible()
+        // displays most viewed section
+        expectMostViewedToBeVisible()
 
-    //vis type is default
-    expectVisTypeToBeDefault()
+        // vis type is default
+        expectVisTypeToBeDefault()
 
-    //axis series has data dimension
-    expectAxisToHaveDimension(AXIS_ID_COLUMNS, DIMENSION_ID_DATA)
+        // axis series has data dimension
+        expectAxisToHaveDimension(AXIS_ID_COLUMNS, DIMENSION_ID_DATA)
 
-    //data dimension has no items
-    expectDimensionToNotHaveItems(DIMENSION_ID_DATA)
+        // data dimension has no items
+        expectDimensionToNotHaveItems(DIMENSION_ID_DATA)
 
-    //axis category has period dimension
-    expectAxisToHaveDimension(AXIS_ID_ROWS, DIMENSION_ID_PERIOD)
+        // axis category has period dimension
+        expectAxisToHaveDimension(AXIS_ID_ROWS, DIMENSION_ID_PERIOD)
 
-    //period dimension has 1 item
-    expectDimensionToHaveItemAmount(DIMENSION_ID_PERIOD, 1)
+        // period dimension has 1 item
+        expectDimensionToHaveItemAmount(DIMENSION_ID_PERIOD, 1)
 
-    //axis filter has orgunit dimension
-    expectAxisToHaveDimension(AXIS_ID_FILTERS, DIMENSION_ID_ORGUNIT)
+        // axis filter has orgunit dimension
+        expectAxisToHaveDimension(AXIS_ID_FILTERS, DIMENSION_ID_ORGUNIT)
 
-    //orgunit dimension has 1 item
-    expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
+        // orgunit dimension has 1 item
+        expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
 
-    //primary File menu buttons are enabled and menu is closed with click
-    clickMenuBarFileButton()
-    const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
-    enabledButtons.forEach((button) => expectFileMenuButtonToBeEnabled(button))
-    closeFileMenuWithClick()
+        // primary File menu buttons are enabled and menu is closed with click
+        clickMenuBarFileButton()
+        const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
+        enabledButtons.forEach((button) =>
+            expectFileMenuButtonToBeEnabled(button)
+        )
+        closeFileMenuWithClick()
 
-    //secondary File menu buttons are disabled and menu is closed with click
-    clickMenuBarFileButton()
-    const disabledButtons = [
-        FILE_MENU_BUTTON_SAVEAS,
-        FILE_MENU_BUTTON_RENAME,
-        FILE_MENU_BUTTON_TRANSLATE,
-        FILE_MENU_BUTTON_SHARE,
-        FILE_MENU_BUTTON_GETLINK,
-        FILE_MENU_BUTTON_DELETE,
-    ]
-    disabledButtons.forEach((button) =>
-        expectFileMenuButtonToBeDisabled(button)
-    )
-    closeFileMenuWithClick()
+        // secondary File menu buttons are disabled and menu is closed with click
+        clickMenuBarFileButton()
+        const disabledButtons = [
+            FILE_MENU_BUTTON_SAVEAS,
+            FILE_MENU_BUTTON_RENAME,
+            FILE_MENU_BUTTON_TRANSLATE,
+            FILE_MENU_BUTTON_SHARE,
+            FILE_MENU_BUTTON_GETLINK,
+            FILE_MENU_BUTTON_DELETE,
+        ]
+        disabledButtons.forEach((button) =>
+            expectFileMenuButtonToBeDisabled(button)
+        )
+        closeFileMenuWithClick()
 
-    //File menu is closed with Escape
-    clickMenuBarFileButton()
-    closeFileMenuWithEsc()
+        // File menu is closed with Escape
+        clickMenuBarFileButton()
+        closeFileMenuWithEsc()
+    })
 })

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -35,69 +35,65 @@ import { expectVisTypeToBeDefault } from '../elements/visualizationTypeSelector.
 import { expectWindowTitleToBeDefault } from '../elements/window.js'
 import { expectStoreCurrentToBeEmpty } from '../utils/store.js'
 
-describe('Start screen', () => {
-    it('Start screen shows the correct initial state', () => {
-        // navigates to the start page
-        goToStartPage()
+test('Start screen shows the correct initial state', () => {
+    //navigates to the start page
+    goToStartPage()
 
-        // window has a title
-        expectWindowTitleToBeDefault()
+    //window has a title
+    expectWindowTitleToBeDefault()
 
-        // store is empty
-        expectStoreCurrentToBeEmpty()
+    //store is empty
+    expectStoreCurrentToBeEmpty()
 
-        // no chart is visible
-        expectVisualizationToNotBeVisible()
+    //no chart is visible
+    expectVisualizationToNotBeVisible()
 
-        // displays most viewed section
-        expectMostViewedToBeVisible()
+    //displays most viewed section
+    expectMostViewedToBeVisible()
 
-        // vis type is default
-        expectVisTypeToBeDefault()
+    //vis type is default
+    expectVisTypeToBeDefault()
 
-        // axis series has data dimension
-        expectAxisToHaveDimension(AXIS_ID_COLUMNS, DIMENSION_ID_DATA)
+    //axis series has data dimension
+    expectAxisToHaveDimension(AXIS_ID_COLUMNS, DIMENSION_ID_DATA)
 
-        // data dimension has no items
-        expectDimensionToNotHaveItems(DIMENSION_ID_DATA)
+    //data dimension has no items
+    expectDimensionToNotHaveItems(DIMENSION_ID_DATA)
 
-        // axis category has period dimension
-        expectAxisToHaveDimension(AXIS_ID_ROWS, DIMENSION_ID_PERIOD)
+    //axis category has period dimension
+    expectAxisToHaveDimension(AXIS_ID_ROWS, DIMENSION_ID_PERIOD)
 
-        // period dimension has 1 item
-        expectDimensionToHaveItemAmount(DIMENSION_ID_PERIOD, 1)
+    //period dimension has 1 item
+    expectDimensionToHaveItemAmount(DIMENSION_ID_PERIOD, 1)
 
-        // axis filter has orgunit dimension
-        expectAxisToHaveDimension(AXIS_ID_FILTERS, DIMENSION_ID_ORGUNIT)
+    //axis filter has orgunit dimension
+    expectAxisToHaveDimension(AXIS_ID_FILTERS, DIMENSION_ID_ORGUNIT)
 
-        // orgunit dimension has 1 item
-        expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
+    //orgunit dimension has 1 item
+    expectDimensionToHaveItemAmount(DIMENSION_ID_ORGUNIT, 1)
 
-        // primary File menu buttons are enabled and menu is closed with click
-        clickMenuBarFileButton()
-        const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
-        enabledButtons.forEach((button) =>
-            expectFileMenuButtonToBeEnabled(button)
-        )
-        closeFileMenuWithClick()
+    //primary File menu buttons are enabled and menu is closed with click
+    clickMenuBarFileButton()
+    const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
+    enabledButtons.forEach((button) => expectFileMenuButtonToBeEnabled(button))
+    closeFileMenuWithClick()
 
-        // secondary File menu buttons are disabled and menu is closed with click
-        clickMenuBarFileButton()
-        const disabledButtons = [
-            FILE_MENU_BUTTON_SAVEAS,
-            FILE_MENU_BUTTON_RENAME,
-            FILE_MENU_BUTTON_TRANSLATE,
-            FILE_MENU_BUTTON_SHARE,
-            FILE_MENU_BUTTON_GETLINK,
-            FILE_MENU_BUTTON_DELETE,
-        ]
-        disabledButtons.forEach((button) =>
-            expectFileMenuButtonToBeDisabled(button)
-        )
-        closeFileMenuWithClick()
+    //secondary File menu buttons are disabled and menu is closed with click
+    clickMenuBarFileButton()
+    const disabledButtons = [
+        FILE_MENU_BUTTON_SAVEAS,
+        FILE_MENU_BUTTON_RENAME,
+        FILE_MENU_BUTTON_TRANSLATE,
+        FILE_MENU_BUTTON_SHARE,
+        FILE_MENU_BUTTON_GETLINK,
+        FILE_MENU_BUTTON_DELETE,
+    ]
+    disabledButtons.forEach((button) =>
+        expectFileMenuButtonToBeDisabled(button)
+    )
+    closeFileMenuWithClick()
 
-        // File menu is closed with Escape
-        clickMenuBarFileButton()
-        closeFileMenuWithEsc()
-    })
+    //File menu is closed with Escape
+    clickMenuBarFileButton()
+    closeFileMenuWithEsc()
 })


### PR DESCRIPTION
To follow [cypress best practice](https://docs.cypress.io/guides/references/best-practices#Creating-Tiny-Tests-With-A-Single-Assertion), consolidate assertions into single tests when they represent a single logical user journey

Positive side effects (in addition to those listed in the best practice page):
- less tests contributing to our monthly cypress subscription total
- less skewed impression of coverage

With these changes the number of tests has gone down from 637 to 569