### PR TITLE
fix: accept displayProperty of both with and without display prefix [v39]

### DIFF
--- a/packages/plugin/src/modules/getRequestOptions.js
+++ b/packages/plugin/src/modules/getRequestOptions.js
@@ -21,9 +21,11 @@ export const getRequestOptions = (visualization, filters, userSettings) => {
     if (userSettings?.displayProperty) {
         switch (userSettings.displayProperty) {
             case 'displayShortName':
+            case 'shortName':
                 options.displayProperty = 'SHORTNAME'
                 break
             case 'displayName':
+            case 'name':
                 options.displayProperty = 'NAME'
                 break
         }


### PR DESCRIPTION
Part of fix for https://dhis2.atlassian.net/browse/DHIS2-12499

The LL and DV plugin treat the `displayProperty` prop differently. LL accepts the value as is, while DV expects it to have the 'display' prefix and then converts it. The result is that displayProperty does not get set for DV for the analytics request. 

Before:
![image](https://github.com/dhis2/data-visualizer-app/assets/6113918/0df40098-c92a-4314-8181-8761524bb8c6)


After: 