### PR TITLE
chore: use last year's periods

### DIFF
--- a/cypress/elements/common.js
+++ b/cypress/elements/common.js
@@ -35,14 +35,12 @@ export const replacePeriodItems = (
     if (isYearOverYear(visType)) {
         const TEST_PERIOD = !useAltData
             ? 'Last 2 six-months'
-            : 'Quarters per year'
+            : 'Last 4 quarters'
         selectYoyCategoryOption(TEST_PERIOD)
         clickMenuBarUpdateButton()
     } else {
         const TEST_PERIOD_TYPE = !useAltData ? 'Six-months' : 'Quarters'
-        const TEST_PERIOD = !useAltData
-            ? 'Last 2 six-month'
-            : 'Quarters this year'
+        const TEST_PERIOD = !useAltData ? 'Last 2 six-month' : 'Last 4 quarters'
         openDimension(DIMENSION_ID_PERIOD)
         unselectAllItemsByButton()
         selectRelativePeriods([TEST_PERIOD], TEST_PERIOD_TYPE)

--- a/cypress/elements/dimensionModal/index.js
+++ b/cypress/elements/dimensionModal/index.js
@@ -139,6 +139,7 @@ export {
 
 export {
     selectRelativePeriods,
+    selectFixedPeriodYear,
     selectFixedPeriods,
     expectPeriodDimensionModalToBeVisible,
     expectRelativePeriodTypeToBe,

--- a/cypress/elements/dimensionModal/periodDimension.js
+++ b/cypress/elements/dimensionModal/periodDimension.js
@@ -41,6 +41,13 @@ export const selectFixedPeriods = (periods, periodType) => {
     periods.forEach((item) => clickSourceOption(item))
 }
 
+export const selectFixedPeriodYear = (year) => {
+    switchToFixedPeriods()
+    cy.getBySel('period-dimension-fixed-period-filter-year-content')
+        .clear()
+        .type(year)
+}
+
 const clickSourceOption = (itemName) =>
     cy.getBySel(selectableItemsEl).contains(itemName).dblclick()
 

--- a/cypress/integration/customErrors/visualizationError.cy.js
+++ b/cypress/integration/customErrors/visualizationError.cy.js
@@ -38,10 +38,10 @@ describe('Visualization error', () => {
         goToStartPage()
         changeVisType(visTypeDisplayNames[VIS_TYPE_PIVOT_TABLE])
 
-        // select period 'This year'
+        // select period 'Last year'
         openDimension(DIMENSION_ID_PERIOD)
         unselectAllItemsByButton()
-        selectRelativePeriods(['This year'], 'Years')
+        selectRelativePeriods(['Last year'], 'Years')
         clickDimensionModalUpdateButton()
 
         // select a narrative item

--- a/cypress/integration/options/cumulativeValues.cy.js
+++ b/cypress/integration/options/cumulativeValues.cy.js
@@ -23,6 +23,7 @@ import {
     selectDataItems,
     selectFixedPeriods,
     unselectAllItemsByButton,
+    selectFixedPeriodYear,
 } from '../../elements/dimensionModal/index.js'
 import { openDimension } from '../../elements/dimensionsPanel.js'
 import { clickContextMenuMove, openContextMenu } from '../../elements/layout.js'
@@ -175,10 +176,11 @@ describe('Options - Cumulative values', () => {
             openContextMenu(DIMENSION_ID_PERIOD)
             clickContextMenuMove(DIMENSION_ID_PERIOD, AXIS_ID_COLUMNS)
 
-            const year = new Date().getFullYear().toString()
+            const year = (new Date().getFullYear() - 1).toString()
 
             openDimension(DIMENSION_ID_PERIOD)
             unselectAllItemsByButton()
+            selectFixedPeriodYear(year)
             selectFixedPeriods(
                 [`October ${year}`, `November ${year}`, `December ${year}`],
                 'Monthly'
@@ -251,9 +253,10 @@ describe('Options - Cumulative values', () => {
             selectDataItems(['BCG doses'])
             clickDimensionModalHideButton()
 
-            const year = new Date().getFullYear().toString()
+            const year = (new Date().getFullYear() - 1).toString()
             openDimension(DIMENSION_ID_PERIOD)
             unselectAllItemsByButton()
+            selectFixedPeriodYear(year)
             selectFixedPeriods([`October ${year}`], 'Monthly')
 
             clickDimensionModalHideButton()

--- a/cypress/integration/options/limitValues.cy.js
+++ b/cypress/integration/options/limitValues.cy.js
@@ -11,6 +11,7 @@ import {
     clickDimensionModalUpdateButton,
     unselectAllItemsByButton,
     selectFixedPeriods,
+    selectFixedPeriodYear,
 } from '../../elements/dimensionModal/index.js'
 import { openDimension } from '../../elements/dimensionsPanel.js'
 import {
@@ -39,7 +40,7 @@ import {
 import { changeVisType } from '../../elements/visualizationTypeSelector.js'
 
 const TEST_INDICATOR = 'ANC visits total'
-const currentYear = new Date().getFullYear().toString()
+const year = (new Date().getFullYear() - 1).toString()
 const expectTableValueToBe = (value, position) =>
     cy
         .getBySel('visualization-container')
@@ -61,13 +62,14 @@ describe('limit values', () => {
         clickDimensionModalUpdateButton()
         openDimension(DIMENSION_ID_PERIOD)
         unselectAllItemsByButton()
+        selectFixedPeriodYear(year)
         selectFixedPeriods(
             [
-                `January ${currentYear}`,
-                `February ${currentYear}`,
-                `March ${currentYear}`,
-                `April ${currentYear}`,
-                `May ${currentYear}`,
+                `January ${year}`,
+                `February ${year}`,
+                `March ${year}`,
+                `April ${year}`,
+                `May ${year}`,
             ],
             'Monthly'
         )

--- a/cypress/integration/options/totals.cy.js
+++ b/cypress/integration/options/totals.cy.js
@@ -16,6 +16,7 @@ import {
     selectAllItemsByButton,
     selectDataElements,
     selectDataItems,
+    selectFixedPeriodYear,
     selectFixedPeriods,
     unselectAllItemsByButton,
 } from '../../elements/dimensionModal/index.js'
@@ -68,9 +69,10 @@ describe('Options - Column totals', () => {
         selectDataElements(['ART enrollment stage 1'])
         clickDimensionModalHideButton()
 
-        const year = new Date().getFullYear().toString()
+        const year = (new Date().getFullYear() - 1).toString()
         openDimension(DIMENSION_ID_PERIOD)
         unselectAllItemsByButton()
+        selectFixedPeriodYear(year)
         selectFixedPeriods(
             [`May ${year}`, `June ${year}`, `July ${year}`],
             'Monthly'
@@ -95,9 +97,10 @@ describe('Options - Column totals', () => {
         ])
         clickDimensionModalHideButton()
 
-        const year = new Date().getFullYear().toString()
+        const year = (new Date().getFullYear() - 1).toString()
         openDimension(DIMENSION_ID_PERIOD)
         unselectAllItemsByButton()
+        selectFixedPeriodYear(year)
         selectFixedPeriods(
             [
                 `January ${year}`,
@@ -158,9 +161,10 @@ describe('Options - Row totals', () => {
             selectDataItems(['BCG doses'])
             clickDimensionModalHideButton()
 
-            const year = new Date().getFullYear().toString()
+            const year = (new Date().getFullYear() - 1).toString()
             openDimension(DIMENSION_ID_PERIOD)
             unselectAllItemsByButton()
+            selectFixedPeriodYear(year)
             selectFixedPeriods([`October ${year}`], 'Monthly')
 
             clickDimensionModalUpdateButton()


### PR DESCRIPTION

### Key features

1. use last year's period wherever possible

---

### Description

This is to avoid failing tests in the beginning of a new year when the new data is not added to the test DB yet.