### PR TITLE
fix: allow scrolling in viz type selector [DHIS2-16790]

### DIFF
--- a/src/components/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
+++ b/src/components/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
@@ -42,7 +42,7 @@
 }
 
 .listContainer {
-    max-height: 85vh;
+    max-block-size: 85vh;
     overflow: scroll;
     max-inline-size: 896px;
     box-shadow: var(--elevations-e400);


### PR DESCRIPTION
Implements [DHIS2-16790](https://dhis2.atlassian.net/browse/DHIS2-16790)

### Description

Fixes issue where content of the visualization type selector cannot be accessed with limited viewport height.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [x] Dashboard tested (N/A)
- [x] Cypress and/or Jest tests added/updated (N/A)
- [x] Docs added (N/A)
- [x] d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/XXX) (N/A)
- [x] Tester approved (Jan)

---

### Screenshots
<img width="1242" height="690" alt="image" src="https://github.com/user-attachments/assets/6090266e-de30-4f75-836b-2c48874b500f" />


[DHIS2-16790]: https://dhis2.atlassian.net/browse/DHIS2-16790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ