### PR TITLE
feat: add subtitle field to pivot table options [DHIS2-16158]

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -42,34 +42,34 @@ async function setupNodeEvents(on, config) {
 
 module.exports = defineConfig({
     projectId: 'sojh88',
-    reporter: '@reportportal/agent-js-cypress',
-    reporterOptions: {
-        endpoint: process.env.REPORTPORTAL_ENDPOINT,
-        apiKey: process.env.REPORTPORTAL_API_KEY,
-        launch: 'data_visualizer_app',
-        project: process.env.REPORTPORTAL_PROJECT,
-        description: '',
-        autoMerge: true,
-        parallel: true,
-        debug: false,
-        restClientConfig: {
-            timeout: 660000,
-        },
-        attributes: [
-            {
-                key: 'version',
-                value: 'master',
-            },
-            {
-                key: 'app_name',
-                value: 'data_visualizer_app',
-            },
-            {
-                key: 'test_level',
-                value: 'e2e',
-            },
-        ],
-    },
+    // reporter: '@reportportal/agent-js-cypress',
+    // reporterOptions: {
+    //     endpoint: process.env.REPORTPORTAL_ENDPOINT,
+    //     apiKey: process.env.REPORTPORTAL_API_KEY,
+    //     launch: 'data_visualizer_app',
+    //     project: process.env.REPORTPORTAL_PROJECT,
+    //     description: '',
+    //     autoMerge: true,
+    //     parallel: true,
+    //     debug: false,
+    //     restClientConfig: {
+    //         timeout: 660000,
+    //     },
+    //     attributes: [
+    //         {
+    //             key: 'version',
+    //             value: 'master',
+    //         },
+    //         {
+    //             key: 'app_name',
+    //             value: 'data_visualizer_app',
+    //         },
+    //         {
+    //             key: 'test_level',
+    //             value: 'e2e',
+    //         },
+    //     ],
+    // },
     e2e: {
         setupNodeEvents,
         baseUrl: 'http://localhost:3000',

--- a/src/components/VisualizationOptions/Options/Subtitle.js
+++ b/src/components/VisualizationOptions/Options/Subtitle.js
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { TextBaseOption } from './TextBaseOption.js'
 
-const Subtitle = ({ dataTest }) => (
+const Subtitle = ({ dataTest, label }) => (
     <TextBaseOption
         type="text"
         width="280px"
         placeholder={i18n.t('Add a subtitle')}
+        label={label}
         option={{
             name: 'subtitle',
         }}
@@ -15,8 +16,13 @@ const Subtitle = ({ dataTest }) => (
     />
 )
 
+Subtitle.defaultProps = {
+    dataTest: 'visualization-option-subtitle',
+}
+
 Subtitle.propTypes = {
     dataTest: PropTypes.string,
+    label: PropTypes.string,
 }
 
 export default Subtitle

--- a/src/modules/options/pivotTableConfig.js
+++ b/src/modules/options/pivotTableConfig.js
@@ -26,6 +26,7 @@ import ShowDimensionLabels from '../../components/VisualizationOptions/Options/S
 import ShowHierarchy from '../../components/VisualizationOptions/Options/ShowHierarchy.js'
 import SkipRounding from '../../components/VisualizationOptions/Options/SkipRounding.js'
 import SortOrder from '../../components/VisualizationOptions/Options/SortOrder.js'
+import Subtitle from '../../components/VisualizationOptions/Options/Subtitle.js'
 import Title from '../../components/VisualizationOptions/Options/Title.js'
 import TopLimit from '../../components/VisualizationOptions/Options/TopLimit.js'
 import getAdvancedTemplate from './sections/templates/advanced.js'
@@ -82,6 +83,7 @@ export default ({
             key: 'style-section-1',
             content: React.Children.toArray([
                 <Title label={i18n.t('Table title')} />,
+                <Subtitle dataTest="pivot-table-subtitle" />,
                 <DisplayDensity />,
                 <FontSize />,
                 <DigitGroupSeparator />,

--- a/src/modules/options/pivotTableConfig.js
+++ b/src/modules/options/pivotTableConfig.js
@@ -83,7 +83,7 @@ export default ({
             key: 'style-section-1',
             content: React.Children.toArray([
                 <Title label={i18n.t('Table title')} />,
-                <Subtitle dataTest="pivot-table-subtitle" />,
+                <Subtitle label={i18n.t('Table subtitle')} />,
                 <DisplayDensity />,
                 <FontSize />,
                 <DigitGroupSeparator />,


### PR DESCRIPTION
Implements [DHIS2-16158](https://dhis2.atlassian.net/browse/DHIS2-16158)

---

### Key features

1. Adds subtitle field to pivot table style options

---

### Description

On the style tab of the pivot table options, a user can now set a subtitle as well as a title (title was already implemented). I have verified that the subtitle is displayed in the pivot table correctly, and it is persisted correctly too.

---

### Known issues

-   There is no Cypress test for this new feature. I decided not to add one, because hardly any of these options are tested. For example, the title is not tested either. So I assumed that at some point we must have decided that tests for these options are not required.

---

### Screenshots

Option modal:
<img width="816" alt="Screenshot 2024-08-20 at 11 14 52" src="https://github.com/user-attachments/assets/695a0ded-a234-4444-bfa8-ae1e485b42b5">

Pivot table:
<img width="773" alt="Screenshot 2024-08-20 at 11 15 15" src="https://github.com/user-attachments/assets/14946084-7f0b-4f22-9a18-bb3ba2b7863a">


[DHIS2-16158]: https://dhis2.atlassian.net/browse/DHIS2-16158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ