### PR TITLE
chore: upgrade @dhis2/analytics for scoped pivot table styles v39

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.10.10",
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#418c49ef9961909473b62ac7af878dfed69c43b1",
         "@dhis2/app-runtime": "^3.9.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#418c49ef9961909473b62ac7af878dfed69c43b1",
+        "@dhis2/analytics": "^24.10.11",
         "@dhis2/app-runtime": "^3.9.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#418c49ef9961909473b62ac7af878dfed69c43b1",
+        "@dhis2/analytics": "^24.10.11",
         "@dhis2/app-runtime": "^3.9.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^8.4.11",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.10.10",
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#418c49ef9961909473b62ac7af878dfed69c43b1",
         "@dhis2/app-runtime": "^3.9.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^8.4.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,10 +2145,9 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24.10.10":
+"@dhis2/analytics@git+https://github.com/d2-ci/analytics.git#418c49ef9961909473b62ac7af878dfed69c43b1":
   version "24.10.10"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.10.10.tgz#b9d35b9a86afb6634b688eab2f50004f0edeb492"
-  integrity sha512-YNfjUy64eZ9wfepSe/Dr53yYay0tFL8nS+mgwXvU1P2qZM41VDqlvutas5DCNhr2kufCZeD15LC1nQlYQn8Tcg==
+  resolved "git+https://github.com/d2-ci/analytics.git#418c49ef9961909473b62ac7af878dfed69c43b1"
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     "@dhis2/multi-calendar-dates" "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,9 +2145,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@git+https://github.com/d2-ci/analytics.git#418c49ef9961909473b62ac7af878dfed69c43b1":
-  version "24.10.10"
-  resolved "git+https://github.com/d2-ci/analytics.git#418c49ef9961909473b62ac7af878dfed69c43b1"
+"@dhis2/analytics@^24.10.11":
+  version "24.10.11"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.10.11.tgz#32237c1c5fee150a24cda57d8083a61c294d4d92"
+  integrity sha512-uRnV1/6A+PjREFk/9x1IUsnJUKjXeTm4+ycG4S0NO6Q76ii3mOQu2YYOjWYbGNRs0I4rz1uGhJXdv5ouo0zfKw==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
Implements [DHIS2-14028](https://dhis2.atlassian.net/browse/DHIS2-14028)

### Description

The `PivotTable` in `@dhis2/analytics` no longer has global styles that bleed out of the component. It now uses scoped styles instead, which is much better in general. However, since plugins are in iframes from version 40 onwards, this fix is only required for this v39 branch.

Once this is merged and a new version is released, https://github.com/dhis2/dashboard-app/pull/3014 needs to be updated to use that new version for the data-visualizer-plugin dependency.

---


[DHIS2-14028]: https://dhis2.atlassian.net/browse/DHIS2-14028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ