### PR TITLE
fix: open as map in new tab (DHIS2-17366)

### DIFF
--- a/src/components/VisualizationTypeSelector/VisualizationTypeSelector.jsx
+++ b/src/components/VisualizationTypeSelector/VisualizationTypeSelector.jsx
@@ -66,7 +66,10 @@ const UnconnectedVisualizationTypeSelector = ({
 
         set(currentAnalyticalObject)
 
-        window.location.href = `${baseUrl}/${MAPS_APP_URL}/#/${USER_DATASTORE_CURRENT_AO_KEY}`
+        window.open(
+            `${baseUrl}/${MAPS_APP_URL}/#/${USER_DATASTORE_CURRENT_AO_KEY}`,
+            '_blank'
+        )
     }
 
     const VisTypesList = (


### PR DESCRIPTION
Implements [DHIS2-17366](https://dhis2.atlassian.net/browse/DHIS2-17366)

### Description

Use window.open with a target instead of location.href.

### Quality checklist

Add _N/A_ to items that are not applicable.

- _N/A_ Dashboard tested
- _N/A_ Cypress and/or Jest tests added/updated
- _N/A_ Docs added
- _N/A_ d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/XXX)
- [x] Tester approved (BR)

### Screenshots

After

<img width="1126" height="1068" alt="Screenshot_2026-07-31_11-01-50" src="https://github.com/user-attachments/assets/405e0db7-41bd-4b15-8a21-bc7d48dcd000" />


[DHIS2-17366]: https://dhis2.atlassian.net/browse/DHIS2-17366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ