### PR TITLE
fix:  restore navigation between visualizations using the browser address bar [DHIS2-19387]

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -35,7 +35,7 @@ import './App.css'
 import './scrollbar.css'
 
 // Used to avoid repeating `history` listener calls -- see below
-let lastLocationKey
+let lastLocation
 
 export class UnconnectedApp extends Component {
     unlisten = null
@@ -163,10 +163,15 @@ export class UnconnectedApp extends Component {
             // Avoid duplicate actions for the same update object. This also
             // avoids a loop, because dispatching a pop state effect below also
             // triggers listeners again (but with the same location object key)
-            if (location.key === lastLocationKey) {
+            const { key, pathname, search } = location
+            if (
+                key === lastLocation?.key &&
+                pathname === lastLocation?.pathname &&
+                search === lastLocation?.search
+            ) {
                 return
             }
-            lastLocationKey = location.key
+            lastLocation = location
             // Dispatch this event for external routing listeners to observe,
             // e.g. global shell
             const popStateEvent = new PopStateEvent('popstate', {


### PR DESCRIPTION
Implements [DHIS2-19387](https://dhis2.atlassian.net/browse/DHIS2-19387)

Manual URL changes trigger location updates with the key `default`, which then results in the `history` skipping its handler because it's the same as the key as the previous updates

It's still important to check they `key` to avoid triggering the handler multiple times for the same location update, but the pathname and search can be checked to see if the rest of the handler should run


https://github.com/user-attachments/assets/b23326ad-c723-4798-94d4-cee609c94036



[DHIS2-19387]: https://dhis2.atlassian.net/browse/DHIS2-19387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ