### PR TITLE
fix: separator for hundreds, thousands and millions is missing in the Pie charts (DHIS2-16172) v39

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24",
+        "@dhis2/analytics": "^24.10.10",
         "@dhis2/app-runtime": "^3.9.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24",
+        "@dhis2/analytics": "^24.10.10",
         "@dhis2/app-runtime": "^3.9.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^8.4.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,10 +2145,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24":
-  version "24.10.9"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.10.9.tgz#9de0f16664693c0c45354d2522444c186606718e"
-  integrity sha512-6GpE1wHNzZ1XE0pBa/sbthFiNLnsA8NUxutUiip0mIlbqshJw8Da0JMszDz+CF4JYU1lg1lcSkrhBWSM4vpDBQ==
+"@dhis2/analytics@^24.10.10":
+  version "24.10.10"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.10.10.tgz#b9d35b9a86afb6634b688eab2f50004f0edeb492"
+  integrity sha512-YNfjUy64eZ9wfepSe/Dr53yYay0tFL8nS+mgwXvU1P2qZM41VDqlvutas5DCNhr2kufCZeD15LC1nQlYQn8Tcg==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
Implements [DHIS2-16172](https://jira.dhis2.org/browse/DHIS2-16172)

**Requires https://github.com/dhis2/analytics/pull/1679**

---

Backport of https://github.com/dhis2/data-visualizer-app/pull/3093 to 39

[DHIS2-16172]: https://dhis2.atlassian.net/browse/DHIS2-16172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ