### PR TITLE
fix: outlier table does not render

### DIFF
--- a/src/components/VisualizationPlugin/VisualizationPlugin.jsx
+++ b/src/components/VisualizationPlugin/VisualizationPlugin.jsx
@@ -404,10 +404,13 @@ export const VisualizationPlugin = ({
 
             if (enabledPeriodTypesData?.metaData) {
                 responses.forEach((response) => {
-                    Object.assign(
-                        response.metaData.items,
-                        enabledPeriodTypesData.metaData
-                    )
+                    // some endpoints (ie. outlierDetection) don't return items in metaData
+                    if (response.metaData?.items) {
+                        Object.assign(
+                            response.metaData.items,
+                            enabledPeriodTypesData.metaData
+                        )
+                    }
                 })
             }
 


### PR DESCRIPTION
Implements [DHIS2-21952](https://dhis2.atlassian.net/browse/DHIS2-21952)

### Description

Due to 43 specific code related to periods, outlier table, which does not have metadata items in the response, did not render.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [x] Dashboard tested
- _N/A_ Cypress and/or Jest tests added/updated
- _N/A_ Docs added
- _N/A_ d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/XXX)
- [x] Tester approved (Jan)

### Screenshots

Before

<img width="973" height="951" alt="Screenshot_2026-08-06_15-58-02" src="https://github.com/user-attachments/assets/0c1d5abc-3231-4bb2-9b78-50dccd9f14e5" />

After

<img width="1397" height="951" alt="Screenshot_2026-08-06_16-01-39" src="https://github.com/user-attachments/assets/eaa565ed-9e8f-4651-9dd7-1b00f5b3b0cb" />


[DHIS2-21952]: https://dhis2.atlassian.net/browse/DHIS2-21952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ