### PR TITLE
fix: separator for hundreds, thousands and millions is missing in the Pie charts (DHIS2-16172)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-visualizer-app",
-    "version": "100.5.4",
+    "version": "999.9.9-2024-06-11T10-59-05",
     "description": "DHIS2 Data Visualizer",
     "license": "BSD-3-Clause",
     "private": true,
@@ -40,7 +40,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.7.0",
+        "@dhis2/analytics": "^26.7.2",
         "@dhis2/app-runtime": "^3.7.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-visualizer-app",
-    "version": "999.9.9-2024-06-11T10-59-05",
+    "version": "100.5.4",
     "description": "DHIS2 Data Visualizer",
     "license": "BSD-3-Clause",
     "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,10 +2029,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.7.0":
-  version "26.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.7.0.tgz#12d314ad2a84423612ff0eb0e32c191552bd8db8"
-  integrity sha512-7ocy+Ke9fYG40rHsICuH35UgIH+ahAgba9xFea0UbRYUhGavMW90mSVpgCNjE+PlefjR0xuHXB2UHYlTjhEIQw==
+"@dhis2/analytics@^26.7.2":
+  version "26.7.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.7.2.tgz#8c6b80274316a277c19868ffc46a26b46ef71979"
+  integrity sha512-rWVlfn0wOhI1Pwj1L9mxn7P3dfiRJ6TcmMdMh07MdGFlENkch3SnTKGMhI7wxESG7L+xmXE31hWMilFY9GOFbw==
   dependencies:
     "@dhis2/multi-calendar-dates" "1.0.0"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
Implements [DHIS2-16172](https://jira.dhis2.org/browse/DHIS2-16172)

**Requires https://github.com/dhis2/analytics/pull/1677**

---

See Analytics PR for info and screenshots


[DHIS2-16172]: https://dhis2.atlassian.net/browse/DHIS2-16172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ