### PR TITLE
fix: open Maps in a new tab instead of navigating away [DHIS2-17366]

### DIFF
--- a/cypress/elements/visualizationTypeSelector.js
+++ b/cypress/elements/visualizationTypeSelector.js
@@ -10,6 +10,11 @@ export const changeVisType = (visTypeName) => {
     cy.getBySel(vstCardEl).contains(visTypeName).click()
 }
 
+export const clickOpenAsMap = () => {
+    clickVisTypeSelector()
+    cy.getBySel(vstCardEl).contains('Open as Map').click()
+}
+
 export const expectVisTypeToBeValue = (value) =>
     cy
         .getBySel(vstButtonTextEl)

--- a/cypress/integration/openAsMap.cy.js
+++ b/cypress/integration/openAsMap.cy.js
@@ -1,12 +1,12 @@
-import { USER_DATASTORE_CURRENT_AO_KEY } from '../../src/modules/currentAnalyticalObject.js'
 import { MAPS_APP_URL } from '../../src/components/VisualizationTypeSelector/VisualizationTypeSelector.jsx'
+import { USER_DATASTORE_CURRENT_AO_KEY } from '../../src/modules/currentAnalyticalObject.js'
 import {
     expectAOTitleToBeValue,
     expectVisualizationToBeVisible,
 } from '../elements/chart.js'
 import { openAOByName } from '../elements/fileMenu/open.js'
-import { clickOpenAsMap } from '../elements/visualizationTypeSelector.js'
 import { goToStartPage } from '../elements/startScreen.js'
+import { clickOpenAsMap } from '../elements/visualizationTypeSelector.js'
 
 describe('open as map', () => {
     it('opens Maps in a new tab instead of navigating away', () => {
@@ -30,11 +30,13 @@ describe('open as map', () => {
         cy.get('@open').should((stub) => {
             const url = stub.getCall(0).args[0]
             const target = stub.getCall(0).args[1]
+            const features = stub.getCall(0).args[2]
 
             expect(url).to.satisfy((url) =>
                 url.endsWith(`/${MAPS_APP_URL}/#/${USER_DATASTORE_CURRENT_AO_KEY}`)
             )
             expect(target).to.equal('_blank')
+            expect(features).to.equal('noopener')
         })
     })
 })

--- a/cypress/integration/openAsMap.cy.js
+++ b/cypress/integration/openAsMap.cy.js
@@ -1,5 +1,3 @@
-import { MAPS_APP_URL } from '../../src/components/VisualizationTypeSelector/VisualizationTypeSelector.jsx'
-import { USER_DATASTORE_CURRENT_AO_KEY } from '../../src/modules/currentAnalyticalObject.js'
 import {
     expectAOTitleToBeValue,
     expectVisualizationToBeVisible,
@@ -7,6 +5,12 @@ import {
 import { openAOByName } from '../elements/fileMenu/open.js'
 import { goToStartPage } from '../elements/startScreen.js'
 import { clickOpenAsMap } from '../elements/visualizationTypeSelector.js'
+
+/* Duplicated from src instead of imported: importing app source pulls the
+ * React component and its CSS module into the Cypress browserify bundle,
+ * which cannot parse them */
+const MAPS_APP_URL = 'dhis-web-maps'
+const USER_DATASTORE_CURRENT_AO_KEY = 'currentAnalyticalObject'
 
 describe('open as map', () => {
     it('opens Maps in a new tab instead of navigating away', () => {

--- a/cypress/integration/openAsMap.cy.js
+++ b/cypress/integration/openAsMap.cy.js
@@ -33,7 +33,9 @@ describe('open as map', () => {
             const features = stub.getCall(0).args[2]
 
             expect(url).to.satisfy((url) =>
-                url.endsWith(`/${MAPS_APP_URL}/#/${USER_DATASTORE_CURRENT_AO_KEY}`)
+                url.endsWith(
+                    `/${MAPS_APP_URL}/#/${USER_DATASTORE_CURRENT_AO_KEY}`
+                )
             )
             expect(target).to.equal('_blank')
             expect(features).to.equal('noopener')

--- a/cypress/integration/openAsMap.cy.js
+++ b/cypress/integration/openAsMap.cy.js
@@ -1,0 +1,40 @@
+import { USER_DATASTORE_CURRENT_AO_KEY } from '../../src/modules/currentAnalyticalObject.js'
+import { MAPS_APP_URL } from '../../src/components/VisualizationTypeSelector/VisualizationTypeSelector.jsx'
+import {
+    expectAOTitleToBeValue,
+    expectVisualizationToBeVisible,
+} from '../elements/chart.js'
+import { openAOByName } from '../elements/fileMenu/open.js'
+import { clickOpenAsMap } from '../elements/visualizationTypeSelector.js'
+import { goToStartPage } from '../elements/startScreen.js'
+
+describe('open as map', () => {
+    it('opens Maps in a new tab instead of navigating away', () => {
+        const pivotTableName = 'ANC: ANC 1 Visits Cumulative Numbers'
+
+        /* Stub window.open so Cypress does not actually navigate to the
+         * Maps app in a new tab */
+        const windowOpenStub = cy.stub().as('open')
+        cy.on('window:before:load', (win) => {
+            cy.stub(win, 'open').callsFake(windowOpenStub)
+        })
+
+        goToStartPage()
+        openAOByName(pivotTableName)
+        expectAOTitleToBeValue(pivotTableName)
+        expectVisualizationToBeVisible('PIVOT_TABLE')
+
+        clickOpenAsMap()
+
+        cy.get('@open').should('have.been.calledOnce')
+        cy.get('@open').should((stub) => {
+            const url = stub.getCall(0).args[0]
+            const target = stub.getCall(0).args[1]
+
+            expect(url).to.satisfy((url) =>
+                url.endsWith(`/${MAPS_APP_URL}/#/${USER_DATASTORE_CURRENT_AO_KEY}`)
+            )
+            expect(target).to.equal('_blank')
+        })
+    })
+})

--- a/src/components/VisualizationTypeSelector/VisualizationTypeSelector.jsx
+++ b/src/components/VisualizationTypeSelector/VisualizationTypeSelector.jsx
@@ -66,7 +66,10 @@ const UnconnectedVisualizationTypeSelector = ({
 
         set(currentAnalyticalObject)
 
-        window.location.href = `${baseUrl}/${MAPS_APP_URL}/#/${USER_DATASTORE_CURRENT_AO_KEY}`
+        window.open(
+            `${baseUrl}/${MAPS_APP_URL}/#/${USER_DATASTORE_CURRENT_AO_KEY}`,
+            '_blank'
+        )
     }
 
     const VisTypesList = (

--- a/src/components/VisualizationTypeSelector/VisualizationTypeSelector.jsx
+++ b/src/components/VisualizationTypeSelector/VisualizationTypeSelector.jsx
@@ -64,11 +64,12 @@ const UnconnectedVisualizationTypeSelector = ({
             ui
         )
 
-        set(currentAnalyticalObject)
+        await set(currentAnalyticalObject)
 
         window.open(
             `${baseUrl}/${MAPS_APP_URL}/#/${USER_DATASTORE_CURRENT_AO_KEY}`,
-            '_blank'
+            '_blank',
+            'noopener'
         )
     }
 


### PR DESCRIPTION
Implements [DHIS2-17366](https://dhis2.atlassian.net/browse/DHIS2-17366)

### Description

"Open as Map" navigated away from Data Visualizer in the same tab via `window.location.href`, so any unsaved work in that tab was lost. This changes it to `window.open(url, '_blank')`, matching how "Open in [App]" already behaves in Dashboard and Maps.

AI Assisted.

---

### Quality checklist

- [x] Dashboard tested — N/A (no dashboard-relevant change)
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added — N/A
- [x] d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/XXX) — N/A
- [ ] Tester approved (name)

---

### ToDos

- [ ] Manual check that no popup blocker interferes with the new-tab open across Chrome/Firefox/Safari **(Can someone test in Safari?)**


---

### Known issues

- N/A

---

### Screenshots

_N/A — behavioral navigation change only_

[DHIS2-17366]: https://dhis2.atlassian.net/browse/DHIS2-17366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ