### PR TITLE
chore: do not run release step on dev branch

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -112,7 +112,7 @@ jobs:
         if: |
             !github.event.push.repository.fork &&
             github.actor != 'dependabot[bot]' &&
-            (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/'))
+            (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
         steps:
             - uses: actions/checkout@v3
               with:


### PR DESCRIPTION
There is no reason to run the release step on the dev branch. Only master and tag builds are needed for bundles.