### PR TITLE
chore: restore report-portal config

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -42,34 +42,34 @@ async function setupNodeEvents(on, config) {
 
 module.exports = defineConfig({
     projectId: 'sojh88',
-    // reporter: '@reportportal/agent-js-cypress',
-    // reporterOptions: {
-    //     endpoint: process.env.REPORTPORTAL_ENDPOINT,
-    //     apiKey: process.env.REPORTPORTAL_API_KEY,
-    //     launch: 'data_visualizer_app',
-    //     project: process.env.REPORTPORTAL_PROJECT,
-    //     description: '',
-    //     autoMerge: true,
-    //     parallel: true,
-    //     debug: false,
-    //     restClientConfig: {
-    //         timeout: 660000,
-    //     },
-    //     attributes: [
-    //         {
-    //             key: 'version',
-    //             value: 'master',
-    //         },
-    //         {
-    //             key: 'app_name',
-    //             value: 'data_visualizer_app',
-    //         },
-    //         {
-    //             key: 'test_level',
-    //             value: 'e2e',
-    //         },
-    //     ],
-    // },
+    reporter: '@reportportal/agent-js-cypress',
+    reporterOptions: {
+        endpoint: process.env.REPORTPORTAL_ENDPOINT,
+        apiKey: process.env.REPORTPORTAL_API_KEY,
+        launch: 'data_visualizer_app',
+        project: process.env.REPORTPORTAL_PROJECT,
+        description: '',
+        autoMerge: true,
+        parallel: true,
+        debug: false,
+        restClientConfig: {
+            timeout: 660000,
+        },
+        attributes: [
+            {
+                key: 'version',
+                value: 'master',
+            },
+            {
+                key: 'app_name',
+                value: 'data_visualizer_app',
+            },
+            {
+                key: 'test_level',
+                value: 'e2e',
+            },
+        ],
+    },
     e2e: {
         setupNodeEvents,
         baseUrl: 'http://localhost:3000',


### PR DESCRIPTION
This PR restores the report portal config, which I disabled in https://github.com/dhis2/data-visualizer-app/pull/3178/commits/ef849d22c610389c8cc05cb8348672b91c08ed38 and accidentally merged into master with https://github.com/dhis2/data-visualizer-app/pull/3178