### PR TITLE
fix: fetch icon with credentials

### DIFF
--- a/src/components/VisualizationPlugin/VisualizationPlugin.js
+++ b/src/components/VisualizationPlugin/VisualizationPlugin.js
@@ -207,10 +207,15 @@ export const VisualizationPlugin = ({
                 dxIds[0] &&
                 responses[0].metaData.items[dxIds[0]]?.style?.icon
             ) {
-                const dxIconResponse = await fetch(
+                const originalIcon = await fetch(
                     responses[0].metaData.items[dxIds[0]].style.icon
-                )
-                const originalIcon = await dxIconResponse.text()
+                ).then((dxIconResponse) => {
+                    if (dxIconResponse.status !== 200) {
+                        return '<svg></svg>'
+                    } else {
+                        return dxIconResponse.text()
+                    }
+                })
 
                 // This allows for color override of the icon using the parent color
                 // needed when a legend color or contrast color is applied

--- a/src/components/VisualizationPlugin/VisualizationPlugin.js
+++ b/src/components/VisualizationPlugin/VisualizationPlugin.js
@@ -208,7 +208,8 @@ export const VisualizationPlugin = ({
                 responses[0].metaData.items[dxIds[0]]?.style?.icon
             ) {
                 const originalIcon = await fetch(
-                    responses[0].metaData.items[dxIds[0]].style.icon
+                    responses[0].metaData.items[dxIds[0]].style.icon,
+                    { method: 'GET', credentials: 'include' }
                 ).then((dxIconResponse) => {
                     if (dxIconResponse.status !== 200) {
                         return '<svg></svg>'


### PR DESCRIPTION
No JIRA issue. This change makes the icons fetching logic more robust:
1. It fetches the icon with credentials which prevents a 500 error on certain versions of the backend
2. If any other response code than 200 is returned, we return a string that can be parsed into an empty icon. This is better than trying to build an SVG from a string that is really a stringified error code / error message 🤣 