### PR TITLE
chore: resolve to @dhis2/ui 9.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
         "whatwg-fetch": "^3.6.2"
     },
     "resolutions": {
-        "@dhis2/ui": "^9.2.0"
+        "@dhis2/ui": "^9.4.4"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,7 +2304,7 @@
   resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-9.4.4.tgz#c4f488496389687ebd47266e93e0aacf27054ef3"
   integrity sha512-AGt+aYqpqb7f/2IH5quZ1bJoSz/WB3p7I1CdZHUPk/XP6rQpO2W7mqoLxiZYOHCiNlTU+sjfXcYauHaWZSTdjw==
 
-"@dhis2/ui@^8.12.3", "@dhis2/ui@^9.2.0", "@dhis2/ui@^9.4.4":
+"@dhis2/ui@^8.12.3", "@dhis2/ui@^9.4.4":
   version "9.4.4"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-9.4.4.tgz#ae7961d42753d72e209f7d11b160b3179e6a6452"
   integrity sha512-w1NMZy/S5tNbXGt7F5J5OM1P8qgq1Bo1ifV34YV3Cs+8rJYkHHsFOokUN+wSTdXUWqIKxOGrRoQkmgmjQ19WlA==


### PR DESCRIPTION
The version mentioned in the resolutions was lower than the one in the dependencies. This was unintentional.