### PR TITLE
chore: include release notes in slackbot message

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -99,7 +99,7 @@ jobs:
         if: |
             !github.event.push.repository.fork &&
             github.actor != 'dependabot[bot]' &&
-            github.event_name != 'pull_request'
+            github.ref == 'refs/heads/master'
         steps:
             - uses: actions/checkout@v3
               with:
@@ -151,13 +151,13 @@ jobs:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
                   payload: |
                       {
-                        "text": ":small_red_triangle_down: :data-visualizer-app: DV release <https://github.com/dhis2/data-visualizer-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>",
+                        "text": ":small_red_triangle_down: :data-visualizer-app: Data Visualizer release <https://github.com/dhis2/data-visualizer-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>",
                         "blocks": [
                           {
                             "type": "section",
                             "text": {
                               "type": "mrkdwn",
-                              "text": ":small_red_triangle_down: :data-visualizer-app: DV release <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>"
+                              "text": ":small_red_triangle_down: :data-visualizer-app: Data Visualizer release <https://github.com/dhis2/data-visualizer-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>"
                             }
                           }
                         ]
@@ -188,13 +188,41 @@ jobs:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
                   payload: |
                       {
-                        "text": ":large_green_circle: :data-visualizer-app: :tada: DV app release succeeded for version: ${{ steps.extract_version.outputs.version }}",
+                        "text": "Data Visualizer app release ${{ steps.extract_version.outputs.version }} succeeded",
                         "blocks": [
+                          {
+                            "type": "header",
+                            "text": {
+                                "type": "plain_text",
+                                "text": ":large_green_circle: :data-visualizer-app: Data Visualizer version ${{ steps.extract_version.outputs.version }} released :tada:",
+                                "emoji": true
+                            }
+                          },
+                          {
+                            "type": "divider"
+                          },
                           {
                             "type": "section",
                             "text": {
-                              "type": "mrkdwn",
-                              "text": ":large_green_circle: :data-visualizer-app: :tada: DV version ${{ steps.extract_version.outputs.version }} released <https://github.com/dhis2/data-visualizer-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess|successfully>"
+                                "type": "mrkdwn",
+                                "text": "*Release Notes*"
+                            }
+                          },
+                          {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": ${{ toJSON(github.event.head_commit.message) }}
+                            }
+                          },
+                          {
+                            "type": "divider"
+                          },
+                          {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "Link to <https://github.com/dhis2/data-visualizer-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess|build>"
                             }
                           }
                         ]


### PR DESCRIPTION
It is useful to see the release notes in the slack channel for a quick reference as to what was released.

The commit message in the "chore(release)" commit includes the release notes, so hopefully it will display nicely.

This is an example of what it will look like (except obviously it will say "Data Visualizer app":

![image](https://github.com/dhis2/data-visualizer-app/assets/6113918/cc881001-e962-4321-abed-01adf9f86a66)
