### PR TITLE
fix: fix a crash when row totals is enabled (DHIS2-17297)

### DIFF
--- a/cypress/elements/pivotTable.js
+++ b/cypress/elements/pivotTable.js
@@ -1,6 +1,9 @@
 const valueCellEl = 'visualization-value-cell'
 const headerCellEl = 'visualization-column-header'
 
+export const expectTableToBeVisible = () =>
+    cy.get('.pivot-table-container').should('have.length', 1).and('be.visible')
+
 export const clickTableValueCell = (index) =>
     cy.getBySel(valueCellEl).eq(index).click()
 

--- a/cypress/integration/options/totals.cy.js
+++ b/cypress/integration/options/totals.cy.js
@@ -1,0 +1,82 @@
+import {
+    AXIS_ID_COLUMNS,
+    AXIS_ID_ROWS,
+    DIMENSION_ID_DATA,
+    DIMENSION_ID_PERIOD,
+    VIS_TYPE_PIVOT_TABLE,
+    visTypeDisplayNames,
+} from '@dhis2/analytics'
+import { checkCheckbox } from '../../elements/common.js'
+import {
+    clickDimensionModalHideButton,
+    clickDimensionModalUpdateButton,
+    expectDimensionModalToBeVisible,
+    selectAllItemsByButton,
+    selectDataElements,
+    selectFixedPeriods,
+    unselectAllItemsByButton,
+} from '../../elements/dimensionModal/index.js'
+import {
+    clickContextMenuAdd,
+    openContextMenu as openDimPanelContextMenu,
+    openDimension,
+} from '../../elements/dimensionsPanel.js'
+import { clickContextMenuMove, openContextMenu } from '../../elements/layout.js'
+import { openOptionsModal } from '../../elements/menuBar.js'
+import {
+    OPTIONS_TAB_DATA,
+    clickOptionsModalHideButton,
+} from '../../elements/optionsModal/index.js'
+import {
+    colTotalsOptionEl,
+    expectColumnsTotalsToBeChecked,
+} from '../../elements/optionsModal/totals.js'
+import { expectTableToBeVisible } from '../../elements/pivotTable.js'
+import { goToStartPage } from '../../elements/startScreen.js'
+import { changeVisType } from '../../elements/visualizationTypeSelector.js'
+import { TEST_CUSTOM_DIMENSIONS } from '../../utils/data.js'
+
+const AREA_DIMENSION = TEST_CUSTOM_DIMENSIONS.find((dim) => dim.name === 'Area')
+
+describe('Options - Column totals', () => {
+    describe('Regression test for DHIS2-17297', () => {
+        it('does not crash', () => {
+            goToStartPage()
+            changeVisType(visTypeDisplayNames[VIS_TYPE_PIVOT_TABLE])
+
+            openOptionsModal(OPTIONS_TAB_DATA)
+            checkCheckbox(colTotalsOptionEl)
+
+            expectColumnsTotalsToBeChecked()
+
+            clickOptionsModalHideButton()
+
+            openContextMenu(DIMENSION_ID_DATA)
+            clickContextMenuMove(DIMENSION_ID_DATA, AXIS_ID_ROWS)
+            openContextMenu(DIMENSION_ID_PERIOD)
+            clickContextMenuMove(DIMENSION_ID_PERIOD, AXIS_ID_COLUMNS)
+
+            openDimension(DIMENSION_ID_DATA)
+            selectDataElements(['ART enrollment stage 1'])
+            clickDimensionModalHideButton()
+
+            const year = new Date().getFullYear().toString()
+            openDimension(DIMENSION_ID_PERIOD)
+            unselectAllItemsByButton()
+            selectFixedPeriods(
+                [`May ${year}`, `June ${year}`, `July ${year}`],
+                'Monthly'
+            )
+            clickDimensionModalHideButton()
+
+            openDimPanelContextMenu(AREA_DIMENSION.id)
+            clickContextMenuAdd(AREA_DIMENSION.id, AXIS_ID_ROWS)
+            expectDimensionModalToBeVisible(AREA_DIMENSION.id)
+            selectAllItemsByButton()
+
+            clickDimensionModalUpdateButton()
+
+            expectTableToBeVisible()
+        })
+    })
+})

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.6.5",
+        "@dhis2/analytics": "999.99.9-pt-crash-alpha.1",
         "@dhis2/app-runtime": "^3.7.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "999.99.9-pt-crash-alpha.1",
+        "@dhis2/analytics": "^26.6.8",
         "@dhis2/app-runtime": "^3.7.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2028,10 +2028,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.6.5":
-  version "26.6.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.5.tgz#44ee29a279c37f3969096d859bc0f07d953e3f42"
-  integrity sha512-ob6kNEEkIAC50RtKuUZWi8Y04uwsPHK/EiYhzxZkSOdS5wFm8X+88KZrD//fILXQjwMhJvl/4+F/T0qVxOF/jQ==
+"@dhis2/analytics@999.99.9-pt-crash-alpha.1":
+  version "999.99.9-pt-crash-alpha.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.99.9-pt-crash-alpha.1.tgz#2cf63e472899154e88ff581185c75ac92f712080"
+  integrity sha512-KVc269FcWX7Hcu3ZPLEQgqU7W1sgQxwFTB05e4WuuFwFoOx/kNMJVSaucteIU1Se/ImZXHamoNj4Fer1ynL1kA==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2028,10 +2028,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@999.99.9-pt-crash-alpha.1":
-  version "999.99.9-pt-crash-alpha.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.99.9-pt-crash-alpha.1.tgz#2cf63e472899154e88ff581185c75ac92f712080"
-  integrity sha512-KVc269FcWX7Hcu3ZPLEQgqU7W1sgQxwFTB05e4WuuFwFoOx/kNMJVSaucteIU1Se/ImZXHamoNj4Fer1ynL1kA==
+"@dhis2/analytics@^26.6.8":
+  version "26.6.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.8.tgz#859f8086198664a9ea14cea149ce7bdf449a19a2"
+  integrity sha512-9l8001MAx+q8K1Qklui8pfF0rrv3MSLA1dEtM93rBODSsQwRE9pbt5wN44i9+n7nAgc7iItBehAQ1hMJ8j7yHg==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
Implements [DHIS2-17297](https://jira.dhis2.org/browse/DHIS2-17297)

**Requires https://github.com/dhis2/analytics/pull/1660**

---

### Key features

1. the actual fix is in `analytics`

---

### Description

See [the ticket](https://jira.dhis2.org/browse/DHIS2-17297) and the [analytics' PR description](https://github.com/dhis2/analytics/pull/1660).

---

### TODO

-   [x] Cypress tests
-   [x] Manual testing
- [x] Update analytics dep once [this PR](https://github.com/dhis2/analytics/pull/1660) is merged

---

### Screenshots

Before:
<img width="1090" alt="Screenshot 2024-05-02 at 11 45 32" src="https://github.com/dhis2/data-visualizer-app/assets/150978/c3f05235-fc31-4cc0-8d1c-bda2e4b82ada">

After:
<img width="944" alt="Screenshot 2024-05-02 at 11 57 56" src="https://github.com/dhis2/data-visualizer-app/assets/150978/4d8e6b40-c91c-4d46-82d0-57b8e0a052aa">



[DHIS2-17297]: https://dhis2.atlassian.net/browse/DHIS2-17297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ