### PR TITLE
fix: prevent font files from being pre-cached

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -15,6 +15,7 @@ const config = {
         enabled: true,
         caching: {
             patternsToOmitFromAppShell: [/.*/],
+            globsToOmitFromPrecache: ['fonts/**'],
         },
     },
 


### PR DESCRIPTION
No issue NR available

### Description

Based on a conversation I had today I have created this PR, but I have to admit I am not quite sure that the changes I have just done are all that's required.

Let me start by adding a few quotes:

> Will this significantly increase PWA install size? 

> I believe this would increase the install size by default; I think it would make sense to use the `pwa.caching.globsToOmitFromPrecache` [option](https://developers.dhis2.org/docs/app-platform/pwa/#opting-in) in `d2.config.js` to not cache them on install :slightly_smiling_face: I think the Maps app does this for some fonts

So that's what I did, but I also looked at the `d2.config.js` in maps and this has a pretty long regex 
 to populate `patternsToOmitFromAppShell`. I am wondering if this is just a completely unrelated setting or if there is some interaction between this one and `globsToOmitFromPrecache`....

So the above is to reduce cache bloat. And I also enquired about caching the files that are being requested by the app:

> I figure out which file each user needs based on the dbLocale and it'd be nice if it the file was cached after the first PDF was downloaded 

> Yeah the default caching behavior will cache the file upon it being requested by the app... For offline purposes, that is; the app will still try over the network every time a runtime-cached file is requested 

> But then the browser just uses a 304 right?

> Yeah

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [x] Dashboard tested
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/XXX) N/A
- [x] Tester approved (Edoardo + Hendrik)

#### Test summary

- ✅ Fonts were indeed pre-cached before this change and are no longer being cached now (Edoardo checked this)
- ✅ Download to PDF still works as expected
- ✅ App still loads in dashboard
- ✅ App still loads in global shell and download to PDF works there too

---
