### PR TITLE
feat: implement option set selection for data items (DHIS2-17872)

### DIFF
--- a/cypress/elements/dimensionModal/dataDimension.js
+++ b/cypress/elements/dimensionModal/dataDimension.js
@@ -168,7 +168,7 @@ export const clickEDIEditButton = (item) =>
         .getBySel(optionContentEl)
         .contains(item)
         .parent()
-        .findBySel('data-dimension-transfer-option-edit-button')
+        .findBySel('data-dimension-transfer-option-edit-calculation-button')
         .click()
 
 export const expectSelectableDataItemsAmountToBe = (amount) =>

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -12,6 +12,7 @@ import {
     REMOVE_UI_LAYOUT_DIMENSIONS,
     SET_UI_ITEMS,
     REMOVE_UI_ITEMS,
+    SET_UI_OPTION_SET_ITEM_BY_ITEM,
     ADD_UI_PARENT_GRAPH_MAP,
     SET_UI_ACTIVE_MODAL_DIALOG,
     SET_UI_YEAR_ON_YEAR_SERIES,
@@ -125,6 +126,11 @@ export const acSetUiItemAttributes = (value) => ({
 
 export const acRemoveUiItemAttributes = (value) => ({
     type: REMOVE_UI_ITEM_ATTRIBUTES,
+    value,
+})
+
+export const acSetUiOptionSetItemByItem = (value) => ({
+    type: SET_UI_OPTION_SET_ITEM_BY_ITEM,
     value,
 })
 

--- a/src/modules/fields/nestedFields.js
+++ b/src/modules/fields/nestedFields.js
@@ -9,7 +9,7 @@ const DIMENSION_ITEM = `dimensionItem~rename(${ID})`
 const LEGEND_SET = `${ID},${NAME}`
 const USER = `${NAME},userCredentials[username]`
 
-const ITEMS = `${DIMENSION_ITEM},${NAME},dimensionItemType,expression,access`
+const ITEMS = `${DIMENSION_ITEM},${NAME},dimensionItemType,expression,access,optionSetId`
 
 const AXIS = `dimension,filter,legendSet[${LEGEND_SET}],items[${ITEMS}]`
 const INTERPRETATIONS = 'id,created'


### PR DESCRIPTION
Implements [DHIS2-17872](https://jira.dhis2.org/browse/DHIS2-17872)

**Requires https://github.com/dhis2/analytics/pull/XXX**

---

### Key features

1. use the option set selection feature in analytics
2. persist option set configuration in the Redux store

---

### Description

Users are able to select the options of the option set assigned to a data item in the Data dimension modal.
The selection is persisted in the Redux store.


---

### TODO

-   [ ] Cypress tests
-   [ ] Update docs
-   [ ] Manual testing
-   [ ] _task_

---

### Known issues

-   [ ] _issue_

---

### Screenshots

Data dimension modal:
![Screenshot 2025-01-23 at 16 16 49](https://github.com/user-attachments/assets/2514c32f-d900-4a80-b19c-47231acbd38e)

Redux store:
![ Screenshot 2025-01-23 at 16 18 01](https://github.com/user-attachments/assets/ce388096-76cf-4dbe-8638-e280dbf6c54b)
