### PR TITLE
fix: sort analytics request params and items for cache hit optimization (DHIS2-17861)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.8.0",
+        "@dhis2/analytics": "^26.8.1",
         "@dhis2/app-runtime": "^3.7.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,10 +2029,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.8.0":
-  version "26.8.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.8.0.tgz#8e8383feef65a4f64b094077fd284af1151ad2b5"
-  integrity sha512-P8mHq1AV5RoXJQZYxzjl3vRRUIlZzLoKpkUVTn/5Ww+Z/Y3smY9YHdOceHK+9ERF1XqZyRhlCLxN8M56u+jR+g==
+"@dhis2/analytics@^26.8.1":
+  version "26.8.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.8.1.tgz#ad72b326e92f0440a0280fc223ff0b85483eac5f"
+  integrity sha512-0y2RMlP1VucSaKCSGIsY4EwYmg6dg3ig765j7StOhbgT6wbRnE32VrQibG/sElGN3jwGf58frIGntEXdqGbjuw==
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
Implements [DHIS2-17861](https://jira.dhis2.org/browse/DHIS2-17861)

**Requires https://github.com/dhis2/analytics/pull/1695**



[DHIS2-17861]: https://dhis2.atlassian.net/browse/DHIS2-17861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ