### PR TITLE
fix: disable Save when vis not in unsaved/dirty state (DHIS2-15373) v39

### DIFF
--- a/cypress/integration/save.cy.js
+++ b/cypress/integration/save.cy.js
@@ -64,6 +64,11 @@ describe('saving an AO', () => {
         it('navigates to the start page', () => {
             goToStartPage()
         })
+        it('checks that Save is disabled', () => {
+            clickMenuBarFileButton()
+            expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVE_EXISTING)
+            closeFileMenuWithClick()
+        })
         it(`changes vis type to ${TEST_VIS_TYPE_NAME}`, () => {
             changeVisType(TEST_VIS_TYPE_NAME)
         })
@@ -90,6 +95,11 @@ describe('saving an AO', () => {
             expectAOTitleToBeUnsaved()
             expectRouteToBeEmpty()
         })
+        it('checks that Save is enabled', () => {
+            clickMenuBarFileButton()
+            expectFileMenuButtonToBeEnabled(FILE_MENU_BUTTON_SAVE_EXISTING)
+            closeFileMenuWithClick()
+        })
         it('checks that Save as is disabled', () => {
             clickMenuBarFileButton()
             expectFileMenuButtonToBeDisabled(FILE_MENU_BUTTON_SAVEAS)
@@ -103,12 +113,11 @@ describe('saving an AO', () => {
         it('checks that the url was changed', () => {
             expectRouteToBeAOId()
         })
-        it('all File menu buttons are enabled', () => {
+        it('all File menu buttons but Save are enabled', () => {
             clickMenuBarFileButton()
             const enabledButtons = [
                 FILE_MENU_BUTTON_NEW,
                 FILE_MENU_BUTTON_OPEN,
-                FILE_MENU_BUTTON_SAVE_EXISTING,
                 FILE_MENU_BUTTON_SAVEAS,
                 FILE_MENU_BUTTON_RENAME,
                 FILE_MENU_BUTTON_TRANSLATE,

--- a/cypress/integration/start.cy.js
+++ b/cypress/integration/start.cy.js
@@ -13,7 +13,6 @@ import {
     expectFileMenuButtonToBeDisabled,
     FILE_MENU_BUTTON_NEW,
     FILE_MENU_BUTTON_OPEN,
-    FILE_MENU_BUTTON_SAVE_NEW,
     FILE_MENU_BUTTON_SAVEAS,
     FILE_MENU_BUTTON_GETLINK,
     FILE_MENU_BUTTON_SHARE,
@@ -75,11 +74,7 @@ describe('viewing the start screen', () => {
     })
     it('primary File menu buttons are enabled and menu is closed with click', () => {
         clickMenuBarFileButton()
-        const enabledButtons = [
-            FILE_MENU_BUTTON_NEW,
-            FILE_MENU_BUTTON_OPEN,
-            FILE_MENU_BUTTON_SAVE_NEW,
-        ]
+        const enabledButtons = [FILE_MENU_BUTTON_NEW, FILE_MENU_BUTTON_OPEN]
         enabledButtons.forEach((button) =>
             expectFileMenuButtonToBeEnabled(button)
         )

--- a/packages/app/src/components/MenuBar/MenuBar.js
+++ b/packages/app/src/components/MenuBar/MenuBar.js
@@ -10,8 +10,14 @@ import { connect } from 'react-redux'
 import * as fromActions from '../../actions/index.js'
 import { getErrorVariantByStatusCode } from '../../modules/error.js'
 import history from '../../modules/history.js'
-import { visTypes } from '../../modules/visualization.js'
+import {
+    visTypes,
+    getVisualizationState,
+    STATE_UNSAVED,
+    STATE_DIRTY,
+} from '../../modules/visualization.js'
 import { sGetCurrent } from '../../reducers/current.js'
+import { sGetVisualization } from '../../reducers/visualization.js'
 import { ToolbarDownloadDropdown } from '../DownloadMenu/ToolbarDownloadDropdown.js'
 import UpdateButton from '../UpdateButton/UpdateButton.js'
 import UpdateVisualizationContainer from '../UpdateButton/UpdateVisualizationContainer.js'
@@ -71,7 +77,13 @@ const UnconnectedMenuBar = ({ dataTest, ...props }, context) => (
             onOpen={onOpen}
             onNew={onNew}
             onRename={getOnRename(props)}
-            onSave={getOnSave(props)}
+            onSave={
+                [STATE_UNSAVED, STATE_DIRTY].includes(
+                    getVisualizationState(props.visualization, props.current)
+                )
+                    ? getOnSave(props)
+                    : undefined
+            }
             onSaveAs={getOnSaveAs(props)}
             onDelete={getOnDelete(props)}
             onError={getOnError(props)}
@@ -89,6 +101,7 @@ UnconnectedMenuBar.propTypes = {
     apiObjectName: PropTypes.string,
     current: PropTypes.object,
     dataTest: PropTypes.string,
+    visualization: PropTypes.object,
 }
 
 UnconnectedMenuBar.contextTypes = {
@@ -97,6 +110,7 @@ UnconnectedMenuBar.contextTypes = {
 
 const mapStateToProps = (state) => ({
     current: sGetCurrent(state),
+    visualization: sGetVisualization(state),
 })
 
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
Backport of the fix for [DHIS2-15373](https://jira.dhis2.org/browse/DHIS2-15373)

---

### Key features

1. disable Save button when visualization is not in unsaved/dirty state

---

### Description

See https://github.com/dhis2/data-visualizer-app/pull/2758

[DHIS2-15373]: https://dhis2.atlassian.net/browse/DHIS2-15373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ