### PR TITLE
fix: fix period filter and loading spinner when filtering in dashboard

### DIFF
--- a/src/api/analytics.js
+++ b/src/api/analytics.js
@@ -59,7 +59,11 @@ export const getAnalyticsRequestForOutlierTable = ({
     const headers = []
 
     columns.forEach(({ dimension, items }) => {
-        parameters[dimension] = items.map(({ id }) => id).join(',')
+        // only use the first period, this accommodates for the dashboard filter scenario
+        parameters[dimension] =
+            dimension === DIMENSION_ID_PERIOD
+                ? items[0].id
+                : items.map(({ id }) => id).join(',')
 
         headers.push(forDownload ? dimension : dimensionIdHeaderMap[dimension])
 

--- a/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
+++ b/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
@@ -27,7 +27,10 @@ const VisualizationPluginWrapper = (props) => {
         [pluginProps]
     )
 
-    useEffect(() => setPluginProps(props), [props])
+    useEffect(() => {
+        setIsLoading(true)
+        setPluginProps(props)
+    }, [props])
 
     const onLoadingComplete = () => setIsLoading(false)
 


### PR DESCRIPTION
Part of [DHIS2-13858](https://jira.dhis2.org/browse/DHIS2-13858)

---

### Key features

1. ensure only the 1st item selected for the period is used
2. enable the loading spinner when plugin props change

---

### Description

When applying filters in dashboard, it's possible to select more than 1 item for the period.
Outlier table only allows for 1 period item.
The fix is to always only use the 1st item for the period dimension, otherwise the outlier api returns an error.

When applying a filter in dashboard, the loading spinner of the plugin didn't trigger.
The fix enabled the loading spinner whenever the plugin props are updated, which causes a re-render of the visualization in the plugin.

---

### Screenshots

Period filter before:
<img width="520" alt="Screenshot 2024-03-20 at 13 57 53" src="https://github.com/dhis2/data-visualizer-app/assets/150978/9e660181-3057-4cd7-be93-b1359c21739b">

Period filter after:
<img width="545" alt="Screenshot 2024-03-20 at 13 59 12" src="https://github.com/dhis2/data-visualizer-app/assets/150978/864169a6-c181-4696-a7bc-dcf9c6f1f0e0">

Loading before:
<img width="519" alt="Screenshot 2024-03-20 at 13 58 20" src="https://github.com/dhis2/data-visualizer-app/assets/150978/1e9bc9a6-75c9-4b77-a957-7a7e4cbecb42">

Loading after:
<img width="529" alt="Screenshot 2024-03-20 at 13 59 04" src="https://github.com/dhis2/data-visualizer-app/assets/150978/f3d921ad-69c2-4354-ba3e-71b0c8add6f9">


[DHIS2-13858]: https://dhis2.atlassian.net/browse/DHIS2-13858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ