### PR TITLE
fix: add dimension item dragging style and active style when options popup is open

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "typescript": "^4.8.4"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.12.2",
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#7a1bd8272f4d967714a5ea802713a1db7f017b02",
         "@dhis2/app-runtime": "^3.13.2",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/src/components/DimensionsPanel/DimensionsPanel.js
@@ -63,6 +63,7 @@ export const Dimensions = ({
             <DndDimensionsPanel
                 onDimensionClick={openDimensionModal}
                 onDimensionOptionsClick={openOptionsMenuForDimension}
+                activeDimensionId={dimensionId}
             />
             {menuIsOpen && dimensionId && ref && (
                 <Layer onClick={toggleMenu}>

--- a/src/components/DimensionsPanel/DndDimensionItem.js
+++ b/src/components/DimensionsPanel/DndDimensionItem.js
@@ -18,6 +18,7 @@ export class DndDimensionItem extends Component {
             isLocked,
             isDeactivated,
             isRecommended,
+            isActive,
             onClick,
             onOptionsClick,
             dataTest,
@@ -48,6 +49,7 @@ export class DndDimensionItem extends Component {
                             className={cx({
                                 [styles.dragging]: snapshot.isDragging,
                                 [styles.notDragging]: !snapshot.isDragging,
+                                [styles.active]: isActive,
                                 [styles.assignedCategories]:
                                     id === DIMENSION_ID_ASSIGNED_CATEGORIES,
                             })}
@@ -56,10 +58,7 @@ export class DndDimensionItem extends Component {
                             {...itemCommonProps}
                         />
                         {snapshot.isDragging && (
-                            <DimensionItem
-                                className={styles.dimensionItemClone}
-                                {...itemCommonProps}
-                            />
+                            <DimensionItem {...itemCommonProps} />
                         )}
                     </>
                 )}
@@ -72,6 +71,7 @@ DndDimensionItem.propTypes = {
     dataTest: PropTypes.string,
     id: PropTypes.string,
     index: PropTypes.number,
+    isActive: PropTypes.bool,
     isDeactivated: PropTypes.bool,
     isLocked: PropTypes.bool,
     isRecommended: PropTypes.bool,

--- a/src/components/DimensionsPanel/DndDimensionList.js
+++ b/src/components/DimensionsPanel/DndDimensionList.js
@@ -48,6 +48,7 @@ export class DndDimensionList extends Component {
             isLocked: this.isLockedDimension(id),
             isDeactivated: this.isDisabledDimension(id),
             isRecommended: this.isRecommendedDimension(id),
+            isActive: id === this.props.activeDimensionId,
             onClick: this.props.onDimensionClick,
             onOptionsClick: this.props.onDimensionOptionsClick,
             dataTest: `${this.props.dataTest}-dimension-item`,
@@ -142,6 +143,7 @@ export class DndDimensionList extends Component {
 }
 
 DndDimensionList.propTypes = {
+    activeDimensionId: PropTypes.string,
     dataTest: PropTypes.string,
     dimensions: PropTypes.array,
     disallowedDimensions: PropTypes.array,

--- a/src/components/DimensionsPanel/DndDimensionsPanel.js
+++ b/src/components/DimensionsPanel/DndDimensionsPanel.js
@@ -35,6 +35,7 @@ export class DndDimensionsPanel extends Component {
                     onDimensionOptionsClick={this.props.onDimensionOptionsClick}
                     onDimensionClick={this.props.onDimensionClick}
                     dataTest="dimensions-panel-list"
+                    activeDimensionId={this.props.activeDimensionId}
                 />
             </div>
         )
@@ -42,6 +43,7 @@ export class DndDimensionsPanel extends Component {
 }
 
 DndDimensionsPanel.propTypes = {
+    activeDimensionId: PropTypes.string,
     onDimensionClick: PropTypes.func,
     onDimensionOptionsClick: PropTypes.func,
 }

--- a/src/components/DimensionsPanel/styles/DndDimensionItem.module.css
+++ b/src/components/DimensionsPanel/styles/DndDimensionItem.module.css
@@ -3,14 +3,16 @@ This keeps the dimension item clone from causing
 a ripple effect in the Dimension list during drag
 */
 
-.notDragging {
+:global(.item).notDragging {
     transform: none !important;
 }
 
-.dragging {
-    background-color: #e8edf2;
-    border-radius: 2px;
+:global(.item).dragging,
+:global(.item).active {
+    background-color: var(--colors-grey100);
+    border-color: var(--colors-grey400);
 }
+
 :global(.item).assignedCategories {
     cursor: grab;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,10 +2148,9 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.12.2":
-  version "26.12.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.12.2.tgz#bab46e4a4e04c2cd321612ec6696775314e194ab"
-  integrity sha512-DlQoFALyv3FidG3zEPmlM5AJHPYgRyj0aIoHlxEKGCT27Kwg726mKkpPAjdTmlxXqbI8OWEjW7PZVcsP/myYWw==
+"@dhis2/analytics@git+https://github.com/d2-ci/analytics.git#7a1bd8272f4d967714a5ea802713a1db7f017b02":
+  version "26.12.1"
+  resolved "git+https://github.com/d2-ci/analytics.git#7a1bd8272f4d967714a5ea802713a1db7f017b02"
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
Implements [DHIS2-17934](https://dhis2.atlassian.net/browse/DHIS2-17934)

**Requires https://github.com/dhis2/analytics/pull/1762**

---

### Fixes

1. Apply hover style to the item being dragged
2. Apply hover style to the item when its options menu is open

---

### TODO

- [ ] Dashboard tested N/A
- [ ] Tests added (Cypress and/or Jest) N/A
- [ ] Docs added N/A
- [ ] i18n strings generated N/A
- [ ] d2-ci dependency replaced

---

### Screenshots

![image](https://github.com/user-attachments/assets/6c2482bb-af77-46f6-8e6f-119bb6dad590)


https://github.com/user-attachments/assets/63c06193-f708-49c4-b716-03e37c53e9fc


