### PR TITLE
chore: use reportportal fork

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -83,7 +83,7 @@ jobs:
 
     call-workflow-e2e-prod:
         needs: [build, lint, test]
-        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests.yml@PR-Branch-info-analytics-workflow
+        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests.yml@master
         secrets:
             baseurl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_DEV }}
             username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -83,7 +83,7 @@ jobs:
 
     call-workflow-e2e-prod:
         needs: [build, lint, test]
-        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests.yml@master
+        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests.yml@PR-Branch-info-analytics-workflow
         secrets:
             baseurl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_DEV }}
             username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -23,14 +23,14 @@ module.exports = defineConfig({
     reporterOptions: {
         endpoint: process.env.REPORTPORTAL_ENDPOINT,
         apiKey: process.env.REPORTPORTAL_API_KEY,
-        launch: 'data_visualizer_app_master',
+        launch: 'data_visualizer_app',
         project: process.env.REPORTPORTAL_PROJECT,
         description: '',
         autoMerge: true,
         parallel: true,
         debug: false,
         restClientConfig: {
-            timeout: 360000,
+            timeout: 660000,
         },
         attributes: [
             {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "@dhis2/cli-style": "^10.5.1",
         "@dhis2/cypress-commands": "^10.0.3",
         "@dhis2/cypress-plugins": "^10.0.2",
-        "@reportportal/agent-js-cypress": "git+https://github.com/adeldhis2/agent-js-cypress.git#develop",
+        "@reportportal/agent-js-cypress": "git+https://github.com/dhis2/agent-js-cypress.git#develop",
         "@reportportal/agent-js-jest": "^5.0.6",
         "cypress": "^12.16.0",
         "cypress-tags": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "@dhis2/cli-style": "^10.5.1",
         "@dhis2/cypress-commands": "^10.0.3",
         "@dhis2/cypress-plugins": "^10.0.2",
-        "@reportportal/agent-js-cypress": "^5.1.3",
+        "@reportportal/agent-js-cypress": "git+https://github.com/adeldhis2/agent-js-cypress.git#develop",
         "@reportportal/agent-js-jest": "^5.0.6",
         "cypress": "^12.16.0",
         "cypress-tags": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2967,12 +2967,11 @@
     "@react-hook/passive-layout-effect" "^1.2.0"
     "@react-hook/resize-observer" "^1.2.1"
 
-"@reportportal/agent-js-cypress@^5.1.3":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@reportportal/agent-js-cypress/-/agent-js-cypress-5.1.3.tgz#596aa9657ad0e8fd7dc57f08304b73decf375d44"
-  integrity sha512-20UBwMR+EGJ0eNGK23kJxYkUp5+43G8wGmWaJCzozp7ihWK/I3mj+SkgjQ5F8FvExGi91ivAbpoXha8Ak5SZuQ==
+"@reportportal/agent-js-cypress@git+https://github.com/adeldhis2/agent-js-cypress.git#develop":
+  version "5.1.4"
+  resolved "git+https://github.com/adeldhis2/agent-js-cypress.git#5db9183458305b559de3ede4984c8d9224a5b8a0"
   dependencies:
-    "@reportportal/client-javascript" "^5.0.12"
+    "@reportportal/client-javascript" "^5.0.14"
     glob "^7.2.3"
     minimatch "^3.1.2"
     mocha "^10.2.0"
@@ -2990,6 +2989,18 @@
   version "5.0.12"
   resolved "https://registry.yarnpkg.com/@reportportal/client-javascript/-/client-javascript-5.0.12.tgz#b6d9254014545ca56599c05105854ea814561f1e"
   integrity sha512-ECLvuDLV7KyKs0wG9Sis3ZqHOq9VMg3fywm1VDegd5HGDKC1hoXxFKfz6ngPY8FZ5O1nt1UJvgEs47shtPHQCg==
+  dependencies:
+    axios "^0.27.2"
+    axios-retry "^3.4.0"
+    glob "^7.2.3"
+    ini "^2.0.0"
+    uniqid "^5.4.0"
+    uuid "^9.0.0"
+
+"@reportportal/client-javascript@^5.0.14":
+  version "5.0.14"
+  resolved "https://registry.yarnpkg.com/@reportportal/client-javascript/-/client-javascript-5.0.14.tgz#48a40f2f33129d74bb7e451aaf25d44742e26fcc"
+  integrity sha512-4ge9ddOB1rFlzqI6j43qCw0cyjQOloiPChA1EFyF3dcV2BXHzGbh8S3SNhwxibvlQtV6piU8e0W9CLN4UWXvSA==
   dependencies:
     axios "^0.27.2"
     axios-retry "^3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2967,9 +2967,9 @@
     "@react-hook/passive-layout-effect" "^1.2.0"
     "@react-hook/resize-observer" "^1.2.1"
 
-"@reportportal/agent-js-cypress@git+https://github.com/adeldhis2/agent-js-cypress.git#develop":
+"@reportportal/agent-js-cypress@git+https://github.com/dhis2/agent-js-cypress.git#develop":
   version "5.1.4"
-  resolved "git+https://github.com/adeldhis2/agent-js-cypress.git#5db9183458305b559de3ede4984c8d9224a5b8a0"
+  resolved "git+https://github.com/dhis2/agent-js-cypress.git#d3afea4e74abdbef39c1121f820f23deca2368f4"
   dependencies:
     "@reportportal/client-javascript" "^5.0.14"
     glob "^7.2.3"


### PR DESCRIPTION
Now you will be able to:
- see all the cypress tests merged in one Report portal launch
- find a launch by : 
   - PR_TITLE
   - BRANCH_NAME
   - CI_BUILD_ID

![image](https://github.com/dhis2/workflows/assets/125370676/8077ed9d-af37-4889-a8b6-ddf4adfcaad5)

Part of the work was done at the level of : 

- https://github.com/dhis2/agent-js-cypress/commit/d3afea4e74abdbef39c1121f820f23deca2368f4
- https://github.com/dhis2/workflows/pull/46
- https://github.com/dhis2/workflows/pull/47
