### PR TITLE
chore: run the release step on both dev and master branches

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -98,8 +98,7 @@ jobs:
         needs: call-workflow-e2e-prod
         if: |
             !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]' &&
-            github.ref == 'refs/heads/master'
+            github.actor != 'dependabot[bot]'
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -98,7 +98,8 @@ jobs:
         needs: call-workflow-e2e-prod
         if: |
             !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]'
+            github.actor != 'dependabot[bot]' &&
+            (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev')
         steps:
             - uses: actions/checkout@v3
               with:


### PR DESCRIPTION
For the 41 soft freeze period, the app bundle needs to be deployed to d2-ci. Since branch 'dev' will be used to build the core bundle, run the release job on both master and dev branches