### PR TITLE
fix: keep original item height to avoid PT not showing up (DHIS2-16888)

### DIFF
--- a/packages/plugin/src/VisualizationPlugin.js
+++ b/packages/plugin/src/VisualizationPlugin.js
@@ -267,6 +267,12 @@ export const VisualizationPlugin = ({
               }
             : style
 
+    // force height when no value available otherwise the PivotTable container sets 0 as height hiding the table content
+    // and Highcharts does not render correctly the chart/legend
+    if (!transformedStyle.height) {
+        transformedStyle.height = '100%'
+    }
+
     const getLegendKey = () => {
         if (hasLegendSet && forDashboard) {
             return (
@@ -330,8 +336,7 @@ export const VisualizationPlugin = ({
                             onDrill ? onToggleContextualMenu : undefined
                         }
                         id={id}
-                        // force height otherwise the PivotTable container sets 0 as height hiding the table content
-                        style={{ ...transformedStyle, height: '100%' }}
+                        style={transformedStyle}
                     />
                 ) : (
                     <ChartPlugin


### PR DESCRIPTION
Implements [DHIS2-16888](https://jira.dhis2.org/browse/DHIS2-16888)

---

### Key features

1. fix dashboard item height passed to PT plugin

---

### Description

In dashboard view mode the PT items were not showing up.
The issue was that the height of the dashboard item was not passed correctly and the PT plugin needs that information for rendering the table.

---

### Screenshots

Before:
<img width="649" alt="Screenshot 2024-02-28 at 11 31 36" src="https://github.com/dhis2/data-visualizer-app/assets/150978/38784d36-2017-49da-a13c-e25a4a13349f">

After:
<img width="659" alt="Screenshot 2024-02-28 at 11 31 42" src="https://github.com/dhis2/data-visualizer-app/assets/150978/18ef912b-e877-413b-a23b-8f19c7cb0000">

