### PR TITLE
chore: remove testRegex from jest config to revert to default test file detection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,6 @@ module.exports = {
     setupFilesAfterEnv: ['./config/testSetup.js'],
 
     testRunner: 'jest-circus/runner',
-    testRegex: ['/src/modules/__tests__/.*.spec.js?$'],
     reporters: [
         'default',
         [


### PR DESCRIPTION
Remove testRegex from Jest config to revert to default jest test file detection

