### PR TITLE
fix: fetch latest visualization before renaming so not to overwrite newer changes

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -194,10 +194,13 @@ export const tDoRenameVisualization =
         }
 
         try {
+            const { visualization } = await apiFetchVisualization(
+                engine,
+                sGetVisualization(getState()).id
+            )
+
             const visToSave = await preparePayloadForSave({
-                visualization: getSaveableVisualization(
-                    sGetVisualization(getState())
-                ),
+                visualization: getSaveableVisualization(visualization),
                 name,
                 description,
                 engine,


### PR DESCRIPTION
Fixes [DHIS2-19506](https://dhis2.atlassian.net/browse/DHIS2-19506)

### Description

Fetch the visualization and apply name and description to that object, which is then used in the rename PUT request. In the app, only name and description are updated, which means the app's copy of the visualization could still be out of date. But that's a different problem that needs a different solution.

---

### Quality checklist

- [ ] Dashboard tested N/A
- [ ] Tests added (Cypress and/or Jest)
- [ ] Docs added N/A
- [ ] Global shell tested N/A
- [ ] d2-ci dependency replaced N/A
