### PR TITLE
fix: infinite spinner when opening the interpretations modal while viewing a visualization

### DIFF
--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -1,0 +1,41 @@
+import { VIS_TYPE_BAR } from '@dhis2/analytics'
+import {
+    expectAOTitleToBeValue,
+    expectVisualizationToBeVisible,
+} from '../elements/chart.js'
+import { openAOByName } from '../elements/fileMenu/index.js'
+import { goToStartPage } from '../elements/startScreen.js'
+
+describe('Interpretations', () => {
+    it('opens the interpretations modal on a saved AO', () => {
+        const ao = {
+            name: 'ANC: 1 and 3 coverage Yearly',
+            type: VIS_TYPE_BAR,
+        }
+
+        // Open the saved AO
+        goToStartPage()
+        openAOByName(ao.name)
+        expectAOTitleToBeValue(ao.name)
+        expectVisualizationToBeVisible(ao.type)
+
+        // Open the interpretations panel
+        cy.getBySel('dhis2-analytics-interpretationsanddetailstoggler').click()
+
+        cy.getBySel('interpretations-list')
+            .find('button')
+            .contains('See interpretation')
+            .click()
+
+        cy.getBySel('interpretation-modal').should('be.visible')
+
+        cy.get('.highcharts-container').should('be.visible')
+
+        cy.getBySel('interpretation-modal')
+            .find('button')
+            .contains('Hide interpretation')
+            .click()
+
+        cy.getBySel('interpretation-modal').should('not.exist')
+    })
+})

--- a/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
+++ b/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
@@ -10,7 +10,6 @@ const VisualizationPluginWrapper = (props) => {
     const [pluginProps, setPluginProps] = useState(props)
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState(null)
-    const { onResponsesReceived = Function.prototype } = props
 
     const onDataSorted = useCallback(
         (sorting) => {
@@ -62,6 +61,7 @@ const VisualizationPluginWrapper = (props) => {
 
     // set loading state only for props that will cause
     // VisualizationPlugin to fetch and call onLoadingComplete
+    const { visualization, onResponsesReceived = Function.prototype } = props
     useEffect(() => {
         setIsLoading(true)
     }, [props.filters, props.forDashboard, props.visualization])
@@ -73,14 +73,14 @@ const VisualizationPluginWrapper = (props) => {
             try {
                 ensureAnalyticsResponsesContainData(
                     responses,
-                    props.visualization.type
+                    visualization.type
                 )
             } catch (error) {
                 setError(error)
             }
             onResponsesReceived(responses)
         },
-        [props.visualization.type, onResponsesReceived]
+        [visualization.type, onResponsesReceived]
     )
 
     if (error) {

--- a/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
+++ b/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
@@ -67,7 +67,7 @@ const VisualizationPluginWrapper = (props) => {
 
     const onLoadingComplete = () => setIsLoading(false)
 
-    const { visualization, onResponsesReceived = Function.prototype } = props
+    const { visualization, onResponsesReceived } = props
     const handleResponsesReceived = useCallback(
         (responses) => {
             try {
@@ -78,7 +78,9 @@ const VisualizationPluginWrapper = (props) => {
             } catch (error) {
                 setError(error)
             }
-            onResponsesReceived(responses)
+
+            typeof onResponsesReceived === 'function' &&
+                onResponsesReceived(responses)
         },
         [visualization.type, onResponsesReceived]
     )

--- a/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
+++ b/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
@@ -10,6 +10,7 @@ const VisualizationPluginWrapper = (props) => {
     const [pluginProps, setPluginProps] = useState(props)
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState(null)
+    const { onResponsesReceived = Function.prototype } = props
 
     const onDataSorted = useCallback(
         (sorting) => {
@@ -67,7 +68,7 @@ const VisualizationPluginWrapper = (props) => {
 
     const onLoadingComplete = () => setIsLoading(false)
 
-    const onResponsesReceived = useCallback(
+    const handleResponsesReceived = useCallback(
         (responses) => {
             try {
                 ensureAnalyticsResponsesContainData(
@@ -77,13 +78,15 @@ const VisualizationPluginWrapper = (props) => {
             } catch (error) {
                 setError(error)
             }
+            onResponsesReceived(responses)
         },
-        [props.visualization.type]
+        [props.visualization.type, onResponsesReceived]
     )
 
     if (error) {
         return <VisualizationErrorInfo error={error} />
     }
+
     return (
         <>
             {isLoading && (
@@ -97,7 +100,7 @@ const VisualizationPluginWrapper = (props) => {
                 {...pluginProps}
                 onDataSorted={onDataSorted}
                 onLoadingComplete={onLoadingComplete}
-                onResponsesReceived={onResponsesReceived}
+                onResponsesReceived={handleResponsesReceived}
             />
         </>
     )

--- a/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
+++ b/src/components/VisualizationPlugin/VisualizationPluginWrapper.js
@@ -61,13 +61,13 @@ const VisualizationPluginWrapper = (props) => {
 
     // set loading state only for props that will cause
     // VisualizationPlugin to fetch and call onLoadingComplete
-    const { visualization, onResponsesReceived = Function.prototype } = props
     useEffect(() => {
         setIsLoading(true)
     }, [props.filters, props.forDashboard, props.visualization])
 
     const onLoadingComplete = () => setIsLoading(false)
 
+    const { visualization, onResponsesReceived = Function.prototype } = props
     const handleResponsesReceived = useCallback(
         (responses) => {
             try {


### PR DESCRIPTION
Fixes [DHIS2-18369](https://dhis2.atlassian.net/browse/DHIS2-18369)

The InterpretationsModal callback onResponsesReceived was not being called after a recent fix introduced its own onResponsesReceived callback

### TODO

-   [x] Cypress tests
-   [x] Manual testing
-   [x] Retest original bug fix [DHIS2-16793](https://dhis2.atlassian.net/browse/DHIS2-16793)
-   [x] Dashboard tested

---


[DHIS2-18369]: https://dhis2.atlassian.net/browse/DHIS2-18369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-16793]: https://dhis2.atlassian.net/browse/DHIS2-16793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ