### PR TITLE
fix: fix regression in Not found visualization error (DHIS2-19187)

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -114,14 +114,12 @@ export const tDoLoadVisualization =
             if (errorResponse?.details?.httpStatusCode === 404) {
                 error = new VisualizationNotFoundError()
                 history.push('/')
-            } else if (errorResponse?.message) {
-                error = errorResponse.message
-            } else {
+            } else if (!errorResponse?.message) {
                 error = new GenericServerError()
             }
             dispatch(clearAll(error))
 
-            logError('tDoLoadVisualization', error)
+            logError('tDoLoadVisualization', error.description || error.message)
         }
     }
 

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -131,10 +131,10 @@ export class UnconnectedVisualization extends Component {
 
         const { renderId } = this.state
 
-        if (!visualization) {
-            return <StartScreen />
-        } else if (error) {
+        if (error) {
             return <VisualizationErrorInfo error={error} />
+        } else if (!visualization) {
+            return <StartScreen />
         } else {
             return (
                 <Fragment>


### PR DESCRIPTION
Implements [DHIS2-19187](https://dhis2.atlassian.net/browse/DHIS2-19187)

---

### Key features

1. fix regression with Not found error not showing up

---

### Description

If a visualization is not found due to using an outdated link or a wrong id in the URL, a custom message should be shown informing about it.
Since v101.0.0 this stopped working.
The culprit was a change introduced when refactoring the error handling.

---

### TODO

- [ ] Dashboard tested

---

### Known issues

- [x] an error different than a 404 does not cause the app to redirect to `/` which has a problem when using the Update button. This was fixed in #3056 but only for the 404 case. Should the redirect happen for other errors as well? A 405 error is easily triggered by an invalid id (ie. remove 1 or more characters from the id in the URL). **NB: this is not a regression introduced by this PR, it's an existing issue that we might want to address in a separate PR.**

---

### Screenshots

Before:
<img width="2173" alt="Screenshot 2025-03-12 at 11 13 55" src="https://github.com/user-attachments/assets/5d8a396a-66f4-411e-b78c-19712499b271" />


After:
<img width="2175" alt="Screenshot 2025-03-12 at 11 13 27" src="https://github.com/user-attachments/assets/d63fe9d1-a293-4ac8-b4e4-3f80bd8123f5" />



[DHIS2-19187]: https://dhis2.atlassian.net/browse/DHIS2-19187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ