### PR TITLE
chore: remove stray console.log

### DIFF
--- a/src/components/Layout/ScatterLayout/ScatterAxis.js
+++ b/src/components/Layout/ScatterLayout/ScatterAxis.js
@@ -133,7 +133,7 @@ const Axis = ({
         ) : (
             <HorizontalIcon />
         )
-    console.log('ScatterBrain')
+
     return (
         <div
             id={label}


### PR DESCRIPTION
No issue in JIRA

---

### Key features

1. Stop logging `ScatterBrain` to the console when showing a scatter plot

