### PR TITLE
fix: fetch latest vis before renaming so not to overwrite others changes

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -194,10 +194,13 @@ export const tDoRenameVisualization =
         }
 
         try {
+            const { visualization } = await apiFetchVisualization(
+                engine,
+                sGetVisualization(getState()).id
+            )
+
             const visToSave = await preparePayloadForSave({
-                visualization: getSaveableVisualization(
-                    sGetVisualization(getState())
-                ),
+                visualization: getSaveableVisualization(visualization),
                 name,
                 description,
                 engine,


### PR DESCRIPTION
What if we fetch the latest before renaming? Potential risks include what will happen in the app when we store the latest vis in redux after renaming.