### PR TITLE
chore: use anly-e2e-4x format for cypress test instances

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -82,7 +82,7 @@ jobs:
     call-workflow-e2e-prod:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
         needs: [build, lint, test, setup-matrix]
-        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@feat/support-hardcoded-dev-version
+        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@feat/hardcoded-dev-version-minor
         with:
             should_record: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record')}}
             spec-group: ${{ needs.setup-matrix.outputs.matrix }}

--- a/cypress/plugins/excludeByVersionTags.js
+++ b/cypress/plugins/excludeByVersionTags.js
@@ -5,9 +5,9 @@ The list of excluded tags returned by getExcludedTags are the tags that cypress 
 
 Using excluded tags (instead of included tags) allows for most of the tests to remain untagged and be run against all supported versions of DHIS2.
 
-DHIS2 officially supports the latest 3 released versions of DHIS2. For example: 2.38, 2.39 and 2.40. Dev would then have version 2.41-SNAPSHOT. Therefore, the getExcludedTags calculates the range of tags based on minimum supported version + 3 (2.38, 2.39, 2.40, 2.41-SNAPSHOT)
+DHIS2 officially supports the latest 3 released versions of DHIS2. For example: 2.40, 2.41 and 2.42. Dev would then have version 2.41-SNAPSHOT. Therefore, the getExcludedTags calculates the range of tags based on minimum supported version + 3 (2.40, 2.1, 2.42, 2.43-SNAPSHOT)
 
-With the minimum supported version of 2.38, the tags will always contain "38", "39", "40" and "41", but the comparison symbols will depend on the current instance version.
+With the minimum supported version of 2.40, the tags will always contain "40", "41" and "42", but the comparison symbols will depend on the current instance version.
 
 Allowed tag comparisons are ">", ">=", "<", "<="
 */

--- a/package.json
+++ b/package.json
@@ -66,5 +66,6 @@
     },
     "resolutions": {
         "@dhis2/ui": "^10.1.10"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Implements [DHIS2-19609](https://dhis2.atlassian.net/browse/DHIS2-19609)

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested N/A
- [ ] Cypress and/or Jest tests added/updated
- [ ] Docs added N/A
- [ ] d2-ci dependency replaced N/A
- [ ] Tester approved (name) N/A
