### PR TITLE
fix: show error UI when plugin has empty rows [DHIS2-16793]

### DIFF
--- a/src/components/Visualization/StartScreen.js
+++ b/src/components/Visualization/StartScreen.js
@@ -7,13 +7,12 @@ import React, { useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import { apiFetchMostViewedVisualizations } from '../../api/mostViewedVisualizations.js'
 import { apiFetchVisualizations } from '../../api/visualization.js'
-import { GenericError } from '../../assets/ErrorIcons.js'
-import { VisualizationError, genericErrorTitle } from '../../modules/error.js'
 import history from '../../modules/history.js'
 import { sGetLoadError } from '../../reducers/loader.js'
 import { sGetUsername } from '../../reducers/user.js'
 import styles from './styles/StartScreen.module.css'
 import { matchVisualizationWithType } from './utils.js'
+import { VisualizationErrorInfo } from './VisualizationErrorInfo.js'
 
 const StartScreen = ({ error, username }) => {
     const [mostViewedVisualizations, setMostViewedVisualizations] = useState([])
@@ -44,7 +43,7 @@ const StartScreen = ({ error, username }) => {
 
     const getContent = () =>
         error ? (
-            getErrorContent()
+            <VisualizationErrorInfo error={error} />
         ) : (
             <div
                 data-test="start-screen"
@@ -107,31 +106,6 @@ const StartScreen = ({ error, username }) => {
                 )}
             </div>
         )
-
-    const getErrorContent = () => (
-        <div
-            className={styles.errorContainer}
-            data-test="start-screen-error-container"
-        >
-            {error instanceof VisualizationError ? (
-                <>
-                    <div className={styles.errorIcon}>{error.icon()}</div>
-                    <p className={styles.errorTitle}>{error.title}</p>
-                    <p className={styles.errorDescription}>
-                        {error.description}
-                    </p>
-                </>
-            ) : (
-                <>
-                    <div className={styles.errorIcon}>{GenericError()}</div>
-                    <p className={styles.errorTitle}>{genericErrorTitle}</p>
-                    <p className={styles.errorDescription}>
-                        {error.message || error}
-                    </p>
-                </>
-            )}
-        </div>
-    )
 
     return (
         <div className={styles.outer}>

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -1,8 +1,4 @@
-import {
-    DIMENSION_ID_DATA,
-    VIS_TYPE_OUTLIER_TABLE,
-    VIS_TYPE_PIVOT_TABLE,
-} from '@dhis2/analytics'
+import { DIMENSION_ID_DATA, VIS_TYPE_PIVOT_TABLE } from '@dhis2/analytics'
 import debounce from 'lodash-es/debounce'
 import PropTypes from 'prop-types'
 import React, { Component, Fragment } from 'react'
@@ -16,10 +12,10 @@ import {
     acSetUiDataSorting,
     acAddParentGraphMap,
 } from '../../actions/ui.js'
+import { ensureAnalyticsResponsesContainData } from '../../modules/analytics.js'
 import {
     AssignedCategoriesDataElementsError,
     GenericServerError,
-    EmptyResponseError,
     AssignedCategoriesAsFilterError,
     MultipleIndicatorAsFilterError,
     NoDataOrDataElementGroupSetError,
@@ -29,7 +25,6 @@ import {
     ValueTypeError,
     AnalyticsGenerationError,
     AnalyticsRequestError,
-    NoOutliersError,
 } from '../../modules/error.js'
 import { removeLastPathSegment } from '../../modules/orgUnit.js'
 import { sGetCurrent } from '../../reducers/current.js'
@@ -144,15 +139,10 @@ export class UnconnectedVisualization extends Component {
 
         this.props.addMetadata(forMetadata)
 
-        if (
-            !responses.some((response) => response.rows && response.rows.length)
-        ) {
-            if (this.props.visualization.type === VIS_TYPE_OUTLIER_TABLE) {
-                throw new NoOutliersError()
-            }
-
-            throw new EmptyResponseError()
-        }
+        ensureAnalyticsResponsesContainData(
+            responses,
+            this.props.visualization.type
+        )
     }
 
     onDrill = (drillData) => {

--- a/src/components/Visualization/VisualizationErrorInfo.js
+++ b/src/components/Visualization/VisualizationErrorInfo.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { GenericError } from '../../assets/ErrorIcons.js'
+import { VisualizationError, genericErrorTitle } from '../../modules/error.js'
+import styles from './styles/VisualizationErrorInfo.module.css'
+
+export const VisualizationErrorInfo = ({ error }) => (
+    <div
+        className={styles.errorContainer}
+        data-test="start-screen-error-container"
+    >
+        {error instanceof VisualizationError ? (
+            <>
+                <div className={styles.errorIcon}>{error.icon()}</div>
+                <p className={styles.errorTitle}>{error.title}</p>
+                <p className={styles.errorDescription}>{error.description}</p>
+            </>
+        ) : (
+            <>
+                <div className={styles.errorIcon}>{GenericError()}</div>
+                <p className={styles.errorTitle}>{genericErrorTitle}</p>
+                <p className={styles.errorDescription}>
+                    {error.message || error}
+                </p>
+            </>
+        )}
+    </div>
+)
+
+VisualizationErrorInfo.propTypes = {
+    error: PropTypes.oneOfType([
+        PropTypes.instanceOf(Error),
+        PropTypes.instanceOf(VisualizationError),
+    ]),
+}

--- a/src/components/Visualization/styles/StartScreen.module.css
+++ b/src/components/Visualization/styles/StartScreen.module.css
@@ -16,43 +16,6 @@
     display: flex;
     align-items: center;
 }
-.errorContainer {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-}
-.errorIcon {
-    inline-size: 136px;
-    block-size: 136px;
-    margin-block-start: 0;
-    margin-block-end: var(--spacers-dp24);
-    margin-inline-start: auto;
-    margin-inline-end: auto;
-}
-.errorTitle {
-    font-weight: 500;
-    font-size: 20px;
-    color: var(--colors-grey800);
-    letter-spacing: 0.15px;
-    line-height: 24px;
-    inline-size: 360px;
-    margin-block-start: 0;
-    margin-block-end: var(--spacers-dp12);
-    margin-inline-start: auto;
-    margin-inline-end: auto;
-}
-.errorDescription {
-    font-weight: 400;
-    font-size: 14px;
-    color: var(--colors-grey700);
-    line-height: 19px;
-    inline-size: 360px;
-    margin-block-start: 0;
-    margin-block-end: 0;
-    margin-inline-start: auto;
-    margin-inline-end: auto;
-}
 .title {
     font-weight: 500;
     font-size: 17px;

--- a/src/components/Visualization/styles/VisualizationErrorInfo.module.css
+++ b/src/components/Visualization/styles/VisualizationErrorInfo.module.css
@@ -4,11 +4,11 @@
     align-items: center;
     text-align: center;
     justify-content: center;
-    width: 100%;
+    inline-size: 100%;
 }
 .errorIcon {
-    width: 136px;
-    height: 136px;
+    inline-size: 136px;
+    block-size: 136px;
     margin-block-start: 0;
     margin-block-end: var(--spacers-dp24);
     margin-inline-start: auto;

--- a/src/components/Visualization/styles/VisualizationErrorInfo.module.css
+++ b/src/components/Visualization/styles/VisualizationErrorInfo.module.css
@@ -1,0 +1,30 @@
+.errorContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    justify-content: center;
+    width: 100%;
+}
+.errorIcon {
+    width: 136px;
+    height: 136px;
+    margin: 0 auto var(--spacers-dp24);
+}
+.errorTitle {
+    font-weight: 500;
+    font-size: 20px;
+    color: var(--colors-grey800);
+    letter-spacing: 0.15px;
+    line-height: 24px;
+    width: 360px;
+    margin: 0 auto var(--spacers-dp12);
+}
+.errorDescription {
+    font-weight: 400;
+    font-size: 14px;
+    color: var(--colors-grey700);
+    line-height: 19px;
+    width: 360px;
+    margin: 0 auto;
+}

--- a/src/components/Visualization/styles/VisualizationErrorInfo.module.css
+++ b/src/components/Visualization/styles/VisualizationErrorInfo.module.css
@@ -9,7 +9,10 @@
 .errorIcon {
     width: 136px;
     height: 136px;
-    margin: 0 auto var(--spacers-dp24);
+    margin-block-start: 0;
+    margin-block-end: var(--spacers-dp24);
+    margin-inline-start: auto;
+    margin-inline-end: auto;
 }
 .errorTitle {
     font-weight: 500;
@@ -17,14 +20,20 @@
     color: var(--colors-grey800);
     letter-spacing: 0.15px;
     line-height: 24px;
-    width: 360px;
-    margin: 0 auto var(--spacers-dp12);
+    inline-size: 360px;
+    margin-block-start: 0;
+    margin-block-end: var(--spacers-dp12);
+    margin-inline-start: auto;
+    margin-inline-end: auto;
 }
 .errorDescription {
     font-weight: 400;
     font-size: 14px;
     color: var(--colors-grey700);
     line-height: 19px;
-    width: 360px;
-    margin: 0 auto;
+    inline-size: 360px;
+    margin-block-start: 0;
+    margin-block-end: 0;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
 }

--- a/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
+++ b/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
@@ -1,12 +1,15 @@
 import { CenteredContent, CircularLoader, ComponentCover } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useState } from 'react'
+import { ensureAnalyticsResponsesContainData } from '../../modules/analytics.js'
+import { VisualizationErrorInfo } from '../Visualization/VisualizationErrorInfo.js'
 import { VisualizationPlugin } from '../VisualizationPlugin/VisualizationPlugin.js'
 
 // handle internal state for features that need to work without the app's Redux store
 const VisualizationPluginWrapper = (props) => {
     const [pluginProps, setPluginProps] = useState(props)
     const [isLoading, setIsLoading] = useState(true)
+    const [error, setError] = useState(null)
 
     const onDataSorted = useCallback(
         (sorting) => {
@@ -64,6 +67,23 @@ const VisualizationPluginWrapper = (props) => {
 
     const onLoadingComplete = () => setIsLoading(false)
 
+    const onResponsesReceived = useCallback(
+        (responses) => {
+            try {
+                ensureAnalyticsResponsesContainData(
+                    responses,
+                    props.visualization.type
+                )
+            } catch (error) {
+                setError(error)
+            }
+        },
+        [props.visualization.type]
+    )
+
+    if (error) {
+        return <VisualizationErrorInfo error={error} />
+    }
     return (
         <>
             {isLoading && (
@@ -77,6 +97,7 @@ const VisualizationPluginWrapper = (props) => {
                 {...pluginProps}
                 onDataSorted={onDataSorted}
                 onLoadingComplete={onLoadingComplete}
+                onResponsesReceived={onResponsesReceived}
             />
         </>
     )

--- a/src/modules/analytics.js
+++ b/src/modules/analytics.js
@@ -6,8 +6,10 @@ import {
     DIMENSION_ID_PERIOD,
     WEEKLY,
     DAILY,
+    VIS_TYPE_OUTLIER_TABLE,
 } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
+import { EmptyResponseError, NoOutliersError } from './error.js'
 
 export const outlierTableHeadersMap = {
     [DIMENSION_ID_DATA]: 'dxname',
@@ -279,5 +281,21 @@ export const getRelativePeriodTypeUsed = (periodItems) => {
             .find((period) => period.id === periodItems[0].id)
     ) {
         return DAILY
+    }
+}
+
+export const ensureAnalyticsResponsesContainData = (
+    responses,
+    visualizationType
+) => {
+    const hasPopulatedRows = responses.some(
+        (response) => response.rows && response.rows.length > 0
+    )
+    if (!hasPopulatedRows) {
+        if (visualizationType === VIS_TYPE_OUTLIER_TABLE) {
+            throw new NoOutliersError()
+        }
+
+        throw new EmptyResponseError()
     }
 }


### PR DESCRIPTION
Implements [DHIS2-16793](https://jira.dhis2.org/browse/DHIS2-16793)

---

### Key features

1. Adds some validation to the plugin wrapper so that it won't attempt to render a visualization when there is no data

---

### Description

The key feature needs no further explanation but there are some things to take into consideration about the implementation:

- The JIRA issue mentions a bug in the `PivotTable` component, and this is indeed where the error is thrown. However, this is really going wrong at an earlier stage: the filter condition has caused the rows to be empty, and really the plugin shouldn't have rendered the `PivotTable` in the first place, but some sort of info/error screen instead. So this is what I have addressed, and I have ignored the bug in the `PivotTable`. I am not sure we need to address this one.
- The most common way to render these types of error views is using an `ErrorBoundary` component. I tried to implement things using one, but struggled to get this to work: somehow the `onComponentDidCatch` hook never got triggered. When I realised that a solution without an `ErrorBoundary` was very simple (less code and no complexity), more in line with the implementation in `StartScreen`, and worked at the first attempt, I decided to stick with that.
- **THIS PR CHANGES THE "NO-DATA" ON A DASHBOARD BEHAVIOUR OF ALL VISUALIZATION TYPES  AND WE NEED TO CHECK IF THIS WHAT WE WANT**

---

### TODO

-   [x] Manual testing (I don't think an e2e test is possible)
-   [ ] Verify if manual test method is correct and sufficiently covers all use cases
-   [ ] Verify if all changes are as intended

---

### Steps I took to test and illustrate the generic changes

1. I created a dashboard with the following content:
    1. **Chart**: ANC: 1-3 trend lines last 12 months
    2. **Pivot Table**: ANC: ANC 1st and 2nd visits at facilities with hierarchy
    3. **Single Value**: BCG coverage last 12 months - Bo
2. I then applied a filter filter for a future period (january 2025) to that dashboard to force missing data. I then took a screenshot.
3. I visited the data visualizer app and opened each of the visualisations above. For each one I changed the period dimension to the same future period I used on the dashboard filter and I then took a screenshot.
4. I then installed a custom DV version, built from the current PR branch, and repeated step 2 & 3.

Below I will illustrate the outcome:

Dashboard view with missing data with BEFORE the changes:
<img width="1714" alt="current_dashboard" src="https://github.com/user-attachments/assets/6533ece8-d855-440b-aefd-2ad0c005a3bb">

Dashboard view with missing data with AFTER the changes:
<img width="1729" alt="after_dashboard" src="https://github.com/user-attachments/assets/6d1d377e-93d9-409e-9a6a-f89c2ed2499e">

Data Visualizer views with no data (the was no change between BEFORE and AFTER):
**Chart**: ANC: 1-3 trend lines last 12 months
<img width="1731" alt="current_chart" src="https://github.com/user-attachments/assets/02e58928-e585-4a3c-a524-6af2e6a6c5e8">

**Pivot Table**: ANC: ANC 1st and 2nd visits at facilities with hierarchy
<img width="1730" alt="current_pivot_table" src="https://github.com/user-attachments/assets/57cbbf23-4409-4be8-99ac-ef02f0202842">

**Single Value**: BCG coverage last 12 months - Bo
<img width="1731" alt="current_single_value" src="https://github.com/user-attachments/assets/e14511c6-2893-4c08-bfeb-012b109169b2">

So my current thinking is that we want these generic changes, because we want the consistency between the behaviour of app VS plugin. But I could be wrong. Specifically I am not 100% sure if "applying a filter on a dashboard" and "changing a dimension in DV" are the same type of thing / should result in the same UI....

### Bugfix reproduction

I also took some steps to reproduce the bug described in [DHIS2-16793](https://jira.dhis2.org/browse/DHIS2-16793) and this resulted in the following screenshot which confirms the bug is indeed gone.

<img width="1120" alt="Screenshot 2024-07-01 at 10 47 18" src="https://github.com/dhis2/data-visualizer-app/assets/353236/0a161fd4-583e-4a17-ba74-d3db4d5796f8">

[DHIS2-16793]: https://dhis2.atlassian.net/browse/DHIS2-16793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ