### PR TITLE
fix: bump analytics with fix for DHIS2-16904

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.7.2",
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#98dfdaae04c20d10adb314ddba3ec9daccb773f3",
         "@dhis2/app-runtime": "^3.7.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,12 +2029,11 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.7.2":
-  version "26.7.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.7.2.tgz#8c6b80274316a277c19868ffc46a26b46ef71979"
-  integrity sha512-rWVlfn0wOhI1Pwj1L9mxn7P3dfiRJ6TcmMdMh07MdGFlENkch3SnTKGMhI7wxESG7L+xmXE31hWMilFY9GOFbw==
+"@dhis2/analytics@git+https://github.com/d2-ci/analytics.git#98dfdaae04c20d10adb314ddba3ec9daccb773f3":
+  version "26.7.4"
+  resolved "git+https://github.com/d2-ci/analytics.git#98dfdaae04c20d10adb314ddba3ec9daccb773f3"
   dependencies:
-    "@dhis2/multi-calendar-dates" "1.0.0"
+    "@dhis2/multi-calendar-dates" "^1.2.1"
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^7.0.2"
     "@dnd-kit/utilities" "^3.2.1"
@@ -2246,13 +2245,14 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/multi-calendar-dates@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0.tgz#bf7f49aecdffa9781837a5d60d56a094b74ab4df"
-  integrity sha512-IB9a+feuS6yE4lpZj/eZ9uBmpYI7Hxitl2Op0JjoRL4tP+p6uw4ns9cjoSdUeIU9sOAxVZV7oQqSyIw+9P6YjQ==
+"@dhis2/d2-i18n@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.1.3.tgz#ad73030f7cfceeed1b5bcaad86a9b336130bdfb1"
+  integrity sha512-vOu6RDNumOJM396mHt35bETk9ai9b6XJyAwlUy1HstUZNvfET61F8rjCmMuXZU6zJ8ELux8kMFqlH8IG0vDJmA==
   dependencies:
-    "@js-temporal/polyfill" "^0.4.2"
-    classnames "^2.3.2"
+    "@types/i18next" "^11.9.0"
+    i18next "^10.3"
+    moment "^2.24.0"
 
 "@dhis2/multi-calendar-dates@^1.1.1":
   version "1.1.1"
@@ -2260,6 +2260,15 @@
   integrity sha512-kaisVuRGfdqY/Up6sWqgc81K67ymPVoRYgYRcT29z61ol2WhiTXTSTuRX/gDO1VKjmskeB5/badRrdLMf4BBUA==
   dependencies:
     "@js-temporal/polyfill" "^0.4.2"
+    classnames "^2.3.2"
+
+"@dhis2/multi-calendar-dates@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.2.1.tgz#d31ac037302879ae624d72d2373ac455b7e357e8"
+  integrity sha512-lIYwpDbHXKnquvkMDuT2E+V/MwjPDIPIfLi9xfWq5SkuZE3zSl0g65echWYySeZ7EzgRhrtYwA3nuWwuGfcV5Q==
+  dependencies:
+    "@dhis2/d2-i18n" "^1.1.3"
+    "@js-temporal/polyfill" "0.4.3"
     classnames "^2.3.2"
 
 "@dhis2/prop-types@^3.1.2":
@@ -2817,7 +2826,7 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@js-temporal/polyfill@^0.4.2":
+"@js-temporal/polyfill@0.4.3", "@js-temporal/polyfill@^0.4.2":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.4.3.tgz#e8f8cf86745eb5050679c46a5ebedb9a9cc1f09b"
   integrity sha512-6Fmjo/HlkyVCmJzAPnvtEWlcbQUSRhi8qlN9EtJA/wP7FqXsevLLrlojR44kzNzrRkpf7eDJ+z7b4xQD/Ycypw==
@@ -3369,6 +3378,11 @@
   integrity sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==
   dependencies:
     "@types/node" "*"
+
+"@types/i18next@^11.9.0":
+  version "11.9.3"
+  resolved "https://registry.yarnpkg.com/@types/i18next/-/i18next-11.9.3.tgz#04d84c6539908ad69665d26d8967f942d1638550"
+  integrity sha512-snM7bMKy6gt7UYdpjsxycqSCAy0fr2JVPY0B8tJ2vp9bN58cE7C880k20PWFM4KXxQ3KsstKM8DLCawGCIH0tg==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"


### PR DESCRIPTION
Part of the fix for [DHIS2-16904](https://jira.dhis2.org/browse/DHIS2-16904)

**Requires https://github.com/dhis2/analytics/pull/1685**

---

### Key features

1. bump `analytics` dependency

---

### Description

The actual fix is in `@dhis2/multi-calendar-dates` which is a dependency of `analytics` and it's used in the `PeriodSelector` component the analytics apps use.

---

### TODO

-   [ ] Cypress tests
-   [ ] Update docs
-   [ ] Manual testing
-   [ ] _task_

---

### Known issues

-   [ ] even after the update, the translations don't show up

---

### Screenshots

Translations don't work for week/bi-week:
<img width="802" alt="Screenshot 2024-06-24 at 16 03 35" src="https://github.com/dhis2/data-visualizer-app/assets/150978/38f73799-c613-489d-abef-f0f817fb3f8d">


