### PR TITLE
fix: apply grab cursor to assigned categories dimension item

### DIFF
--- a/src/components/DimensionsPanel/DndDimensionItem.js
+++ b/src/components/DimensionsPanel/DndDimensionItem.js
@@ -1,4 +1,7 @@
-import { DimensionItem } from '@dhis2/analytics'
+import {
+    DimensionItem,
+    DIMENSION_ID_ASSIGNED_CATEGORIES,
+} from '@dhis2/analytics'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -45,7 +48,8 @@ export class DndDimensionItem extends Component {
                             className={cx({
                                 [styles.dragging]: snapshot.isDragging,
                                 [styles.notDragging]: !snapshot.isDragging,
-                                [styles.assignedCategories]: id === 'co',
+                                [styles.assignedCategories]:
+                                    id === DIMENSION_ID_ASSIGNED_CATEGORIES,
                             })}
                             onClick={onClick}
                             onOptionsClick={onOptionsClick}

--- a/src/components/DimensionsPanel/DndDimensionItem.js
+++ b/src/components/DimensionsPanel/DndDimensionItem.js
@@ -1,4 +1,5 @@
 import { DimensionItem } from '@dhis2/analytics'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Draggable } from 'react-beautiful-dnd'
@@ -41,11 +42,11 @@ export class DndDimensionItem extends Component {
                             innerRef={provided.innerRef}
                             {...provided.draggableProps}
                             {...provided.dragHandleProps}
-                            className={
-                                snapshot.isDragging
-                                    ? styles.dragging
-                                    : styles.notDragging
-                            }
+                            className={cx({
+                                [styles.dragging]: snapshot.isDragging,
+                                [styles.notDragging]: !snapshot.isDragging,
+                                [styles.assignedCategories]: id === 'co',
+                            })}
                             onClick={onClick}
                             onOptionsClick={onOptionsClick}
                             {...itemCommonProps}

--- a/src/components/DimensionsPanel/styles/DndDimensionItem.module.css
+++ b/src/components/DimensionsPanel/styles/DndDimensionItem.module.css
@@ -1,5 +1,5 @@
 /*
-This keeps the dimension item clone from causing 
+This keeps the dimension item clone from causing
 a ripple effect in the Dimension list during drag
 */
 
@@ -10,4 +10,7 @@ a ripple effect in the Dimension list during drag
 .dragging {
     background-color: #e8edf2;
     border-radius: 2px;
+}
+.assignedCategories {
+    cursor: grab !important;
 }

--- a/src/components/DimensionsPanel/styles/DndDimensionItem.module.css
+++ b/src/components/DimensionsPanel/styles/DndDimensionItem.module.css
@@ -11,6 +11,9 @@ a ripple effect in the Dimension list during drag
     background-color: #e8edf2;
     border-radius: 2px;
 }
-.assignedCategories {
-    cursor: grab !important;
+:global(.item).assignedCategories {
+    cursor: grab;
+}
+:global(.item.selected).assignedCategories {
+    cursor: default;
 }

--- a/src/components/Layout/Chip.js
+++ b/src/components/Layout/Chip.js
@@ -189,7 +189,8 @@ const Chip = ({
                         dimensionId,
                         DIMENSION_PROP_NO_ITEMS
                     ) && !items.length,
-                [styles.assignedCategories]: dimensionId === 'co',
+                [styles.assignedCategories]:
+                    dimensionId === DIMENSION_ID_ASSIGNED_CATEGORIES,
             })}
             data-dimensionid={dimensionId}
             draggable={!isLocked}

--- a/src/components/Layout/Chip.js
+++ b/src/components/Layout/Chip.js
@@ -189,6 +189,7 @@ const Chip = ({
                         dimensionId,
                         DIMENSION_PROP_NO_ITEMS
                     ) && !items.length,
+                [styles.assignedCategories]: dimensionId === 'co',
             })}
             data-dimensionid={dimensionId}
             draggable={!isLocked}

--- a/src/components/Layout/styles/Chip.module.css
+++ b/src/components/Layout/styles/Chip.module.css
@@ -25,7 +25,7 @@
 }
 
 .chip.assignedCategories {
-    cursor: grab !important;
+    cursor: grab;
 }
 
 .chipEmpty {

--- a/src/components/Layout/styles/Chip.module.css
+++ b/src/components/Layout/styles/Chip.module.css
@@ -24,6 +24,10 @@
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 }
 
+.chip.assignedCategories {
+    cursor: grab !important;
+}
+
 .chipEmpty {
     background-color: var(--colors-grey100);
     border-color: var(--colors-grey400);


### PR DESCRIPTION
Implements [DHIS2-15140](https://dhis2.atlassian.net/browse/DHIS2-15140)

---

### Key features

1. Updates cursor style for assigned categories dimension item

---

### Screenshots

| When/where | Style rule | Screenshot |
| ------------- | ------------- | ------------- |
| Sidebar unselected  | `cursor: grab;`  | <img width="243" alt="sidebar_unselected" src="https://github.com/user-attachments/assets/4d01e9c6-4470-478d-92a9-3c2ea849c4c8"> | 
| Sidebar selected  | `cursor: default;`  | <img width="247" alt="sidebar_selected" src="https://github.com/user-attachments/assets/dd53b60d-b119-4d6c-b6fa-9fd61e77f454"> | 
| Layout  | `cursor: grab;`  | <img width="238" alt="layout" src="https://github.com/user-attachments/assets/83c7ed42-9fef-4aa1-90b6-bddfa3afb44a"> | 



[DHIS2-15140]: https://dhis2.atlassian.net/browse/DHIS2-15140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ