### PR TITLE
fix: show loading spinner while waiting for data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-visualizer-app",
-    "version": "999.9.9-outlier-table-2024-03-12T13-45-36",
+    "version": "100.4.0",
     "description": "DHIS2 Data Visualizer",
     "license": "BSD-3-Clause",
     "private": true,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "start-server-and-test": "^2.0.0"
     },
     "dependencies": {
-        "@dhis2/analytics": "999.9.9-outlier-table.alpha.4",
+        "@dhis2/analytics": "999.99.9-outlier-and-te.alpha.1",
         "@dhis2/app-runtime": "^3.7.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-visualizer-app",
-    "version": "100.4.0",
+    "version": "999.9.9-outlier-table-2024-03-12T13-45-36",
     "description": "DHIS2 Data Visualizer",
     "license": "BSD-3-Clause",
     "private": true,
@@ -41,7 +41,7 @@
         "start-server-and-test": "^2.0.0"
     },
     "dependencies": {
-        "@dhis2/analytics": "999.99.9-outlier-and-te.alpha.1",
+        "@dhis2/analytics": "^26.6.0",
         "@dhis2/app-runtime": "^3.7.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/src/components/VisualizationOptions/Options/OutliersMaxResults.js
+++ b/src/components/VisualizationOptions/Options/OutliersMaxResults.js
@@ -27,7 +27,7 @@ const OutliersMaxResults = () => {
     }
 
     const onChange = ({ value }) => {
-        const parsedValue = parseInt(value, 10)
+        const parsedValue = parseInt(value || MIN_VALUE, 10)
 
         dispatch(
             acSetUiOptions({

--- a/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
+++ b/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
@@ -1,11 +1,11 @@
-import { CenteredContent, CircularLoader, Layer } from '@dhis2/ui'
+import { CenteredContent, CircularLoader, ComponentCover } from '@dhis2/ui'
 import React, { useCallback, useEffect, useState } from 'react'
 import { VisualizationPlugin } from '../VisualizationPlugin/VisualizationPlugin.js'
 
 // handle internal state for features that need to work without the app's Redux store
 const VisualizationPluginWrapper = (props) => {
     const [pluginProps, setPluginProps] = useState(props)
-    const [isLoading, setIsLoading] = useState(false)
+    const [isLoading, setIsLoading] = useState(true)
 
     const onDataSorted = useCallback(
         (sorting) => {
@@ -34,11 +34,11 @@ const VisualizationPluginWrapper = (props) => {
     return (
         <>
             {isLoading && (
-                <Layer>
+                <ComponentCover>
                     <CenteredContent>
                         <CircularLoader />
                     </CenteredContent>
-                </Layer>
+                </ComponentCover>
             )}
             <VisualizationPlugin
                 {...pluginProps}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2028,10 +2028,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@999.9.9-outlier-table.alpha.4":
-  version "999.9.9-outlier-table.alpha.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-outlier-table.alpha.4.tgz#a5ca4dc5cc8d1e819d9462c69a1d12149b9351c7"
-  integrity sha512-JtvJxqRQSEDoo2+Jq+bo0NIb2gq0hqCQfCpnTpET08uwkYFAwu6YKma2Z0rmK3A9IM0wwqSJNx3a7Cje7Px9BQ==
+"@dhis2/analytics@999.99.9-outlier-and-te.alpha.1":
+  version "999.99.9-outlier-and-te.alpha.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.99.9-outlier-and-te.alpha.1.tgz#0da88a32c3540aaaa8de01942219b2abebd4c89f"
+  integrity sha512-Hn/Gp2iuYzZOkTfyBJXK+r+am78+A/Fkq0QiHXpJai5pgGA07ze6tv2jouPCWKnfXSKStZgTLt1QvvJ9DkojAQ==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2028,10 +2028,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@999.99.9-outlier-and-te.alpha.1":
-  version "999.99.9-outlier-and-te.alpha.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.99.9-outlier-and-te.alpha.1.tgz#0da88a32c3540aaaa8de01942219b2abebd4c89f"
-  integrity sha512-Hn/Gp2iuYzZOkTfyBJXK+r+am78+A/Fkq0QiHXpJai5pgGA07ze6tv2jouPCWKnfXSKStZgTLt1QvvJ9DkojAQ==
+"@dhis2/analytics@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.0.tgz#1d70463fca8a4d5f5838928e9ab6c5c07873715f"
+  integrity sha512-fO8ozVfnTulXQptPcT3W/y+Ru6sN/Qjhr6dWHL4LsG2siL1v8QOWKcnM/yScClJtRZvsbEnQ6vX47c7ujRsGUA==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
### Key features

1. show the loading spinner in dashboard while waiting for analytics data
2. don't allow clearing `maxResults` value

---

### Description

The spinner was never enabled, the fix avoids a blank looking dashboard item when analytics takes some time.

If you were clearing the value for the `maxResults` option, a 400 error was returned from the outlierDetection api because `NaN` was passed as value for the option.
The allowed range is 1-500, the fix makes sure it's not possible to clear the value.

---

### Screenshots

![Screenshot 2024-03-12 at 10 30 52](https://github.com/dhis2/data-visualizer-app/assets/150978/c59685ab-be00-49c3-93ad-66d22eb9e67c)

