### PR TITLE
fix: visualization canvas loading background (DHIS2-19533)

### DIFF
--- a/src/components/Visualization/styles/Visualization.style.js
+++ b/src/components/Visualization/styles/Visualization.style.js
@@ -12,6 +12,6 @@ export default {
         insetInlineStart: 0,
         insetBlockStart: 0,
         zIndex: 100,
-        background: '#ffffffab',
+        background: 'var(--colors-grey300)',
     },
 }


### PR DESCRIPTION
Fixes [DHIS2-19533](https://dhis2.atlassian.net/browse/DHIS2-19533)

### Description

This PR changes the background color of the visualization canvas `loading` cover to match the standard app background color.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ _N/A_ ] Dashboard tested
- [ _N/A_ ] Cypress and/or Jest tests added/updated
- [ _N/A_ ] Docs added
- [ _N/A_ ] d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/XXX)
- [x] Tester approved (Jan)

---

### Screenshots

Before: 

![DV loading canvas](https://github.com/user-attachments/assets/468a1ed9-4eac-49a3-9227-3dd0d3d8d80b)


After:

![image](https://github.com/user-attachments/assets/dc3b1d61-b940-4584-a1ba-ed17b98a2609)





[DHIS2-19533]: https://dhis2.atlassian.net/browse/DHIS2-19533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ