### PR TITLE
feat: upgrade analytics to get pivot table truncated title feature [v39] [DHIS2-14827]

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,7 @@
         "redux-mock-store": "^1.5.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.10.13",
+        "@dhis2/analytics": "^24.11.0",
         "@dhis2/app-runtime": "^3.9.0",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -14,7 +14,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.10.13",
+        "@dhis2/analytics": "^24.11.0",
         "@dhis2/app-runtime": "^3.9.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^8.4.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,10 +2138,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24.10.13":
-  version "24.10.13"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.10.13.tgz#2b4cf949996703c7f0ea172dceef542813dde69f"
-  integrity sha512-kpwwzbnzb8gfzYScjM5EfkkCZLXFYYYXa+Aq3nepfQUci3Iy4OYb9vB0yNMMz4ldqOh/hZVN8w/kwrXCt3OJGw==
+"@dhis2/analytics@^24.11.0":
+  version "24.11.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.11.0.tgz#8bc16aa1ee134ab84d1ffb4df5a5dea818a1ea66"
+  integrity sha512-POoBbVynhXPetMcwGmkCWeKBO2ATz/gNOcqKxgQP7YJ/CPKAe0XsGeTOY95/KX9X5VJF1tVWJx9pNEkWuEc5Fg==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     "@dhis2/multi-calendar-dates" "^1.2.2"


### PR DESCRIPTION
Implements [DHIS2-14827](https://dhis2.atlassian.net/browse/DHIS2-14827)

This feature was implemented fully in @dhis2/analytics so all we need in DV is a version bump.

The PR against the dev branch (https://github.com/dhis2/data-visualizer-app/pull/2858) was closed because the analytics version there got bumped in another merged PR.

---

### Key features

1. Because we now truncate the title, long filters won't stretch the table horizontally anymore
2. Once the title gets truncated a tooltip will be available for users to see the full title

---

[DHIS2-14827]: https://dhis2.atlassian.net/browse/DHIS2-14827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ